### PR TITLE
Add support for trusting X-Forwarded-For header to get client IP

### DIFF
--- a/warpgate-common/src/config/mod.rs
+++ b/warpgate-common/src/config/mod.rs
@@ -139,6 +139,9 @@ pub struct HTTPConfig {
 
     #[serde(default)]
     pub key: String,
+
+    #[serde(default)]
+    pub trust_x_forwarded_for: bool,
 }
 
 impl Default for HTTPConfig {
@@ -148,6 +151,7 @@ impl Default for HTTPConfig {
             listen: _default_http_listen(),
             certificate: "".to_owned(),
             key: "".to_owned(),
+            trust_x_forwarded_for: false,
         }
     }
 }

--- a/warpgate-protocol-http/src/logging.rs
+++ b/warpgate-protocol-http/src/logging.rs
@@ -17,9 +17,9 @@ pub async fn span_for_request(req: &Request) -> poem::Result<Span> {
         .map(|x| x.ip().to_string())
         .unwrap_or("<unknown>".into());
 
-    let client_ip = match config.store.http.trust_x_forwarded_for {
+    let client_ip = match config.store.http.trust_x_forwarded_headers {
         true => req
-            .header("X-Forwarded-For")
+            .header("x-forwarded-for")
             .map(|x| x.to_string())
             .unwrap_or(remote_ip),
         false => remote_ip,

--- a/warpgate-protocol-http/src/logging.rs
+++ b/warpgate-protocol-http/src/logging.rs
@@ -1,17 +1,29 @@
 use http::{Method, StatusCode, Uri};
 use poem::{FromRequest, Request};
+use poem::web::Data;
 use tracing::*;
+use warpgate_core::Services;
 
 use crate::session_handle::WarpgateServerHandleFromRequest;
 
 pub async fn span_for_request(req: &Request) -> poem::Result<Span> {
     let handle = WarpgateServerHandleFromRequest::from_request_without_body(req).await;
+    let services: Data<&Services> = <_>::from_request_without_body(req).await?;
+    let config = services.config.lock().await;
 
-    let client_ip = req
+    let remote_ip = req
         .remote_addr()
         .as_socket_addr()
         .map(|x| x.ip().to_string())
         .unwrap_or("<unknown>".into());
+
+    let client_ip = match config.store.http.trust_x_forwarded_for {
+        true => req
+            .header("X-Forwarded-For")
+            .map(|x| x.to_string())
+            .unwrap_or(remote_ip),
+        false => remote_ip,
+    };
 
     Ok(match handle {
         Ok(ref handle) => {


### PR DESCRIPTION
This fixes #882 
falls back to remote ip if header unavailable

Added `trust_x_forwarded_headers` option in warpgate.yaml config
```yaml
http:
  enable: true
  listen: "0.0.0.0:8888"
  certificate: "./data/tls.certificate.pem"
  key: "./data/tls.key.pem"
  trust_x_forwarded_headers: false
```