### PR TITLE
Correct dependency install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can also use the admin web interface to view the live session list, review s
 * You'll need Rust, NodeJS and NPM
 * Clone the repo
 * [Just](https://github.com/casey/just) is used to run tasks - install it: `cargo install just`
-* Install the admin UI deps: `just npm`
+* Install the admin UI deps: `just npm install`
 * Build the frontend: `just npm run build`
 * Build Warpgate: `cargo build` (optionally `--release`)
 


### PR DESCRIPTION
The dependency install command in the contribution guide isn't correct. It should be `just npm install` rather than `just npm`.