### PR TITLE
feat(ssh): make inactivity timeout configurable

### DIFF
--- a/warpgate-common/src/config/defaults.rs
+++ b/warpgate-common/src/config/defaults.rs
@@ -79,3 +79,7 @@ pub(crate) fn _default_ssh_listen() -> ListenEndpoint {
 pub(crate) fn _default_ssh_keys_path() -> String {
     "./data/keys".to_owned()
 }
+
+pub(crate) fn _default_ssh_inactivity_timeout() -> Duration {
+    Duration::SECOND * 60 * 5
+}

--- a/warpgate-common/src/config/mod.rs
+++ b/warpgate-common/src/config/mod.rs
@@ -118,6 +118,9 @@ pub struct SshConfig {
 
     #[serde(default)]
     pub host_key_verification: SshHostKeyVerificationMode,
+
+    #[serde(default = "_default_ssh_inactivity_timeout", with = "humantime_serde")]
+    pub inactivity_timeout: Duration,
 }
 
 impl Default for SshConfig {
@@ -128,6 +131,7 @@ impl Default for SshConfig {
             keys: _default_ssh_keys_path(),
             host_key_verification: Default::default(),
             external_port: None,
+            inactivity_timeout: _default_ssh_inactivity_timeout(),
         }
     }
 }

--- a/warpgate-protocol-ssh/src/server/mod.rs
+++ b/warpgate-protocol-ssh/src/server/mod.rs
@@ -27,7 +27,7 @@ pub async fn run_server(services: Services, address: SocketAddr) -> Result<()> {
         russh::server::Config {
             auth_rejection_time: Duration::from_secs(1),
             auth_rejection_time_initial: Some(Duration::from_secs(0)),
-            inactivity_timeout: Some(Duration::from_secs(300)),
+            inactivity_timeout: Some(config.store.ssh.inactivity_timeout),
             methods: MethodSet::PUBLICKEY | MethodSet::PASSWORD | MethodSet::KEYBOARD_INTERACTIVE,
             keys: load_host_keys(&config)?,
             event_buffer_size: 100,


### PR DESCRIPTION
With this change, the SSH inactivity timeout is now configurable. By default, is set at 5 minutes (300 seconds), which was the already existing value.

Solves #943 