### PR TITLE
Option to add query results to logging for postgres connections

### DIFF
--- a/warpgate-common/src/config/target.rs
+++ b/warpgate-common/src/config/target.rs
@@ -123,6 +123,10 @@ pub struct TargetPostgresOptions {
 
     #[serde(default)]
     pub tls: Tls,
+
+    /// If true, log query results for audit purposes
+    #[serde(default)]
+    pub log_query_results: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Object, Default)]

--- a/warpgate-web/src/admin/config/targets/Target.svelte
+++ b/warpgate-web/src/admin/config/targets/Target.svelte
@@ -204,6 +204,15 @@
             <TlsConfiguration bind:value={target.options.tls} />
         {/if}
 
+        {#if target.options.kind === 'Postgres'}
+            <FormGroup check class="mb-3">
+                <Input type="checkbox" bind:checked={target.options.log_query_results} />
+                <label class="form-check-label ms-2">
+                    Log query results (for auditing)
+                </label>
+            </FormGroup>
+        {/if}
+
         <h4 class="mt-4">Allow access for roles</h4>
         <Loadable promise={loadRoles()}>
             {#snippet children(roles)}


### PR DESCRIPTION
This is a vibe coded solution to #1392

Buyer beware. I'm not exceptionally confident in these changes, but if someone else is, this is a feature I would love to have added to warpgate to improve our ability to audit queries.

# Feature:
This adds a toggle in the UI for enable/disable the ability to log query results, not just the queries themselves as it works today. 