### PR TITLE
Fix SSH Client to respond to keyboard-interactive when target has optional 2FA

### DIFF
--- a/warpgate-protocol-ssh/src/client/mod.rs
+++ b/warpgate-protocol-ssh/src/client/mod.rs
@@ -565,11 +565,11 @@ impl RemoteClient {
                                 }
                                 let key_str = key.public_key().to_openssh().map_err(russh::Error::from)?;
                                 let mut response  = session
-                                        .authenticate_publickey(
-                                            ssh_options.username.clone(),
-                                            PrivateKeyWithHashAlg::new(key.clone(), best_hash),
-                                        )
-                                        .await?;
+                                    .authenticate_publickey(
+                                        ssh_options.username.clone(),
+                                        PrivateKeyWithHashAlg::new(key.clone(), best_hash),
+                                    )
+                                    .await?;
 
                                 auth_result = self._handle_auth_result(
                                     &mut session,
@@ -581,11 +581,11 @@ impl RemoteClient {
                                     // Corner case: OpenSSH advertising rsa2-sha-* through server-sig-algs, but it being
                                     // disabled via PubkeyAcceptedAlgorithms. So far the only case is our own test suite.
                                     // In this case we retry with ssh-rsa (SHA1)
-                                    response  = session
+                                    response = session
                                         .authenticate_publickey(
-                                        ssh_options.username.clone(),
-                                        PrivateKeyWithHashAlg::new(key.clone(), best_hash),
-                                    ).await?;
+                                            ssh_options.username.clone(),
+                                            PrivateKeyWithHashAlg::new(key.clone(), None),
+                                        ).await?;
 
                                     auth_result = self._handle_auth_result(
                                         &mut session,

--- a/warpgate-protocol-ssh/src/client/mod.rs
+++ b/warpgate-protocol-ssh/src/client/mod.rs
@@ -15,9 +15,9 @@ use channel_session::SessionChannel;
 pub use error::SshClientError;
 use futures::pin_mut;
 use handler::ClientHandler;
-use russh::client::Handle;
+use russh::client::{AuthResult, Handle, KeyboardInteractiveAuthResponse};
 use russh::keys::PublicKey;
-use russh::{kex, Preferred, Sig};
+use russh::{kex, MethodKind, Preferred, Sig};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::{oneshot, Mutex};
 use tokio::task::JoinHandle;
@@ -536,9 +536,17 @@ impl RemoteClient {
                     let mut auth_result = false;
                     match ssh_options.auth {
                         SSHTargetAuth::Password(auth) => {
-                            auth_result = session
-                                .authenticate_password(ssh_options.username.clone(), auth.password.expose_secret())
-                                .await?.success();
+                            let response = session
+                                    .authenticate_password(
+                                        ssh_options.username.clone(),
+                                        auth.password.expose_secret()
+                                    )
+                                    .await?;
+                            auth_result = self._handle_auth_result(
+                                &mut session,
+                                ssh_options.username.clone(),
+                                response
+                            ).await.unwrap_or(false);
                             if auth_result {
                                 debug!(username=&ssh_options.username[..], "Authenticated with password");
                             }
@@ -548,12 +556,18 @@ impl RemoteClient {
                             let keys = load_all_usable_private_keys(&*self.services.config.lock().await, ssh_options.allow_insecure_algos.unwrap_or(false))?;
                             for key in keys.into_iter() {
                                 let key_str = key.public_key().to_openssh().map_err(russh::Error::from)?;
-                                auth_result = session
-                                    .authenticate_publickey(
-                                        ssh_options.username.clone(),
-                                        key
-                                    )
-                                    .await?.success();
+                                let response  = session
+                                        .authenticate_publickey(
+                                            ssh_options.username.clone(),
+                                            key
+                                        )
+                                        .await?;
+                                auth_result = self._handle_auth_result(
+                                    &mut session,
+                                    ssh_options.username.clone(),
+                                    response
+                                ).await.unwrap_or(false);
+
                                 if auth_result {
                                     debug!(username=&ssh_options.username[..], key=%key_str, "Authenticated with key");
                                     break;
@@ -589,6 +603,77 @@ impl RemoteClient {
                 }
             }
         }
+    }
+
+    /// Handles an AuthResult from a password or public key authentication attempt.
+    /// If presented with an additional keyboard-interactive challenge it will respond with empty
+    /// strings. This ensures optional 2fa is respected, where this extra challenge always happens.
+    ///
+    /// TODO: Optionally implement forwarding the challenges to the user
+    ///
+    /// # Arguments
+    ///
+    /// * `session`: the session for which the initial result is
+    /// * `username`: username of the authenticating user
+    /// * `result`: the initial result received via the configured auth method
+    async fn _handle_auth_result(
+        &self,
+        session: &mut Handle<ClientHandler>,
+        username: String,
+        result: AuthResult,
+    ) -> Result<bool> {
+        debug!("Handling AuthResult");
+        match result {
+            AuthResult::Success => {
+                debug!("AuthResult is already success, no further handling needed");
+                return Ok(true);
+            }
+            AuthResult::Failure {
+                remaining_methods: methods,
+            } => {
+                debug!("Initial auth failed, checking remaining methods");
+                for method in methods.into_iter() {
+                    if matches!(method, MethodKind::KeyboardInteractive) {
+                        debug!("Found keyboard-interactive challenge");
+                        let mut kb_result = session
+                            .authenticate_keyboard_interactive_start(
+                                username.clone(),
+                                None,
+                            )
+                            .await?;
+
+                        while let KeyboardInteractiveAuthResponse::InfoRequest {
+                            name: _name,
+                            instructions: _instructions,
+                            prompts,
+                        } = kb_result {
+                            for prompt in prompts.iter().clone() {
+                                debug!(prompt=prompt.prompt, echo=prompt.echo, "Prompt received for keyboard-interactive");
+                            }
+                            debug!("Responding with empty responses");
+                            kb_result = session
+                                .authenticate_keyboard_interactive_respond(
+                                    vec![String::new(); prompts.len()]
+                                ).await?;
+                        }
+
+                        match kb_result {
+                            KeyboardInteractiveAuthResponse::Success => {
+                                debug!("keyboard-interactive challenge successful");
+                                return Ok(true);
+                            }
+                            KeyboardInteractiveAuthResponse::Failure { remaining_methods: _remaining_methods } => {
+                                debug!("keyboard-interactive challenge failed");
+                                return Ok(false);
+                            }
+                            _ => {}
+                        }
+                    }
+                    continue;
+                }
+            }
+        }
+        Ok(false)
     }
 
     async fn open_shell(&mut self, channel_id: Uuid) -> Result<(), SshClientError> {


### PR DESCRIPTION
This PR fixes https://github.com/warp-tech/warpgate/issues/1272 for both public key and password targets.

When a keyboard-interactive prompt is offered it will respond with empty responses to given prompts. For targets with enforced 2FA via TOTP for example, this will fail as the code is not correct and the session will terminate. For targets that have 2FA enabled, but don't enforce it this will ensure the connection will be setup as sshd expects those empty responses.