### PR TITLE
fix(panel): fix user profile link

### DIFF
--- a/warpgate-web/src/common/AuthBar.svelte
+++ b/warpgate-web/src/common/AuthBar.svelte
@@ -20,7 +20,7 @@ async function singleLogout () {
 
 {#if $serverInfo?.username}
     <div class="ms-auto">
-        <a href="/#/profile">
+        <a href="/@warpgate/#/profile">
             {$serverInfo.username}
         </a>
         {#if $serverInfo.authorizedViaTicket}


### PR DESCRIPTION
some strange behaviour can be triggered if you access an HTTP target, go back to homepage and click on the user profile link. By adding `/@wargate` to the URL, the request is always sent to warpgate HTTP panel