### PR TITLE
Upgrade openidconnect and oauth2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,20 +1855,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.30",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
@@ -1883,6 +1869,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -2587,16 +2574,16 @@ dependencies = [
 
 [[package]]
 name = "oauth2"
-version = "4.4.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "chrono",
  "getrandom",
- "http 0.2.12",
+ "http 1.1.0",
  "rand",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -2628,16 +2615,16 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openidconnect"
-version = "3.5.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47e80a9cfae4462dd29c41e987edd228971d6565553fbc14b8a11e666d91590"
+checksum = "6dd50d4a5e7730e754f94d977efe61f611aadd3131f6a2b464f6e3a4167e8ef7"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.7",
  "chrono",
  "dyn-clone",
  "ed25519-dalek",
  "hmac",
- "http 0.2.12",
+ "http 1.1.0",
  "itertools",
  "log",
  "oauth2",
@@ -2647,7 +2634,6 @@ dependencies = [
  "rsa",
  "serde",
  "serde-value",
- "serde_derive",
  "serde_json",
  "serde_path_to_error",
  "serde_plain",
@@ -3501,47 +3487,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
@@ -3554,7 +3499,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
- "hyper-rustls 0.27.3",
+ "hyper-rustls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -3581,6 +3526,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.26.8",
  "windows-registry",
 ]
 
@@ -3887,7 +3833,6 @@ version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
- "log",
  "ring 0.17.8",
  "rustls-webpki 0.101.7",
  "sct",
@@ -4602,7 +4547,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -4877,27 +4822,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5031,16 +4955,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
 ]
 
 [[package]]
