### PR TITLE
`version` attribute is obsolete

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   warpgate:
     image: ghcr.io/warp-tech/warpgate


### PR DESCRIPTION
Remove attribute to avoid the following warning:

```
WARN[0000] /srv/warpgate/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```