### PR TITLE
Implement option to trust unknown audiences

### DIFF
--- a/warpgate-sso/src/config.rs
+++ b/warpgate-sso/src/config.rs
@@ -64,6 +64,8 @@ pub enum SsoInternalProviderConfig {
         scopes: Vec<String>,
         role_mappings: Option<HashMap<String, String>>,
         additional_trusted_audiences: Option<Vec<String>>,
+        #[serde(default)]
+        trust_unknown_audiences: bool,
     },
 }
 
@@ -229,6 +231,18 @@ impl SsoInternalProviderConfig {
                 ..
             } => additional_trusted_audiences.as_ref(),
             _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn trust_unknown_audiences(&self) -> bool {
+        #[allow(clippy::match_like_matches_macro)]
+        match self {
+            SsoInternalProviderConfig::Custom {
+                trust_unknown_audiences,
+                ..
+            } => *trust_unknown_audiences,
+            _ => false,
         }
     }
 }

--- a/warpgate-sso/src/sso.rs
+++ b/warpgate-sso/src/sso.rs
@@ -171,6 +171,10 @@ impl SsoClient {
                 .set_other_audience_verifier_fn(|aud| trusted_audiences.contains(aud.deref()));
         }
 
+        if self.config.trust_unknown_audiences() {
+            token_verifier = token_verifier.set_other_audience_verifier_fn(|_aud|true);
+        }
+
         let id_token: &CoreIdToken = token_response.id_token().ok_or(SsoError::NotOidc)?;
         let claims = id_token.claims(&token_verifier, nonce)?;
 


### PR DESCRIPTION
Currently Warpgate implements openidconnect_rs in a way where the OIDC audience has to be either just the warpgate client id or you have to explicitly trust every additional client id. Some IdP's ([ZITADEL](https://zitadel.com/) in my case) however don't let you limit the audience for a specific client on the IdP side, and in my usecase clients in the IdP project are often added or removed. Having to update the warpgate config every time this happens is undoable for me, as such I would like to explicitly trust any unknown client via config. 

This PR implements that via an added optional setting (`trust_unknown_audiences`) for the OIDC-custom provider.