### PR TITLE
Docker image : add healthcheck, linting and run as regular user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,7 @@ RUN just npm ci \
 
 FROM debian:bullseye-20250520
 LABEL maintainer=heywoodlh
+ARG USER_ID=1000
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -39,6 +40,9 @@ RUN <<EOF
   rm -rf /var/lib/apt/lists/*
 EOF
 
+# RUN adduser warpgate --system --home /data
+RUN adduser warpgate --disabled-password --gecos "" --uid ${USER_ID} --home /data --shell /usr/sbin/nologin
+
 COPY --from=build /opt/warpgate/target/release/warpgate /usr/local/bin/warpgate
 
 VOLUME /data
@@ -47,5 +51,7 @@ HEALTHCHECK CMD wget --no-verbose --tries=1 --no-check-certificate --spider http
 
 ENV DOCKER=1
 
+USER warpgate
 ENTRYPOINT ["warpgate", "--config", "/data/warpgate.yaml"]
 CMD ["run"]
+


### PR DESCRIPTION
Hi, 

After reading on that issue :  [#1302](https://github.com/warp-tech/warpgate/issues/1302)

I've made the docker image non root,  I tested creating a user and making ssh connection and it worked.

I also added a healthcheck, but we need a proper healthcheck endpoint for that, see [#1432](https://github.com/warp-tech/warpgate/issues/1432)

And there is some linting / best practices, the only thing i disabled is the hadolint check that wants you to pin version. 
See here : [https://github.com/hadolint/hadolint/wiki/DL3008](hadolint-3008)

