### PR TITLE
feat(http): support for insecured websocket connections if `TLS Verify`flag is disabled

### DIFF
--- a/warpgate-protocol-http/src/proxy.rs
+++ b/warpgate-protocol-http/src/proxy.rs
@@ -14,7 +14,7 @@ use once_cell::sync::Lazy;
 use poem::session::Session;
 use poem::web::websocket::{Message, WebSocket};
 use poem::{Body, FromRequest, IntoResponse, Request, Response};
-use tokio_tungstenite::{connect_async_with_config, connect_async_tls_with_config, tungstenite, Connector};
+use tokio_tungstenite::{connect_async_tls_with_config, tungstenite, Connector};
 use tracing::*;
 use url::Url;
 use warpgate_common::{configure_tls_connector, try_block, TargetHTTPOptions, TlsMode, WarpgateError};

--- a/warpgate-protocol-http/src/proxy.rs
+++ b/warpgate-protocol-http/src/proxy.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use cookie::Cookie;
@@ -13,10 +14,10 @@ use once_cell::sync::Lazy;
 use poem::session::Session;
 use poem::web::websocket::{Message, WebSocket};
 use poem::{Body, FromRequest, IntoResponse, Request, Response};
-use tokio_tungstenite::{connect_async_with_config, tungstenite};
+use tokio_tungstenite::{connect_async_with_config, connect_async_tls_with_config, tungstenite, Connector};
 use tracing::*;
 use url::Url;
-use warpgate_common::{try_block, TargetHTTPOptions, TlsMode, WarpgateError};
+use warpgate_common::{configure_tls_connector, try_block, TargetHTTPOptions, TlsMode, WarpgateError};
 use warpgate_web::lookup_built_file;
 
 use crate::common::{SessionAuthorization, SessionExt};
@@ -433,15 +434,30 @@ async fn proxy_ws_inner(
     client_request = inject_own_headers(req, client_request).await?;
     client_request = rewrite_request(client_request, options)?;
 
-    let (client, client_response) = connect_async_with_config(
-        client_request
-            .body(())
-            .map_err(poem::error::InternalServerError)?,
-        None,
-        true,
-    )
-    .await
-    .map_err(poem::error::BadGateway)?;
+    let result = if !options.tls.verify {
+        let tls_config = configure_tls_connector(true, true, None)
+            .await
+            .map_err(poem::error::InternalServerError)?;
+        let connector = Connector::Rustls(Arc::new(tls_config));
+
+        connect_async_tls_with_config(
+            client_request
+                .body(())
+                .map_err(poem::error::InternalServerError)?,
+            None,
+            true,
+            Some(connector),
+        ).await
+    } else {
+        connect_async_with_config(
+            client_request
+                .body(())
+                .map_err(poem::error::InternalServerError)?,
+            None,
+            true,
+        ).await
+    };
+    let (client, client_response) = result.map_err(poem::error::BadGateway)?;
 
     tracing::info!("{:?} {:?} - WebSocket", client_response.status(), uri);
 

--- a/warpgate-protocol-http/src/proxy.rs
+++ b/warpgate-protocol-http/src/proxy.rs
@@ -446,7 +446,8 @@ async fn proxy_ws_inner(
         None,
         true,
         Some(connector),
-    ).await
+    )
+    .await
     .map_err(poem::error::BadGateway)?;
 
     tracing::info!("{:?} {:?} - WebSocket", client_response.status(), uri);


### PR DESCRIPTION
Related with issue #923. From the web panel, it is possible to configure a certain target to ignore invalid certificates for HTTP requests. However, this flag was not being applied to websocket connections because they are treated in a different manner.

This fix handles the creation of the TLS connector with the proper configuration in case the flag is enabled.

I'm a noobie with Rust, some maybe some adjustments can be made.

Feel free to give the required feedback.