### PR TITLE
fix(logs): normalize logs timestamp format with fixed sub-second digits

### DIFF
--- a/warpgate-core/src/logging/socket.rs
+++ b/warpgate-core/src/logging/socket.rs
@@ -1,5 +1,6 @@
 use bytes::BytesMut;
 use chrono::Local;
+use chrono::format::{SecondsFormat};
 use tokio::net::UnixDatagram;
 use tracing::*;
 use tracing_subscriber::registry::LookupSpan;


### PR DESCRIPTION
During the configuration of the log forwarding service in Warpgate and the subsequent processing of messages, I noticed that the timestamp format received is inconsistent. In some cases, the data is sent in milliseconds, and in others, in nanoseconds. 

According to the `chrono` library documentation,  `to_rfc3339` method uses the `AutoSi` format by default, which means it automatically selects one of Secs, Millis, Micros, or Nanos to display all available non-zero sub-second digits. More info [here](https://docs.rs/chrono/latest/chrono/format/enum.SecondsFormat.html).

This can lead to processing issues in systems that expect a fixed layout (e.g., Telegraf). To resolve this, the function call should be changed to `to_rfc3339_opts`, passing a fixed format of nanoseconds.