### PR TITLE
Manual install of nodesource repository

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,8 @@ FROM rust:1.72.1-bullseye AS build
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key > /etc/apt/trusted.gpg.d/nodesource.asc \
+    && echo "deb [signed-by=/etc/apt/trusted.gpg.d/nodesource.asc] https://deb.nodesource.com/node_16.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \
     && apt-get install -y ca-certificates-java nodejs openjdk-17-jdk \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
The script https://deb.nodesource.com/setup_16.x has been deprecated (see #967).

This PR install nodesource repository manualy like documented on https://deb.nodesource.com