### PR TITLE
Feature - forward username

### DIFF
--- a/warpgate-protocol-ssh/src/server/session.rs
+++ b/warpgate-protocol-ssh/src/server/session.rs
@@ -1472,11 +1472,16 @@ impl ServerSession {
                 .map(|(t, opt)| (t.clone(), opt.clone()))
         };
 
-        let Some((target, ssh_options)) = target else {
+        let Some((target, mut ssh_options)) = target else {
             self.target = TargetSelection::NotFound(target_name.to_string());
             warn!("Selected target not found");
             return Ok(());
         };
+
+        // Forward username from the authenticated user to the target, if target has no username
+        if ssh_options.username.is_empty() {
+            ssh_options.username = username.to_string();
+        }
 
         let _ = self.server_handle.lock().await.set_target(&target).await;
         self.target = TargetSelection::Found(target, ssh_options);

--- a/warpgate-web/src/admin/Target.svelte
+++ b/warpgate-web/src/admin/Target.svelte
@@ -148,7 +148,10 @@ async function toggleRole (role: Role) {
         </div>
 
         <FormGroup floating label="Username">
-            <input class="form-control" bind:value={target.options.username} />
+            <input class="form-control"
+                placeholder="Note: blank value here will forward username from warpgate authenticated user"
+                bind:value={target.options.username} 
+            />
         </FormGroup>
 
         <div class="d-flex">

--- a/warpgate-web/src/theme/_theme.scss
+++ b/warpgate-web/src/theme/_theme.scss
@@ -92,3 +92,12 @@ input:-webkit-autofill:focus {
 .page-item.active .page-link {
     text-decoration: underline;
 }
+
+// Fix placeholder text with floating FormGroup labels
+.form-floating>.form-control::placeholder {
+    color: revert;
+}
+
+.form-floating>.form-control:not(:focus)::placeholder {
+    color: transparent;
+}


### PR DESCRIPTION
Relates: #440

If username is not present in ssh config - we take in from current authenticated user and try to login with it.  
Since there is no point in blank username field, added some placeholder text to it, explaining username forwarding.  

Also there is some bug with floating FormGroup placeholder text in bootstrap 5, this simple css fix helped: https://github.com/twbs/bootstrap/issues/33999#issuecomment-843540381.