### PR TITLE
Switch OOB SSO authentication for SSH to use the instructions instead of the name

### DIFF
--- a/warpgate-protocol-ssh/src/server/session.rs
+++ b/warpgate-protocol-ssh/src/server/session.rs
@@ -1360,7 +1360,8 @@ impl ServerSession {
                     login_url.set_fragment(Some(&format!("/login/{auth_state_id}")));
 
                     russh::server::Auth::Partial {
-                        name: Cow::Owned(format!(
+                        name: Cow::Borrowed("Warpgate authentication"),
+                        instructions: Cow::Owned(format!(
                             concat!(
                             "-----------------------------------------------------------------------\n",
                             "Warpgate authentication: please open the following URL in your browser:\n",
@@ -1375,7 +1376,6 @@ impl ServerSession {
                                 .collect::<Vec<_>>()
                                 .join(" ")
                         )),
-                        instructions: Cow::Borrowed(""),
                         prompts: Cow::Owned(vec![(Cow::Borrowed("Press Enter when done: "), true)]),
                     }
                 } else {


### PR DESCRIPTION
Some SFTP clients (specifically WinSCP) truncate the name parameter for keyboard interactive login (WinSCP specifically puts it in the titlebar):
![image](https://github.com/warp-tech/warpgate/assets/51303984/dc90ad67-e383-4cba-8326-79f08405fde6)

This PR changes the Warpgate authentication flow to use the keyboard interactive parameter for instructions for the primary instructions for SSO web-based auth, instead of the name. This results in the following UI for WinSCP:
![image](https://github.com/warp-tech/warpgate/assets/51303984/0893f9c3-8724-4a4e-8c62-3e1d1484f2f0)

Filezilla:
![image](https://github.com/warp-tech/warpgate/assets/51303984/089f7f72-73e2-4d0e-bb45-4d470b8fb39b)

and OpenSSH:
![image](https://github.com/warp-tech/warpgate/assets/51303984/02ff7fbd-4bc6-47a0-aadc-b8d32c42fb59)

Perhaps some changes to the wording may be in order (e.g. to prevent the duplication of 'Warpgate authentication' in OpenSSH and FileZilla, but I thought I would leave this PR as being as minimal as possible for the meantime.