### PR TITLE
Group dependabot version bump prs if they are minor or patch bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,24 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     labels: ["type/deps"]
-    open-pull-requests-limit: 25
+    #open-pull-requests-limit: 25
     schedule:
       interval: "daily"
+    groups:
+      version-bumps:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: "npm"
     directory: "/warpgate-web"
     labels: ["type/deps"]
-    open-pull-requests-limit: 25
+    #open-pull-requests-limit: 25
+    groups:
+      version-bumps:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
     schedule:
       interval: "daily"


### PR DESCRIPTION
Based on [the docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups).

Unfortunately I can't test this, but according to the documentation examples, this should make dependabot group all version bump PRs into a single PR per package manager. Only major version bumps and security issues are still raised as separate PRs.

I also removed the PR limit, since this setting probably makes more sense than simply limiting the dependabot PRs.