@@ -5717,7 +5631,7 @@ dependencies = [
  "poem",
  "poem-openapi",
  "regex",
- "reqwest 0.12.7",
+ "reqwest",
  "sea-orm",
  "serde",
  "serde_json",
@@ -5954,6 +5868,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"
@@ -6328,16 +6251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/warpgate-protocol-http/src/api/sso_provider_detail.rs
+++ b/warpgate-protocol-http/src/api/sso_provider_detail.rs
@@ -67,7 +67,7 @@ impl Api {
         return_url.set_path("@warpgate/api/sso/return");
         debug!("Return URL: {}", &return_url);
 
-        let client = SsoClient::new(provider_config.provider.clone());
+        let client = SsoClient::new(provider_config.provider.clone())?;
 
         let sso_req = client.start_login(return_url.to_string()).await?;
 

--- a/warpgate-protocol-http/src/api/sso_provider_list.rs
+++ b/warpgate-protocol-http/src/api/sso_provider_list.rs
@@ -308,7 +308,7 @@ impl Api {
             return Ok(StartSloResponse::NotFound);
         };
 
-        let client = SsoClient::new(provider_config.provider.clone());
+        let client = SsoClient::new(provider_config.provider.clone())?;
         let logout_url = client.logout(state.token, return_url).await?;
 
         logout(session, session_middleware.lock().await.deref_mut());

--- a/warpgate-sso/Cargo.toml
+++ b/warpgate-sso/Cargo.toml
@@ -9,7 +9,11 @@ bytes.workspace = true
 thiserror = "1.0"
 tokio = { version = "1.20", features = ["tracing", "macros"] }
 tracing.workspace = true
-openidconnect = { version = "3.5", features = ["reqwest", "rustls-tls", "accept-string-booleans"] }
+openidconnect = { version = "4.0", features = [
+    "reqwest",
+    "rustls-tls",
+    "accept-string-booleans",
+] }
 serde.workspace = true
 serde_json.workspace = true
 once_cell = "1.17"

--- a/warpgate-sso/src/error.rs
+++ b/warpgate-sso/src/error.rs
@@ -1,6 +1,8 @@
 use std::error::Error;
 
-use openidconnect::{ClaimsVerificationError, SignatureVerificationError, SigningError};
+use openidconnect::{
+    reqwest, ClaimsVerificationError, ConfigurationError, SignatureVerificationError, SigningError,
+};
 
 #[derive(thiserror::Error, Debug)]
 pub enum SsoError {
@@ -20,12 +22,16 @@ pub enum SsoError {
     ClaimsVerification(#[from] ClaimsVerificationError),
     #[error("signing error: {0}")]
     Signing(#[from] SigningError),
+    #[error("reqwest: {0}")]
+    Reqwest(#[from] reqwest::Error),
     #[error("I/O: {0}")]
     Io(#[from] std::io::Error),
     #[error("JWT error: {0}")]
     Jwt(#[from] jsonwebtoken::errors::Error),
     #[error("signature verification: {0}")]
     SignatureVerification(#[from] SignatureVerificationError),
+    #[error("configuration: {0}")]
+    Configuration(#[from] ConfigurationError),
     #[error("the OIDC provider doesn't support RP-initiated logout")]
     LogoutNotSupported,
     #[error(transparent)]

--- a/warpgate-sso/src/error.rs
+++ b/warpgate-sso/src/error.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use openidconnect::{ClaimsVerificationError, SigningError};
+use openidconnect::{ClaimsVerificationError, SignatureVerificationError, SigningError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum SsoError {
@@ -24,6 +24,8 @@ pub enum SsoError {
     Io(#[from] std::io::Error),
     #[error("JWT error: {0}")]
     Jwt(#[from] jsonwebtoken::errors::Error),
+    #[error("signature verification: {0}")]
+    SignatureVerification(#[from] SignatureVerificationError),
     #[error("the OIDC provider doesn't support RP-initiated logout")]
     LogoutNotSupported,
     #[error(transparent)]

--- a/warpgate-sso/src/request.rs
+++ b/warpgate-sso/src/request.rs
@@ -25,8 +25,7 @@ impl SsoLoginRequest {
     }
 
     pub async fn verify_code(self, code: String) -> Result<SsoLoginResponse, SsoError> {
-        //
-        let result = SsoClient::new(self.config)
+        let result = SsoClient::new(self.config)?
             .finish_login(self.pkce_verifier, self.redirect_url, &self.nonce, code)
             .await?;
 

--- a/warpgate-sso/src/sso.rs
+++ b/warpgate-sso/src/sso.rs
@@ -3,16 +3,14 @@ use std::ops::Deref;
 
 use futures::future::OptionFuture;
 use openidconnect::core::{
-    CoreAuthenticationFlow, CoreClient,
-    CoreGenderClaim, CoreIdToken, CoreIdTokenClaims,
+    CoreAuthenticationFlow, CoreClient, CoreGenderClaim, CoreIdToken, CoreIdTokenClaims,
 };
 use openidconnect::url::Url;
 use openidconnect::{
-    reqwest, AccessTokenHash, AdditionalClaims, AuthorizationCode, CsrfToken,
-    DiscoveryError, EndpointMaybeSet, EndpointNotSet,
-    EndpointSet, LogoutRequest, Nonce, OAuth2TokenResponse, PkceCodeChallenge,
-    PkceCodeVerifier, PostLogoutRedirectUrl, ProviderMetadataWithLogout, RedirectUrl,
-    RequestTokenError, Scope, TokenResponse, UserInfoClaims,
+    reqwest, AccessTokenHash, AdditionalClaims, AuthorizationCode, CsrfToken, DiscoveryError,
+    EndpointMaybeSet, EndpointNotSet, EndpointSet, LogoutRequest, Nonce, OAuth2TokenResponse,
+    PkceCodeChallenge, PkceCodeVerifier, PostLogoutRedirectUrl, ProviderMetadataWithLogout,
+    RedirectUrl, RequestTokenError, Scope, TokenResponse, UserInfoClaims,
 };
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -59,10 +57,10 @@ async fn make_client(
     http_client: &reqwest::Client,
 ) -> Result<
     CoreClient<
-        EndpointSet, // HasAuthUrl
-        EndpointNotSet, // HasDeviceAuthUrl
-        EndpointNotSet, // HasIntrospectionUrl
-        EndpointNotSet, // HasRevocationUrl
+        EndpointSet,      // HasAuthUrl
+        EndpointNotSet,   // HasDeviceAuthUrl
+        EndpointNotSet,   // HasIntrospectionUrl
+        EndpointNotSet,   // HasRevocationUrl
         EndpointMaybeSet, // HasTokenUrl
         EndpointMaybeSet, // HasUserInfoUrl
     >,
@@ -81,12 +79,11 @@ async fn make_client(
 }
 
 impl SsoClient {
-    pub fn new(config: SsoInternalProviderConfig) -> Self {
-        let http_client = reqwest::ClientBuilder::new().build().unwrap();
-        Self {
+    pub fn new(config: SsoInternalProviderConfig) -> Result<Self, SsoError> {
+        Ok(Self {
             config,
-            http_client,
-        }
+            http_client: reqwest::ClientBuilder::new().build()?,
+        })
     }
 
     pub async fn supports_single_logout(&self) -> Result<bool, SsoError> {
@@ -147,7 +144,7 @@ impl SsoClient {
             .await?
             .set_redirect_uri(redirect_url);
 
-        let mut req = client.exchange_code(AuthorizationCode::new(code)).unwrap();
+        let mut req = client.exchange_code(AuthorizationCode::new(code))?;
         if let Some(verifier) = pkce_verifier {
             req = req.set_pkce_verifier(verifier);
         }


### PR DESCRIPTION
PS: I'm pretty new in Rust! I'm totally aware of any feedbacks or revamp

Recently we figured out that many people complaining about SSL/Certificate error when using custom CA. Even if this Certificates and CA are correctly installed on system.

On my own use case, we've enterprise internal CA, that I've installed them (full chain) inside `/usr/local/share/ca-certificates/` and ran `update-ca-certificates`. Fact checking using `curl` without `-k` option, is working but still have error on **Warpgate**

```
Request(Reqwest(reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("gitlab.customdomain")), port: None, path: "/.well-known/openid-configuration", query: None, fragment: None }, source: hyper::Error(Connect, Custom { kind: Other, error: Custom { kind: InvalidData, error: InvalidCertificate(UnknownIssuer) } }) }))
08:09:46 ERROR HTTP: Request failed method=GET url=https://localhost:8888/@warpgate/api/sso/providers/custom/start?next=%2F error=provider discovery error: Request error: request failed client_ip=127.0.0.1
```

I've performed some tests with following configurations:

1. `reqwest 0.12` and patching **Warpgate** inside `Sso::discover_metadata` to perform call to my GitLab just to check if success or not + `openidconnect 3.5` (which depends on `reqwest 0.11`)

the patch is really simple

```diff
diff --git a/warpgate-sso/src/sso.rs b/warpgate-sso/src/sso.rs
index 81ca453..d6f4fa7 100644
--- a/warpgate-sso/src/sso.rs
+++ b/warpgate-sso/src/sso.rs
@@ -41,9 +41,21 @@ pub struct SsoClient {
 pub async fn discover_metadata(
     config: &SsoInternalProviderConfig,
 ) -> Result<ProviderMetadataWithLogout, SsoError> {
+    let builder2 = reqwest::Client::builder();
+    let client2 = builder2.build().unwrap();
+    let result = client2
+        .get("https://gitlab.customdomain")
+        .send()
+        .await;
+    println!("{:?}", result);
+
     ProviderMetadataWithLogout::discover_async(config.issuer_url()?, async_http_client)
```

```
# println! of the patch
Ok(Response { url: "https://gitlab.customdomain/users/sign_in", status: 200, headers: {"server": "nginx/1.21.6", "date": "Tue, 04 Feb 2025 07:59:16 GMT", "content-type": "text/html; charset=utf-8", "content-length": "9440", "connection": "keep-alive", "vary": "Accept-Encoding", "vary": "Accept", "cache-control": "max-age=0, private, must-revalidate", "content-security-policy": "", "etag": "W/\"554eff6a0ca52bc3584b130595bbbdd7\"", "permissions-policy": "interest-cohort=()", "set-cookie": "preferred_language=en; path=/; Secure; SameSite=None", "set-cookie": "_gitlab_session=ec40314f7d2bad0255e5a802be1fe0c4; path=/; expires=Tue, 04 Feb 2025 09:59:16 GMT; secure; HttpOnly; SameSite=None", "x-content-type-options": "nosniff", "x-download-options": "noopen", "x-frame-options": "SAMEORIGIN", "x-gitlab-meta": "{\"correlation_id\":\"01JK7ZGZWRF7X7FTDEBC4Y1FMG\",\"version\":\"1\"}", "x-permitted-cross-domain-policies": "none", "x-request-id": "01JK7ZGZWRF7X7FTDEBC4Y1FMG", "x-runtime": "0.026065", "x-ua-compatible": "IE=edge", "x-xss-protection": "1; mode=block", "strict-transport-security": "max-age=63072000", "strict-transport-security": "max-age=31536000", "referrer-policy": "strict-origin-when-cross-origin", "access-control-allow-headers": "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers, Authorization", "access-control-allow-credentials": "true"} })
# Inside Sso flow
Err(reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("gitlab.customdomain")), port: None, path: "/", query: None, fragment: None }, source: hyper::Error(Connect, Custom { kind: Other, error: Custom { kind: InvalidData, error: InvalidCertificate(UnknownIssuer) } }) })
```

2. `reqwest 0.11` and same patch + `openidconnect 3.5` (which depends on `reqwest 0.11`)

Leads to double errors

```
# println! of the patch
Err(reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("gitlab.customdomain")), port: None, path: "/", query: None, fragment: None }, source: hyper::Error(Connect, Custom { kind: Other, error: Custom { kind: InvalidData, error: InvalidCertificate(UnknownIssuer) } }) })
# Inside Sso flow
Err(reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("gitlab.customdomain")), port: None, path: "/", query: None, fragment: None }, source: hyper::Error(Connect, Custom { kind: Other, error: Custom { kind: InvalidData, error: InvalidCertificate(UnknownIssuer) } }) })
```

I don't find the cause why using reqwest `0.11` installed certificates are ignored, but seems to be the origin.

To enforce `openidconnect` to use `reqwest 0.12` we've to upgrade to new version `4.0` (and in my env, upgrade fix the issue)

May fixes issues #1208 and #1140