### PR TITLE
fix: Remove SSH known hosts entry when deleting SSH targets

### DIFF
--- a/warpgate-admin/src/api/targets.rs
+++ b/warpgate-admin/src/api/targets.rs
@@ -206,6 +206,18 @@ impl DetailApi {
             .exec(&*db)
             .await?;
 
+        if target.kind == TargetKind::Ssh {
+            let options: TargetOptions = serde_json::from_value(target.options.clone())?;
+            if let TargetOptions::Ssh(ssh_options) = options {
+                use warpgate_db_entities::KnownHost;
+                KnownHost::Entity::delete_many()
+                    .filter(KnownHost::Column::Host.eq(&ssh_options.host))
+                    .filter(KnownHost::Column::Port.eq(ssh_options.port as i32))
+                    .exec(&*db)
+                    .await?;
+            }
+        }
+
         target.delete(&*db).await?;
         Ok(DeleteTargetResponse::Deleted)
     }


### PR DESCRIPTION
When a target is deleted from the admin UI, any associated SSH known hosts entries are now also removed. This prevents orphaned host key entries from remaining in the database after a target is deleted, which could cause confusion if a new target with the same hostname is created later.

closes: #1251