### PR TITLE
fix(ssh): add diffie-hellman-group-exchange-sha256 in ssh key exchang…

### DIFF
--- a/warpgate-protocol-ssh/src/client/mod.rs
+++ b/warpgate-protocol-ssh/src/client/mod.rs
@@ -444,7 +444,7 @@ impl RemoteClient {
                     kex::ECDH_SHA2_NISTP521,
                     kex::DH_G16_SHA512,
                     kex::DH_G14_SHA256, // non-default
-                    kex::DH_G14_SHA256,
+                    kex::DH_GEX_SHA256,
                     kex::DH_G1_SHA1, // non-default
                     kex::EXTENSION_SUPPORT_AS_CLIENT,
                     kex::EXTENSION_SUPPORT_AS_SERVER,


### PR DESCRIPTION
### Summary

This PR adds support for the `diffie-hellman-group-exchange-sha256` key exchange algorithm in the SSH client.

### Background

While attempting to connect to a Mikrotik router with `strong-crypto` option enabled, I encountered a key exchange failure. The server only offers `diffie-hellman-group-exchange-sha256`, which is not currently supported by our client. As a result, the SSH handshake failed with the following error:

```
warpgate_protocol_ssh::client: Connection error error=Ssh(NoCommonAlgo { 
    kind: Kex, 
    ours: [
        "curve25519-sha256", 
        "curve25519-sha256@libssh.org", 
        "ecdh-sha2-nistp256", 
        "ecdh-sha2-nistp384", 
        "ecdh-sha2-nistp521", 
        "diffie-hellman-group16-sha512", 
        "diffie-hellman-group14-sha256", 
        "diffie-hellman-group14-sha256", 
        "diffie-hellman-group1-sha1", 
        "ext-info-c", 
        "ext-info-s", 
        "kex-strict-c-v00@openssh.com", 
        "kex-strict-s-v00@openssh.com"
    ], 
    theirs: ["diffie-hellman-group-exchange-sha256"] 
})
```

### Proposed Fix

The `diffie-hellman-group-exchange-sha256` algorithm is now added to the list of supported key exchange methods. It appears that the original intent may have been to include this algorithm, but due to a copy-paste oversight, `diffie-hellman-group14-sha256` was added twice instead.

https://github.com/warp-tech/warpgate/blob/f1520c79b05eb078b7ef35e746aef853be7ad009/warpgate-protocol-ssh/src/client/mod.rs#L446-L447