### PR TITLE
Add title when adding public keys

### DIFF
--- a/tests/test_ssh_proto.py
+++ b/tests/test_ssh_proto.py
@@ -48,6 +48,7 @@ def setup_user_and_target(
         api.create_public_key_credential(
             user.id,
             sdk.NewPublicKeyCredential(
+                label="Public Key",
                 openssh_public_key=open("ssh-keys/id_ed25519.pub").read().strip(),
             ),
         )

--- a/tests/test_ssh_user_auth_otp.py
+++ b/tests/test_ssh_user_auth_otp.py
@@ -35,6 +35,7 @@ class Test:
             api.create_public_key_credential(
                 user.id,
                 sdk.NewPublicKeyCredential(
+                    label="Public Key",
                     openssh_public_key=open("ssh-keys/id_ed25519.pub").read().strip()
                 ),
             )

--- a/tests/test_ssh_user_auth_pubkey.py
+++ b/tests/test_ssh_user_auth_pubkey.py
@@ -29,6 +29,7 @@ class Test:
             api.create_public_key_credential(
                 user.id,
                 sdk.NewPublicKeyCredential(
+                    label="Public Key",
                     openssh_public_key=open("ssh-keys/id_ed25519.pub").read().strip()
                 ),
             )
@@ -104,6 +105,7 @@ class Test:
             api.create_public_key_credential(
                 user.id,
                 sdk.NewPublicKeyCredential(
+                    label="Public Key",
                     openssh_public_key=open("ssh-keys/id_rsa.pub").read().strip()
                 ),
             )

--- a/warpgate-admin/src/api/public_key_credentials.rs
+++ b/warpgate-admin/src/api/public_key_credentials.rs
@@ -18,11 +18,13 @@ use super::AnySecurityScheme;
 #[derive(Object)]
 struct ExistingPublicKeyCredential {
     id: Uuid,
+    openssh_public_key_title: String,
     openssh_public_key: String,
 }
 
 #[derive(Object)]
 struct NewPublicKeyCredential {
+    openssh_public_key_title: String,
     openssh_public_key: String,
 }
 
@@ -30,6 +32,7 @@ impl From<PublicKeyCredential::Model> for ExistingPublicKeyCredential {
     fn from(credential: PublicKeyCredential::Model) -> Self {
         Self {
             id: credential.id,
+            openssh_public_key_title: credential.openssh_public_key_title,
             openssh_public_key: credential.openssh_public_key,
         }
     }
@@ -112,6 +115,7 @@ impl ListApi {
         let object = PublicKeyCredential::ActiveModel {
             id: Set(Uuid::new_v4()),
             user_id: Set(*user_id),
+            openssh_public_key_title: Set(body.openssh_public_key_title.clone()),
             ..PublicKeyCredential::ActiveModel::from(UserPublicKeyCredential::try_from(&*body)?)
         }
         .insert(&*db)

--- a/warpgate-admin/src/api/public_key_credentials.rs
+++ b/warpgate-admin/src/api/public_key_credentials.rs
@@ -18,13 +18,13 @@ use super::AnySecurityScheme;
 #[derive(Object)]
 struct ExistingPublicKeyCredential {
     id: Uuid,
-    openssh_public_key_title: String,
+    label: String,
     openssh_public_key: String,
 }
 
 #[derive(Object)]
 struct NewPublicKeyCredential {
-    openssh_public_key_title: String,
+    label: String,
     openssh_public_key: String,
 }
 
@@ -32,7 +32,7 @@ impl From<PublicKeyCredential::Model> for ExistingPublicKeyCredential {
     fn from(credential: PublicKeyCredential::Model) -> Self {
         Self {
             id: credential.id,
-            openssh_public_key_title: credential.openssh_public_key_title,
+            label: credential.label,
             openssh_public_key: credential.openssh_public_key,
         }
     }
@@ -115,7 +115,7 @@ impl ListApi {
         let object = PublicKeyCredential::ActiveModel {
             id: Set(Uuid::new_v4()),
             user_id: Set(*user_id),
-            openssh_public_key_title: Set(body.openssh_public_key_title.clone()),
+            label: Set(body.label.clone()),
             ..PublicKeyCredential::ActiveModel::from(UserPublicKeyCredential::try_from(&*body)?)
         }
         .insert(&*db)
@@ -158,7 +158,7 @@ impl DetailApi {
         let model = PublicKeyCredential::ActiveModel {
             id: Set(id.0),
             user_id: Set(*user_id),
-            openssh_public_key_title: Set(body.openssh_public_key_title.clone()),
+            label: Set(body.label.clone()),
             ..<_>::from(UserPublicKeyCredential::try_from(&*body)?)
         }
         .update(&*db)

--- a/warpgate-admin/src/api/public_key_credentials.rs
+++ b/warpgate-admin/src/api/public_key_credentials.rs
@@ -158,6 +158,7 @@ impl DetailApi {
         let model = PublicKeyCredential::ActiveModel {
             id: Set(id.0),
             user_id: Set(*user_id),
+            openssh_public_key_title: Set(body.openssh_public_key_title.clone()),
             ..<_>::from(UserPublicKeyCredential::try_from(&*body)?)
         }
         .update(&*db)

--- a/warpgate-db-entities/src/PublicKeyCredential.rs
+++ b/warpgate-db-entities/src/PublicKeyCredential.rs
@@ -11,7 +11,7 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
     pub user_id: Uuid,
-    pub openssh_public_key_title: String,
+    pub label: String,
     pub openssh_public_key: String,
 }
 

--- a/warpgate-db-entities/src/PublicKeyCredential.rs
+++ b/warpgate-db-entities/src/PublicKeyCredential.rs
@@ -11,6 +11,7 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
     pub user_id: Uuid,
+    pub openssh_public_key_title: String,
     pub openssh_public_key: String,
 }
 

--- a/warpgate-db-migrations/src/lib.rs
+++ b/warpgate-db-migrations/src/lib.rs
@@ -13,6 +13,7 @@ mod m00008_users;
 mod m00009_credential_models;
 mod m00010_parameters;
 mod m00011_rsa_key_algos;
+mod m00012_add_openssh_public_key_title;
 
 pub struct Migrator;
 
@@ -31,6 +32,7 @@ impl MigratorTrait for Migrator {
             Box::new(m00009_credential_models::Migration),
             Box::new(m00010_parameters::Migration),
             Box::new(m00011_rsa_key_algos::Migration),
+            Box::new(m00012_add_openssh_public_key_title::Migration),
         ]
     }
 }

--- a/warpgate-db-migrations/src/lib.rs
+++ b/warpgate-db-migrations/src/lib.rs
@@ -13,7 +13,7 @@ mod m00008_users;
 mod m00009_credential_models;
 mod m00010_parameters;
 mod m00011_rsa_key_algos;
-mod m00012_add_openssh_public_key_title;
+mod m00012_add_openssh_public_key_label;
 
 pub struct Migrator;
 
@@ -32,7 +32,7 @@ impl MigratorTrait for Migrator {
             Box::new(m00009_credential_models::Migration),
             Box::new(m00010_parameters::Migration),
             Box::new(m00011_rsa_key_algos::Migration),
-            Box::new(m00012_add_openssh_public_key_title::Migration),
+            Box::new(m00012_add_openssh_public_key_label::Migration),
         ]
     }
 }

--- a/warpgate-db-migrations/src/m00012_add_openssh_public_key_label.rs
+++ b/warpgate-db-migrations/src/m00012_add_openssh_public_key_label.rs
@@ -4,7 +4,7 @@ pub struct Migration;
 
 impl MigrationName for Migration {
     fn name(&self) -> &str {
-        "m00012_add_openssh_public_key_title"
+        "m00012_add_openssh_public_key_label"
     }
 }
 
@@ -18,7 +18,7 @@ impl MigrationTrait for Migration {
                 Table::alter()
                     .table(public_key_credential::Entity)
                     .add_column(
-                        ColumnDef::new(Alias::new("openssh_public_key_title"))
+                        ColumnDef::new(Alias::new("label"))
                             .string()
                             .not_null()
                     ).to_owned()
@@ -31,7 +31,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(public_key_credential::Entity)
-                    .drop_column(Alias::new("openssh_public_key_title"))
+                    .drop_column(Alias::new("label"))
                     .to_owned(),
             )
             .await

--- a/warpgate-db-migrations/src/m00012_add_openssh_public_key_label.rs
+++ b/warpgate-db-migrations/src/m00012_add_openssh_public_key_label.rs
@@ -21,7 +21,9 @@ impl MigrationTrait for Migration {
                         ColumnDef::new(Alias::new("label"))
                             .string()
                             .not_null()
-                    ).to_owned()
+                            .default("Public Key")
+                    )
+                    .to_owned()
             )
             .await
     }

