### PR TITLE
Set the config file format

### DIFF
--- a/warpgate/src/config.rs
+++ b/warpgate/src/config.rs
@@ -11,7 +11,7 @@ use warpgate_common::{WarpgateConfig, WarpgateConfigStore};
 
 pub fn load_config(path: &Path, secure: bool) -> Result<WarpgateConfig> {
     let mut store: serde_yaml::Value = Config::builder()
-        .add_source(File::new(path.to_str().unwrap_or(""), FileFormat::Yaml))
+        .add_source(File::new(path.to_str().ok_or_else(|| anyhow::anyhow!("Invalid path"))?, FileFormat::Yaml))
         .add_source(Environment::with_prefix("WARPGATE"))
         .build()
         .context("Could not load config")?

--- a/warpgate/src/config.rs
+++ b/warpgate/src/config.rs
@@ -11,7 +11,7 @@ use warpgate_common::{WarpgateConfig, WarpgateConfigStore};
 
 pub fn load_config(path: &Path, secure: bool) -> Result<WarpgateConfig> {
     let mut store: serde_yaml::Value = Config::builder()
-        .add_source(File::new(path, FileFormat::Yaml))
+        .add_source(File::new(path.to_str().unwrap_or(""), FileFormat::Yaml))
         .add_source(Environment::with_prefix("WARPGATE"))
         .build()
         .context("Could not load config")?

--- a/warpgate/src/config.rs
+++ b/warpgate/src/config.rs
@@ -11,7 +11,10 @@ use warpgate_common::{WarpgateConfig, WarpgateConfigStore};
 
 pub fn load_config(path: &Path, secure: bool) -> Result<WarpgateConfig> {
     let mut store: serde_yaml::Value = Config::builder()
-        .add_source(File::new(path.to_str().ok_or_else(|| anyhow::anyhow!("Invalid path"))?, FileFormat::Yaml))
+        .add_source(File::new(
+            path.to_str().context("Invalid config path")?,
+            FileFormat::Yaml,
+        ))
         .add_source(Environment::with_prefix("WARPGATE"))
         .build()
         .context("Could not load config")?

--- a/warpgate/src/config.rs
+++ b/warpgate/src/config.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use config::{Config, Environment, File};
+use config::{Config, Environment, File, FileFormat};
 use notify::{recommended_watcher, RecursiveMode, Watcher};
 use tokio::sync::{broadcast, mpsc, Mutex};
 use tracing::*;
@@ -11,7 +11,7 @@ use warpgate_common::{WarpgateConfig, WarpgateConfigStore};
 
 pub fn load_config(path: &Path, secure: bool) -> Result<WarpgateConfig> {
     let mut store: serde_yaml::Value = Config::builder()
-        .add_source(File::from(path))
+        .add_source(File::new(path, FileFormat::Yaml))
         .add_source(Environment::with_prefix("WARPGATE"))
         .build()
         .context("Could not load config")?


### PR DESCRIPTION
This sets the file format to be yaml instead of let the config to figure it out by extension. The problem is that it guesses file format by extension and some tools - eg ansible - create tempfiles without extension to validate the config changes before applying them, that makes the validation always fail.

This PR changes how the config file is loaded so that it doesn't guess file type.