--- a/warpgate-db-migrations/src/m00012_add_openssh_public_key_title.rs
+++ b/warpgate-db-migrations/src/m00012_add_openssh_public_key_title.rs
@@ -1,0 +1,40 @@
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m00012_add_openssh_public_key_title"
+    }
+}
+
+use crate::m00009_credential_models::public_key_credential;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(public_key_credential::Entity)
+                    .add_column(
+                        ColumnDef::new(Alias::new("openssh_public_key_title"))
+                            .string()
+                            .not_null()
+                    ).to_owned()
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(public_key_credential::Entity)
+                    .drop_column(Alias::new("openssh_public_key_title"))
+                    .to_owned(),
+            )
+            .await
+    }
+
+}

--- a/warpgate-protocol-http/src/api/credentials.rs
+++ b/warpgate-protocol-http/src/api/credentials.rs
@@ -72,7 +72,7 @@ enum CredentialsStateResponse {
 
 #[derive(Object)]
 struct NewPublicKeyCredential {
-    openssh_public_key_title: String,
+    label: String,
     openssh_public_key: String,
 }
 
@@ -289,7 +289,7 @@ impl Api {
         let object = PublicKeyCredential::ActiveModel {
             id: Set(Uuid::new_v4()),
             user_id: Set(user_model.id),
-            openssh_public_key_title: Set(body.openssh_public_key_title.clone()),
+            label: Set(body.label.clone()),
             openssh_public_key: Set(body.openssh_public_key.clone()),
         }
         .insert(&*db)

--- a/warpgate-protocol-http/src/api/credentials.rs
+++ b/warpgate-protocol-http/src/api/credentials.rs
@@ -80,14 +80,19 @@ struct NewPublicKeyCredential {
 struct ExistingPublicKeyCredential {
     id: Uuid,
     label: String,
+    abbreviated: String,
 }
 
 fn abbreviate_public_key(k: &str) -> String {
     let l = 10;
+    if k.len() <= l {
+        return k.to_string(); // Return the full key if it's shorter than or equal to `l`.
+    }
+
     format!(
         "{}...{}",
-        &k[..l.min(k.len())],
-        &k[(k.len() - l).max(l).min(k.len() - 1)..]
+        &k[..l.min(k.len())],                // Take the first `l` characters.
+        &k[k.len().saturating_sub(l)..]      // Take the last `l` characters safely.
     )
 }
 
@@ -95,7 +100,8 @@ impl From<entities::PublicKeyCredential::Model> for ExistingPublicKeyCredential 
     fn from(credential: entities::PublicKeyCredential::Model) -> Self {
         Self {
             id: credential.id,
-            label: abbreviate_public_key(&credential.openssh_public_key),
+            label: credential.label,
+            abbreviated: abbreviate_public_key(&credential.openssh_public_key),
         }
     }
 }

--- a/warpgate-protocol-http/src/api/credentials.rs
+++ b/warpgate-protocol-http/src/api/credentials.rs
@@ -72,6 +72,7 @@ enum CredentialsStateResponse {
 
 #[derive(Object)]
 struct NewPublicKeyCredential {
+    openssh_public_key_title: String,
     openssh_public_key: String,
 }
 
@@ -288,6 +289,7 @@ impl Api {
         let object = PublicKeyCredential::ActiveModel {
             id: Set(Uuid::new_v4()),
             user_id: Set(user_model.id),
+            openssh_public_key_title: Set(body.openssh_public_key_title.clone()),
             openssh_public_key: Set(body.openssh_public_key.clone()),
         }
         .insert(&*db)

--- a/warpgate-web/src/admin/CredentialEditor.svelte
+++ b/warpgate-web/src/admin/CredentialEditor.svelte
@@ -184,7 +184,9 @@
         editingSsoCredentialInstance = null
     }
 
-    async function savePublicKeyCredential (opensshPublicKey: string) {
+    async function savePublicKeyCredential (opensshPublicKeyTitle: string, opensshPublicKey: string) {
+        // TODO: If it is an existing key, update it
+        //      Otherwise, create a new one
         if (editingPublicKeyCredentialInstance) {
             editingPublicKeyCredentialInstance.opensshPublicKey = opensshPublicKey
             await api.updatePublicKeyCredential({
@@ -196,6 +198,7 @@
             const credential = await api.createPublicKeyCredential({
                 userId,
                 newPublicKeyCredential: {
+                    opensshPublicKeyTitle,
                     opensshPublicKey,
                 },
             })

--- a/warpgate-web/src/admin/CredentialEditor.svelte
+++ b/warpgate-web/src/admin/CredentialEditor.svelte
@@ -185,9 +185,8 @@
     }
 
     async function savePublicKeyCredential (opensshPublicKeyTitle: string, opensshPublicKey: string) {
-        // TODO: If it is an existing key, update it
-        //      Otherwise, create a new one
         if (editingPublicKeyCredentialInstance) {
+            editingPublicKeyCredentialInstance.opensshPublicKeyTitle = opensshPublicKeyTitle
             editingPublicKeyCredentialInstance.opensshPublicKey = opensshPublicKey
             await api.updatePublicKeyCredential({
                 userId,

--- a/warpgate-web/src/admin/CredentialEditor.svelte
+++ b/warpgate-web/src/admin/CredentialEditor.svelte
@@ -184,9 +184,9 @@
         editingSsoCredentialInstance = null
     }
 
-    async function savePublicKeyCredential (opensshPublicKeyTitle: string, opensshPublicKey: string) {
+    async function savePublicKeyCredential (label: string, opensshPublicKey: string) {
         if (editingPublicKeyCredentialInstance) {
-            editingPublicKeyCredentialInstance.opensshPublicKeyTitle = opensshPublicKeyTitle
+            editingPublicKeyCredentialInstance.label = label
             editingPublicKeyCredentialInstance.opensshPublicKey = opensshPublicKey
             await api.updatePublicKeyCredential({
                 userId,
@@ -197,7 +197,7 @@
             const credential = await api.createPublicKeyCredential({
                 userId,
                 newPublicKeyCredential: {
-                    opensshPublicKeyTitle,
+                    label,
                     opensshPublicKey,
                 },
             })
@@ -252,7 +252,7 @@
         {/if}
         {#if credential.kind === 'PublicKey'}
             <Fa fw icon={faKey} />
-            <span class="type">{credential.opensshPublicKeyTitle}</span>
+            <span class="type">{credential.label}</span>
             <span class="text-muted ms-2">{abbreviatePublicKey(credential.opensshPublicKey)}</span>
         {/if}
         {#if credential.kind === 'Totp'}

--- a/warpgate-web/src/admin/CredentialEditor.svelte
+++ b/warpgate-web/src/admin/CredentialEditor.svelte
@@ -253,7 +253,7 @@
         {/if}
         {#if credential.kind === 'PublicKey'}
             <Fa fw icon={faKey} />
-            <span class="type">Public key</span>
+            <span class="type">{credential.opensshPublicKeyTitle}</span>
             <span class="text-muted ms-2">{abbreviatePublicKey(credential.opensshPublicKey)}</span>
         {/if}
         {#if credential.kind === 'Totp'}

--- a/warpgate-web/src/admin/PublicKeyCredentialModal.svelte
+++ b/warpgate-web/src/admin/PublicKeyCredentialModal.svelte
@@ -4,6 +4,7 @@
         Form,
         FormGroup,
         Input,
+        Label,
         Modal,
         ModalBody,
         ModalFooter,
@@ -15,7 +16,7 @@
     interface Props {
         isOpen: boolean
         instance?: ExistingPublicKeyCredential
-        save: (opensshPublicKey: string) => void
+        save: (opensshPublicKeyTitle: string, opensshPublicKey: string) => void
     }
 
     let {
@@ -25,11 +26,12 @@
     }: Props = $props()
 
     let field: HTMLInputElement|undefined = $state()
+    let opensshPublicKeyTitle: string = $state('')
     let opensshPublicKey: string = $state('')
     let validated = $state(false)
 
     function _save () {
-        if (!opensshPublicKey) {
+        if (!opensshPublicKey || !opensshPublicKeyTitle) {
             return
         }
         if (opensshPublicKey.includes(' ')) {
@@ -37,7 +39,7 @@
             opensshPublicKey = `${parts[0]} ${parts[1]}`
         }
         isOpen = false
-        save(opensshPublicKey)
+        save(opensshPublicKeyTitle, opensshPublicKey)
     }
 
     function _cancel () {
@@ -56,9 +58,16 @@
         e.preventDefault()
     }}>
         <ModalHeader toggle={_cancel}>
-            Public key
+            Add new SSH Public Key
         </ModalHeader>
         <ModalBody>
+            <FormGroup floating label="Title">
+                <Input
+                    bind:inner={field}
+                    type="text"
+                    required
+                    bind:value={opensshPublicKeyTitle} />
+            </FormGroup>
             <FormGroup floating label="Public key in OpenSSH format">
                 <Input
                     style="font-family: monospace; height: 15rem"

--- a/warpgate-web/src/admin/PublicKeyCredentialModal.svelte
+++ b/warpgate-web/src/admin/PublicKeyCredentialModal.svelte
@@ -15,7 +15,7 @@
     interface Props {
         isOpen: boolean
         instance?: ExistingPublicKeyCredential
-        save: (opensshPublicKeyTitle: string, opensshPublicKey: string) => void
+        save: (label: string, opensshPublicKey: string) => void
     }
 
     let {
@@ -25,12 +25,12 @@
     }: Props = $props()
 
     let field: HTMLInputElement|undefined = $state()
-    let opensshPublicKeyTitle: string = $state('')
+    let label: string = $state('')
     let opensshPublicKey: string = $state('')
     let validated = $state(false)
 
     function _save () {
-        if (!opensshPublicKey || !opensshPublicKeyTitle) {
+        if (!opensshPublicKey || !label) {
             return
         }
         if (opensshPublicKey.includes(' ')) {
@@ -38,7 +38,7 @@
             opensshPublicKey = `${parts[0]} ${parts[1]}`
         }
         isOpen = false
-        save(opensshPublicKeyTitle, opensshPublicKey)
+        save(label, opensshPublicKey)
     }
 
     function _cancel () {
@@ -48,7 +48,7 @@
 
 <Modal toggle={_cancel} isOpen={isOpen} on:open={() => {
     if (instance) {
-        opensshPublicKeyTitle = instance.opensshPublicKeyTitle
+        label = instance.label
         opensshPublicKey = instance.opensshPublicKey
     }
     field?.focus()
@@ -58,15 +58,15 @@
         e.preventDefault()
     }}>
         <ModalHeader toggle={_cancel}>
-            Add new SSH Public Key
+            Add an SSH public key
         </ModalHeader>
         <ModalBody>
-            <FormGroup floating label="Title">
+            <FormGroup floating label="Label">
                 <Input
                     bind:inner={field}
                     type="text"
                     required
-                    bind:value={opensshPublicKeyTitle} />
+                    bind:value={label} />
             </FormGroup>
             <FormGroup floating label="Public key in OpenSSH format">
                 <Input

--- a/warpgate-web/src/admin/PublicKeyCredentialModal.svelte
+++ b/warpgate-web/src/admin/PublicKeyCredentialModal.svelte
@@ -4,7 +4,6 @@
         Form,
         FormGroup,
         Input,
-        Label,
         Modal,
         ModalBody,
         ModalFooter,
@@ -49,6 +48,7 @@
 
 <Modal toggle={_cancel} isOpen={isOpen} on:open={() => {
     if (instance) {
+        opensshPublicKeyTitle = instance.opensshPublicKeyTitle
         opensshPublicKey = instance.opensshPublicKey
     }
     field?.focus()

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate Web Admin",
-    "version": "0.11.0"
+    "version": "0.12.0"
   },
   "servers": [
     {
@@ -2154,12 +2154,16 @@
         "type": "object",
         "required": [
           "id",
+          "openssh_public_key_title",
           "openssh_public_key"
         ],
         "properties": {
           "id": {
             "type": "string",
             "format": "uuid"
+          },
+          "openssh_public_key_title": {
+            "type": "string"
           },
           "openssh_public_key": {
             "type": "string"
@@ -2272,9 +2276,13 @@
       "NewPublicKeyCredential": {
         "type": "object",
         "required": [
+          "openssh_public_key_title",
           "openssh_public_key"
         ],
         "properties": {
+          "openssh_public_key_title": {
+            "type": "string"
+          },
           "openssh_public_key": {
             "type": "string"
           }

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -2154,7 +2154,7 @@
         "type": "object",
         "required": [
           "id",
-          "openssh_public_key_title",
+          "label",
           "openssh_public_key"
         ],
         "properties": {
@@ -2162,7 +2162,7 @@
             "type": "string",
             "format": "uuid"
           },
-          "openssh_public_key_title": {
+          "label": {
             "type": "string"
           },
           "openssh_public_key": {
@@ -2276,11 +2276,11 @@
       "NewPublicKeyCredential": {
         "type": "object",
         "required": [
-          "openssh_public_key_title",
+          "label",
           "openssh_public_key"
         ],
         "properties": {
-          "openssh_public_key_title": {
+          "label": {
             "type": "string"
           },
           "openssh_public_key": {

--- a/warpgate-web/src/gateway/CredentialManager.svelte
+++ b/warpgate-web/src/gateway/CredentialManager.svelte
@@ -31,9 +31,10 @@
         creds!.password = state
     }
 
-    async function createPublicKey (opensshPublicKey: string) {
+    async function createPublicKey (label: string, opensshPublicKey: string) {
         const credential = await api.addMyPublicKey({
             newPublicKeyCredential: {
+                label,
                 opensshPublicKey,
             },
         })
@@ -156,6 +157,7 @@
         <div class="list-group-item credential">
             <Fa fw icon={faKey} />
             <span class="label">{credential.label}</span>
+            <span class="text-muted ms-2">{credential.abbreviated}</span>
             <span class="ms-auto"></span>
             <a
                 class="hover-reveal ms-2"

--- a/warpgate-web/src/gateway/lib/openapi-schema.json
+++ b/warpgate-web/src/gateway/lib/openapi-schema.json
@@ -799,11 +799,11 @@
       "NewPublicKeyCredential": {
         "type": "object",
         "required": [
-          "openssh_public_key_title",
+          "label",
           "openssh_public_key"
         ],
         "properties": {
-          "openssh_public_key_title": {
+          "label": {
             "type": "string"
           },
           "openssh_public_key": {

--- a/warpgate-web/src/gateway/lib/openapi-schema.json
+++ b/warpgate-web/src/gateway/lib/openapi-schema.json
@@ -688,7 +688,8 @@
         "type": "object",
         "required": [
           "id",
-          "label"
+          "label",
+          "abbreviated"
         ],
         "properties": {
           "id": {
@@ -696,6 +697,9 @@
             "format": "uuid"
           },
           "label": {
+            "type": "string"
+          },
+          "abbreviated": {
             "type": "string"
           }
         }

--- a/warpgate-web/src/gateway/lib/openapi-schema.json
+++ b/warpgate-web/src/gateway/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate HTTP proxy",
-    "version": "0.11.0"
+    "version": "0.12.0"
   },
   "servers": [
     {
@@ -799,9 +799,13 @@
       "NewPublicKeyCredential": {
         "type": "object",
         "required": [
+          "openssh_public_key_title",
           "openssh_public_key"
         ],
         "properties": {
+          "openssh_public_key_title": {
+            "type": "string"
+          },
           "openssh_public_key": {
             "type": "string"
           }


### PR DESCRIPTION
This PR adds the title input as a field in the frontend and saves it in the DB.

A view from the modal:

<img width="504" alt="Screenshot 2024-12-15 at 12 43 59 AM" src="https://github.com/user-attachments/assets/ffaf3fa2-1556-4033-b2a9-09947184b473" />

Public key after being saved:

<img width="1320" alt="Screenshot 2024-12-15 at 12 46 21 AM" src="https://github.com/user-attachments/assets/38421627-5d16-4fdb-b9f6-1cee85a6f29f" />

Working on this, I realized that we should probably add more metadata like when it was added, when it was last used etc.

Fixes: https://github.com/warp-tech/warpgate/issues/714
Fixes: https://github.com/warp-tech/warpgate/issues/754
Fixes: https://github.com/warp-tech/warpgate/issues/898
Fixes: https://github.com/warp-tech/warpgate/issues/1176


One thing to note is that my passwords manager stopped recognizing the public id field as one. 