### PR TITLE
Add target groups for improved interface

### DIFF
--- a/warpgate-admin/src/api/mod.rs
+++ b/warpgate-admin/src/api/mod.rs
@@ -16,6 +16,7 @@ mod ssh_connection_test;
 mod ssh_keys;
 mod sso_credentials;
 mod targets;
+mod target_groups;
 mod tickets_detail;
 mod tickets_list;
 pub mod users;
@@ -32,6 +33,7 @@ pub fn get() -> impl OpenApi {
         ssh_keys::Api,
         logs::Api,
         (targets::ListApi, targets::DetailApi, targets::RolesApi),
+        (target_groups::ListApi, target_groups::DetailApi),
         (users::ListApi, users::DetailApi, users::RolesApi),
         (
             password_credentials::ListApi,

--- a/warpgate-admin/src/api/target_groups.rs
+++ b/warpgate-admin/src/api/target_groups.rs
@@ -1,0 +1,208 @@
+use std::sync::Arc;
+
+use poem::web::Data;
+use poem_openapi::param::Path;
+use poem_openapi::payload::Json;
+use poem_openapi::{ApiResponse, Object, OpenApi};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, ModelTrait, QueryFilter,
+    QueryOrder, Set,
+};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+use warpgate_common::WarpgateError;
+use warpgate_db_entities::TargetGroup;
+
+use super::AnySecurityScheme;
+
+#[derive(Object)]
+struct TargetGroupDataRequest {
+    name: String,
+    description: Option<String>,
+    color: Option<String>,
+}
+
+#[derive(ApiResponse)]
+enum GetTargetGroupsResponse {
+    #[oai(status = 200)]
+    Ok(Json<Vec<TargetGroup::Model>>),
+}
+
+#[derive(ApiResponse)]
+enum CreateTargetGroupResponse {
+    #[oai(status = 201)]
+    Created(Json<TargetGroup::Model>),
+
+    #[oai(status = 409)]
+    Conflict(Json<String>),
+
+    #[oai(status = 400)]
+    BadRequest(Json<String>),
+}
+
+pub struct ListApi;
+
+#[OpenApi]
+impl ListApi {
+    #[oai(path = "/target-groups", method = "get", operation_id = "list_target_groups")]
+    async fn api_list_target_groups(
+        &self,
+        db: Data<&Arc<Mutex<DatabaseConnection>>>,
+        _sec_scheme: AnySecurityScheme,
+    ) -> Result<GetTargetGroupsResponse, WarpgateError> {
+        let db = db.lock().await;
+        let groups = TargetGroup::Entity::find()
+            .order_by_asc(TargetGroup::Column::Name)
+            .all(&*db)
+            .await?;
+
+        Ok(GetTargetGroupsResponse::Ok(Json(groups)))
+    }
+
+    #[oai(path = "/target-groups", method = "post", operation_id = "create_target_group")]
+    async fn api_create_target_group(
+        &self,
+        db: Data<&Arc<Mutex<DatabaseConnection>>>,
+        body: Json<TargetGroupDataRequest>,
+        _sec_scheme: AnySecurityScheme,
+    ) -> Result<CreateTargetGroupResponse, WarpgateError> {
+        if body.name.is_empty() {
+            return Ok(CreateTargetGroupResponse::BadRequest(Json("name".into())));
+        }
+
+        let db = db.lock().await;
+        let existing = TargetGroup::Entity::find()
+            .filter(TargetGroup::Column::Name.eq(body.name.clone()))
+            .one(&*db)
+            .await?;
+        if existing.is_some() {
+            return Ok(CreateTargetGroupResponse::Conflict(Json(
+                "Name already exists".into(),
+            )));
+        }
+
+        let values = TargetGroup::ActiveModel {
+            id: Set(Uuid::new_v4()),
+            name: Set(body.name.clone()),
+            description: Set(body.description.clone().unwrap_or_default()),
+            color: Set(body.color.clone()),
+        };
+
+        let group = values.insert(&*db).await.map_err(WarpgateError::from)?;
+
+        Ok(CreateTargetGroupResponse::Created(Json(group)))
+    }
+}
+
+#[derive(ApiResponse)]
+enum GetTargetGroupResponse {
+    #[oai(status = 200)]
+    Ok(Json<TargetGroup::Model>),
+    #[oai(status = 404)]
+    NotFound,
+}
+
+#[derive(ApiResponse)]
+enum UpdateTargetGroupResponse {
+    #[oai(status = 200)]
+    Ok(Json<TargetGroup::Model>),
+    #[oai(status = 400)]
+    BadRequest,
+    #[oai(status = 404)]
+    NotFound,
+}
+
+#[derive(ApiResponse)]
+enum DeleteTargetGroupResponse {
+    #[oai(status = 204)]
+    Deleted,
+
+
+    #[oai(status = 404)]
+    NotFound,
+}
+
+pub struct DetailApi;
+
+#[OpenApi]
+impl DetailApi {
+    #[oai(path = "/target-groups/:id", method = "get", operation_id = "get_target_group")]
+    async fn api_get_target_group(
+        &self,
+        db: Data<&Arc<Mutex<DatabaseConnection>>>,
+        id: Path<Uuid>,
+        _sec_scheme: AnySecurityScheme,
+    ) -> Result<GetTargetGroupResponse, WarpgateError> {
+        let db = db.lock().await;
+        let group = TargetGroup::Entity::find_by_id(id.0)
+            .one(&*db)
+            .await?;
+
+        match group {
+            Some(group) => Ok(GetTargetGroupResponse::Ok(Json(group))),
+            None => Ok(GetTargetGroupResponse::NotFound),
+        }
+    }
+
+    #[oai(path = "/target-groups/:id", method = "put", operation_id = "update_target_group")]
+    async fn api_update_target_group(
+        &self,
+        db: Data<&Arc<Mutex<DatabaseConnection>>>,
+        id: Path<Uuid>,
+        body: Json<TargetGroupDataRequest>,
+        _sec_scheme: AnySecurityScheme,
+    ) -> Result<UpdateTargetGroupResponse, WarpgateError> {
+        if body.name.is_empty() {
+            return Ok(UpdateTargetGroupResponse::BadRequest);
+        }
+
+        let db = db.lock().await;
+        let group = TargetGroup::Entity::find_by_id(id.0)
+            .one(&*db)
+            .await?;
+
+        match group {
+            Some(group) => {
+                // Check if name is already taken by another group
+                let existing = TargetGroup::Entity::find()
+                    .filter(TargetGroup::Column::Name.eq(body.name.clone()))
+                    .filter(TargetGroup::Column::Id.ne(id.0))
+                    .one(&*db)
+                    .await?;
+                if existing.is_some() {
+                    return Ok(UpdateTargetGroupResponse::BadRequest);
+                }
+
+                let mut group: TargetGroup::ActiveModel = group.into();
+                group.name = Set(body.name.clone());
+                group.description = Set(body.description.clone().unwrap_or_default());
+                group.color = Set(body.color.clone());
+
+                let group = group.update(&*db).await.map_err(WarpgateError::from)?;
+                Ok(UpdateTargetGroupResponse::Ok(Json(group)))
+            }
+            None => Ok(UpdateTargetGroupResponse::NotFound),
+        }
+    }
+
+    #[oai(path = "/target-groups/:id", method = "delete", operation_id = "delete_target_group")]
+    async fn api_delete_target_group(
+        &self,
+        db: Data<&Arc<Mutex<DatabaseConnection>>>,
+        id: Path<Uuid>,
+        _sec_scheme: AnySecurityScheme,
+    ) -> Result<DeleteTargetGroupResponse, WarpgateError> {
+        let db = db.lock().await;
+        let group = TargetGroup::Entity::find_by_id(id.0)
+            .one(&*db)
+            .await?;
+
+        match group {
+            Some(group) => {
+                group.delete(&*db).await.map_err(WarpgateError::from)?;
+                Ok(DeleteTargetGroupResponse::Deleted)
+            }
+            None => Ok(DeleteTargetGroupResponse::NotFound),
+        }
+    }
+}

--- a/warpgate-common/src/config/target.rs
+++ b/warpgate-common/src/config/target.rs
@@ -139,6 +139,7 @@ pub struct Target {
     #[serde(flatten)]
     pub options: TargetOptions,
     pub rate_limit_bytes_per_second: Option<u32>,
+    pub group_id: Option<Uuid>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Union)]

--- a/warpgate-core/src/db/mod.rs
+++ b/warpgate-core/src/db/mod.rs
@@ -119,6 +119,7 @@ pub async fn populate_db(
                 ))
                 .map_err(WarpgateError::from)?),
                 rate_limit_bytes_per_second: Set(None),
+                group_id: Set(None),
             };
 
             values.insert(&*db).await.map_err(WarpgateError::from)?

--- a/warpgate-db-entities/src/Target.rs
+++ b/warpgate-db-entities/src/Target.rs
@@ -52,6 +52,7 @@ pub struct Model {
     pub kind: TargetKind,
     pub options: serde_json::Value,
     pub rate_limit_bytes_per_second: Option<i64>,
+    pub group_id: Option<Uuid>,
 }
 
 impl Related<super::Role::Entity> for Entity {
@@ -65,7 +66,17 @@ impl Related<super::Role::Entity> for Entity {
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
-pub enum Relation {}
+pub enum Relation {
+    #[sea_orm(belongs_to = "super::TargetGroup::Entity", from = "Column::GroupId", to = "super::TargetGroup::Column::Id")]
+    TargetGroup,
+}
+
+
+impl Related<super::TargetGroup::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::TargetGroup.def()
+    }
+}
 
 impl ActiveModelBehavior for ActiveModel {}
 
@@ -81,6 +92,7 @@ impl TryFrom<Model> for Target {
             allow_roles: vec![],
             options,
             rate_limit_bytes_per_second: model.rate_limit_bytes_per_second.map(|v| v as u32),
+            group_id: model.group_id,
         })
     }
 }

--- a/warpgate-db-entities/src/TargetGroup.rs
+++ b/warpgate-db-entities/src/TargetGroup.rs
@@ -1,0 +1,25 @@
+use poem_openapi::Object;
+use sea_orm::entity::prelude::*;
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Object)]
+#[sea_orm(table_name = "target_groups")]
+#[oai(rename = "TargetGroup")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub name: String,
+    #[sea_orm(column_type = "Text")]
+    pub description: String,
+    pub color: Option<String>, // Hex color code for UI display
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(has_many = "super::Target::Entity")]
+    Target,
+}
+
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/warpgate-db-entities/src/lib.rs
+++ b/warpgate-db-entities/src/lib.rs
@@ -12,6 +12,7 @@ pub mod Role;
 pub mod Session;
 pub mod SsoCredential;
 pub mod Target;
+pub mod TargetGroup;
 pub mod TargetRoleAssignment;
 pub mod Ticket;
 pub mod User;

--- a/warpgate-db-migrations/src/lib.rs
+++ b/warpgate-db-migrations/src/lib.rs
@@ -21,6 +21,7 @@ mod m00016_fix_public_key_length;
 mod m00017_descriptions;
 mod m00018_ticket_description;
 mod m00019_rate_limits;
+mod m00020_target_groups;
 
 pub struct Migrator;
 
@@ -47,6 +48,7 @@ impl MigratorTrait for Migrator {
             Box::new(m00017_descriptions::Migration),
             Box::new(m00018_ticket_description::Migration),
             Box::new(m00019_rate_limits::Migration),
+            Box::new(m00020_target_groups::Migration),
         ]
     }
 }

--- a/warpgate-db-migrations/src/m00020_target_groups.rs
+++ b/warpgate-db-migrations/src/m00020_target_groups.rs
@@ -1,0 +1,102 @@
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m00020_target_groups"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Create target_groups table
+        manager
+            .create_table(
+                Table::create()
+                    .table(TargetGroups::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(TargetGroups::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(TargetGroups::Name)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TargetGroups::Description)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TargetGroups::Color)
+                            .string()
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Add group_id column to targets table
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Targets::Table)
+                    .add_column(
+                        ColumnDef::new(Targets::GroupId)
+                            .uuid()
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Note: SQLite doesn't support adding foreign key constraints to existing tables
+        // The foreign key relationship will be enforced at the application level
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Remove group_id column from targets table
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Targets::Table)
+                    .drop_column(Targets::GroupId)
+                    .to_owned(),
+            )
+            .await?;
+
+        // Drop target_groups table
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(TargetGroups::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum TargetGroups {
+    Table,
+    Id,
+    Name,
+    Description,
+    Color,
+}
+
+#[derive(DeriveIden)]
+enum Targets {
+    Table,
+    GroupId,
+}

--- a/warpgate-web/src/admin/config/Config.svelte
+++ b/warpgate-web/src/admin/config/Config.svelte
@@ -43,6 +43,15 @@
         '/tickets/create': wrap({
             asyncComponent: () => import('./CreateTicket.svelte') as any,
         }),
+        '/target-groups/create': wrap({
+            asyncComponent: () => import('./target-groups/CreateTargetGroup.svelte') as any,
+        }),
+        '/target-groups/:id': wrap({
+            asyncComponent: () => import('./target-groups/TargetGroup.svelte') as any,
+        }),
+        '/target-groups': wrap({
+            asyncComponent: () => import('./target-groups/TargetGroups.svelte') as any,
+        }),
     }
 
     let sidebarMode = $state(false)
@@ -54,6 +63,14 @@
         title="Targets"
         description="Destinations for users to connect to"
         href="/config/targets"
+        small={sidebarMode}
+    />
+
+    <NavListItem
+        class="mb-2"
+        title="Target Groups"
+        description="Organize targets into groups"
+        href="/config/target-groups"
         small={sidebarMode}
     />
 

--- a/warpgate-web/src/admin/config/CreateTarget.svelte
+++ b/warpgate-web/src/admin/config/CreateTarget.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
-    import { api, type TargetOptions, TlsMode } from 'admin/lib/api'
+    import { api, type TargetOptions, type TargetGroup, TlsMode } from 'admin/lib/api'
     import { replace } from 'svelte-spa-router'
     import { Button, ButtonGroup, Form, FormGroup } from '@sveltestrap/sveltestrap'
     import { stringifyError } from 'common/errors'
     import Alert from 'common/sveltestrap-s5-ports/Alert.svelte'
     import { TargetKind } from 'gateway/lib/api'
     import RadioButton from 'common/RadioButton.svelte'
+    import { onMount } from 'svelte'
 
     let error: string|null = $state(null)
     let name = $state('')
     let type: TargetKind = $state(TargetKind.Ssh)
+    let groups: TargetGroup[] = $state([])
+    let selectedGroupId: string | undefined = $state()
 
     async function create () {
         try {
@@ -62,6 +65,7 @@
                 targetDataRequest: {
                     name,
                     options,
+                    groupId: selectedGroupId,
                 },
             })
             replace(`/config/targets/${target.id}`)
@@ -69,6 +73,14 @@
             error = await stringifyError(err)
         }
     }
+
+    onMount(async () => {
+        try {
+            groups = await api.listTargetGroups()
+        } catch (e) {
+            console.error('Failed to load target groups:', e)
+        }
+    })
 
     const kinds: { name: string, value: TargetKind }[] = [
         { name: 'SSH', value: TargetKind.Ssh },
@@ -109,6 +121,15 @@
 
             <FormGroup floating label="Name">
                 <input class="form-control" required bind:value={name} />
+            </FormGroup>
+
+            <FormGroup floating label="Group">
+                <select class="form-control" bind:value={selectedGroupId}>
+                    <option value={undefined}>No group</option>
+                    {#each groups as group}
+                        <option value={group.id}>{group.name}</option>
+                    {/each}
+                </select>
             </FormGroup>
 
             <Button

--- a/warpgate-web/src/admin/config/target-groups/CreateTargetGroup.svelte
+++ b/warpgate-web/src/admin/config/target-groups/CreateTargetGroup.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+    import { api, type TargetGroupDataRequest } from 'admin/lib/api'
+    import { link } from 'svelte-spa-router'
+    import { Button, FormGroup, Input, Label, Alert } from '@sveltestrap/sveltestrap'
+
+    let name = $state('')
+    let description = $state('')
+    let color = $state('')
+    let saving = $state(false)
+    let error: string | undefined = $state()
+
+    async function save () {
+        if (!name.trim()) {
+            error = 'Name is required'
+            return
+        }
+
+        saving = true
+        error = undefined
+
+        try {
+            await api.createTargetGroup({
+                targetGroupDataRequest: {
+                    name: name.trim(),
+                    description: description.trim() || undefined,
+                    color: color.trim() || undefined,
+                }
+            })
+            // Redirect to groups list
+            location.href = '/config/target-groups'
+        } catch (e) {
+            error = 'Failed to create target group'
+            console.error(e)
+        } finally {
+            saving = false
+        }
+    }
+</script>
+
+<div class="container-max-md">
+    <div class="page-summary-bar">
+        <h1>Create target group</h1>
+    </div>
+
+    {#if error}
+        <Alert color="danger">{error}</Alert>
+    {/if}
+
+    <form on:submit|preventDefault={save}>
+        <FormGroup>
+            <Label for="name">Name</Label>
+            <Input
+                id="name"
+                bind:value={name}
+                required
+                disabled={saving}
+            />
+        </FormGroup>
+
+        <FormGroup>
+            <Label for="description">Description</Label>
+            <Input
+                id="description"
+                type="textarea"
+                bind:value={description}
+                disabled={saving}
+            />
+        </FormGroup>
+
+        <FormGroup>
+            <Label for="color">Color</Label>
+            <Input
+                id="color"
+                type="color"
+                bind:value={color}
+                disabled={saving}
+            />
+            <small class="form-text text-muted">
+                Optional color for visual organization
+            </small>
+        </FormGroup>
+
+        <div class="d-flex gap-2">
+            <Button type="submit" color="primary" disabled={saving}>
+                {saving ? 'Creating...' : 'Create'}
+            </Button>
+            <a class="btn btn-secondary" href="/config/target-groups" use:link>
+                Cancel
+            </a>
+        </div>
+    </form>
+</div>

--- a/warpgate-web/src/admin/config/target-groups/TargetGroup.svelte
+++ b/warpgate-web/src/admin/config/target-groups/TargetGroup.svelte
@@ -3,7 +3,6 @@
     import { link } from 'svelte-spa-router'
     import { onMount } from 'svelte'
     import { Button, FormGroup, Input, Label, Alert } from '@sveltestrap/sveltestrap'
-    import Loadable from 'common/Loadable.svelte'
 
     interface Props {
         params: { id: string };
@@ -51,8 +50,8 @@
                     color: color || undefined,
                 }
             })
-            // Reload the group data
-            group = await api.getTargetGroup({ id: groupId })
+            // Redirect to groups list after successful save
+            location.href = '/@warpgate/admin#/config/target-groups'
         } catch (e) {
             saveError = 'Failed to save target group'
             console.error(e)
@@ -69,7 +68,7 @@
         try {
             await api.deleteTargetGroup({ id: groupId })
             // Redirect to groups list
-            location.href = '/config/target-groups'
+            location.href = '/@warpgate/admin#/config/target-groups'
         } catch (e) {
             saveError = 'Failed to delete target group'
             console.error(e)
@@ -77,65 +76,69 @@
     }
 </script>
 
-<Loadable promise={loading ? Promise.resolve() : Promise.resolve()} bind:data={group}>
-    {#if error}
-        <Alert color="danger">{error}</Alert>
-    {:else if group}
-        <div class="container-max-md">
-            <div class="page-summary-bar">
-                <h1>Edit target group</h1>
-                <div class="ms-auto">
-                    <Button color="danger" onclick={deleteGroup}>Delete</Button>
-                </div>
-            </div>
-
-            {#if saveError}
-                <Alert color="danger">{saveError}</Alert>
-            {/if}
-
-            <form on:submit|preventDefault={save}>
-                <FormGroup>
-                    <Label for="name">Name</Label>
-                    <Input
-                        id="name"
-                        bind:value={name}
-                        required
-                        disabled={saving}
-                    />
-                </FormGroup>
-
-                <FormGroup>
-                    <Label for="description">Description</Label>
-                    <Input
-                        id="description"
-                        type="textarea"
-                        bind:value={description}
-                        disabled={saving}
-                    />
-                </FormGroup>
-
-                <FormGroup>
-                    <Label for="color">Color</Label>
-                    <Input
-                        id="color"
-                        type="color"
-                        bind:value={color}
-                        disabled={saving}
-                    />
-                    <small class="form-text text-muted">
-                        Optional color for visual organization
-                    </small>
-                </FormGroup>
-
-                <div class="d-flex gap-2">
-                    <Button type="submit" color="primary" disabled={saving}>
-                        {saving ? 'Saving...' : 'Save'}
-                    </Button>
-                    <a class="btn btn-secondary" href="/config/target-groups" use:link>
-                        Cancel
-                    </a>
-                </div>
-            </form>
+{#if loading}
+    <div class="d-flex justify-content-center p-4">
+        <div class="spinner-border" role="status">
+            <span class="visually-hidden">Loading...</span>
         </div>
-    {/if}
-</Loadable>
+    </div>
+{:else if error}
+    <Alert color="danger">{error}</Alert>
+{:else if group}
+    <div class="container-max-md">
+        <div class="page-summary-bar">
+            <h1>Edit target group</h1>
+            <div class="ms-auto">
+                <Button color="danger" onclick={deleteGroup}>Delete</Button>
+            </div>
+        </div>
+
+        {#if saveError}
+            <Alert color="danger">{saveError}</Alert>
+        {/if}
+
+        <form on:submit|preventDefault={save}>
+            <FormGroup>
+                <Label for="name">Name</Label>
+                <Input
+                    id="name"
+                    bind:value={name}
+                    required
+                    disabled={saving}
+                />
+            </FormGroup>
+
+            <FormGroup>
+                <Label for="description">Description</Label>
+                <Input
+                    id="description"
+                    type="textarea"
+                    bind:value={description}
+                    disabled={saving}
+                />
+            </FormGroup>
+
+            <FormGroup>
+                <Label for="color">Color</Label>
+                <Input
+                    id="color"
+                    type="color"
+                    bind:value={color}
+                    disabled={saving}
+                />
+                <small class="form-text text-muted">
+                    Optional color for visual organization
+                </small>
+            </FormGroup>
+
+            <div class="d-flex gap-2">
+                <Button type="submit" color="primary" disabled={saving}>
+                    {saving ? 'Saving...' : 'Save'}
+                </Button>
+                <a class="btn btn-secondary" href="/config/target-groups" use:link>
+                    Cancel
+                </a>
+            </div>
+        </form>
+    </div>
+{/if}

--- a/warpgate-web/src/admin/config/target-groups/TargetGroup.svelte
+++ b/warpgate-web/src/admin/config/target-groups/TargetGroup.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+    import { api, type TargetGroup, type TargetGroupDataRequest } from 'admin/lib/api'
+    import { link } from 'svelte-spa-router'
+    import { onMount } from 'svelte'
+    import { Button, FormGroup, Input, Label, Alert } from '@sveltestrap/sveltestrap'
+    import Loadable from 'common/Loadable.svelte'
+
+    interface Props {
+        params: { id: string };
+    }
+
+    let { params }: Props = $props()
+    let groupId = params.id
+
+    let group: TargetGroup | undefined = $state()
+    let loading = $state(true)
+    let error: string | undefined = $state()
+    let saving = $state(false)
+    let saveError: string | undefined = $state()
+
+    let name = $state('')
+    let description = $state('')
+    let color = $state('')
+
+    onMount(async () => {
+        try {
+            group = await api.getTargetGroup({ id: groupId })
+            name = group.name
+            description = group.description
+            color = group.color || ''
+        } catch (e) {
+            error = 'Failed to load target group'
+            console.error(e)
+        } finally {
+            loading = false
+        }
+    })
+
+    async function save () {
+        if (!group) return
+
+        saving = true
+        saveError = undefined
+
+        try {
+            await api.updateTargetGroup({
+                id: groupId,
+                targetGroupDataRequest: {
+                    name,
+                    description: description || undefined,
+                    color: color || undefined,
+                }
+            })
+            // Reload the group data
+            group = await api.getTargetGroup({ id: groupId })
+        } catch (e) {
+            saveError = 'Failed to save target group'
+            console.error(e)
+        } finally {
+            saving = false
+        }
+    }
+
+    async function deleteGroup () {
+        if (!group || !confirm(`Are you sure you want to delete the group "${group.name}"?`)) {
+            return
+        }
+
+        try {
+            await api.deleteTargetGroup({ id: groupId })
+            // Redirect to groups list
+            location.href = '/config/target-groups'
+        } catch (e) {
+            saveError = 'Failed to delete target group'
+            console.error(e)
+        }
+    }
+</script>
+
+<Loadable promise={loading ? Promise.resolve() : Promise.resolve()} bind:data={group}>
+    {#if error}
+        <Alert color="danger">{error}</Alert>
+    {:else if group}
+        <div class="container-max-md">
+            <div class="page-summary-bar">
+                <h1>Edit target group</h1>
+                <div class="ms-auto">
+                    <Button color="danger" onclick={deleteGroup}>Delete</Button>
+                </div>
+            </div>
+
+            {#if saveError}
+                <Alert color="danger">{saveError}</Alert>
+            {/if}
+
+            <form on:submit|preventDefault={save}>
+                <FormGroup>
+                    <Label for="name">Name</Label>
+                    <Input
+                        id="name"
+                        bind:value={name}
+                        required
+                        disabled={saving}
+                    />
+                </FormGroup>
+
+                <FormGroup>
+                    <Label for="description">Description</Label>
+                    <Input
+                        id="description"
+                        type="textarea"
+                        bind:value={description}
+                        disabled={saving}
+                    />
+                </FormGroup>
+
+                <FormGroup>
+                    <Label for="color">Color</Label>
+                    <Input
+                        id="color"
+                        type="color"
+                        bind:value={color}
+                        disabled={saving}
+                    />
+                    <small class="form-text text-muted">
+                        Optional color for visual organization
+                    </small>
+                </FormGroup>
+
+                <div class="d-flex gap-2">
+                    <Button type="submit" color="primary" disabled={saving}>
+                        {saving ? 'Saving...' : 'Save'}
+                    </Button>
+                    <a class="btn btn-secondary" href="/config/target-groups" use:link>
+                        Cancel
+                    </a>
+                </div>
+            </form>
+        </div>
+    {/if}
+</Loadable>

--- a/warpgate-web/src/admin/config/target-groups/TargetGroups.svelte
+++ b/warpgate-web/src/admin/config/target-groups/TargetGroups.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+    import { Observable, from, map } from 'rxjs'
+    import { type TargetGroup, api } from 'admin/lib/api'
+    import ItemList, { type LoadOptions, type PaginatedResponse } from 'common/ItemList.svelte'
+    import { link } from 'svelte-spa-router'
+    import EmptyState from 'common/EmptyState.svelte'
+
+    function getTargetGroups (options: LoadOptions): Observable<PaginatedResponse<TargetGroup>> {
+        return from(api.listTargetGroups()).pipe(map(groups => ({
+            items: groups,
+            offset: 0,
+            total: groups.length,
+        })))
+    }
+</script>
+
+<div class="container-max-md">
+    <div class="page-summary-bar">
+        <h1>target groups</h1>
+        <a
+            class="btn btn-primary ms-auto"
+            href="/config/target-groups/create"
+            use:link>
+            Add a group
+        </a>
+    </div>
+
+    <ItemList load={getTargetGroups} showSearch={true}>
+        {#snippet empty()}
+            <EmptyState
+                title="No target groups yet"
+                hint="Target groups help organize your targets for easier management"
+            />
+        {/snippet}
+        {#snippet item(group)}
+            <a
+                class="list-group-item list-group-item-action"
+                href="/config/target-groups/{group.id}"
+                use:link>
+                <div class="me-auto">
+                    <div class="d-flex align-items-center">
+                        {#if group.color}
+                            <div
+                                class="me-2 rounded"
+                                style="width: 12px; height: 12px; background-color: {group.color};"
+                            ></div>
+                        {/if}
+                        <strong>{group.name}</strong>
+                    </div>
+                    {#if group.description}
+                        <small class="d-block text-muted">{group.description}</small>
+                    {/if}
+                </div>
+            </a>
+        {/snippet}
+    </ItemList>
+</div>
+
+<style lang="scss">
+    .list-group-item {
+        display: flex;
+        align-items: center;
+    }
+</style>

--- a/warpgate-web/src/admin/config/targets/Target.svelte
+++ b/warpgate-web/src/admin/config/targets/Target.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { api, type Role, type Target } from 'admin/lib/api'
+    import { api, type Role, type Target, type TargetGroup } from 'admin/lib/api'
     import AsyncButton from 'common/AsyncButton.svelte'
     import ConnectionInstructions from 'common/ConnectionInstructions.svelte'
     import { TargetKind } from 'gateway/lib/api'
@@ -25,9 +25,11 @@
     let target: Target | undefined = $state()
     let roleIsAllowed: Record<string, any> = $state({})
     let connectionsInstructionsModalOpen = $state(false)
+    let groups: TargetGroup[] = $state([])
 
     async function init () {
         target = await api.getTarget({ id: params.id })
+        groups = await api.listTargetGroups()
     }
 
     async function loadRoles () {
@@ -155,6 +157,15 @@
 
         <FormGroup floating label="Description">
             <Input bind:value={target.description} />
+        </FormGroup>
+
+        <FormGroup floating label="Group">
+            <select class="form-control" bind:value={target.groupId}>
+                <option value={undefined}>No group</option>
+                {#each groups as group}
+                    <option value={group.id}>{group.name}</option>
+                {/each}
+            </select>
         </FormGroup>
 
         {#if target.options.kind === 'Ssh'}

--- a/warpgate-web/src/admin/config/targets/Targets.svelte
+++ b/warpgate-web/src/admin/config/targets/Targets.svelte
@@ -130,7 +130,7 @@
                     {/if}
                 </small>
             </a>
-                {/snippet}
+        {/snippet}
     </ItemList>
 </div>
 

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate Web Admin",
-    "version": "v0.15.0-11-gd858319-modified"
+    "version": "v0.16.0-23-g4b37548-modified"
   },
   "servers": [
     {
@@ -830,6 +830,17 @@
             "required": false,
             "deprecated": false,
             "explode": true
+          },
+          {
+            "name": "group_id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "query",
+            "required": false,
+            "deprecated": false,
+            "explode": true
           }
         ],
         "responses": {
@@ -1219,6 +1230,212 @@
           }
         ],
         "operationId": "delete_target_role"
+      }
+    },
+    "/target-groups": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TargetGroup"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          }
+        ],
+        "operationId": "list_target_groups"
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json; charset=utf-8": {
+              "schema": {
+                "$ref": "#/components/schemas/TargetGroupDataRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/TargetGroup"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          }
+        ],
+        "operationId": "create_target_group"
+      }
+    },
+    "/target-groups/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/TargetGroup"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          }
+        ],
+        "operationId": "get_target_group"
+      },
+      "put": {
+        "parameters": [
+          {
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json; charset=utf-8": {
+              "schema": {
+                "$ref": "#/components/schemas/TargetGroupDataRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/TargetGroup"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          }
+        ],
+        "operationId": "update_target_group"
+      },
+      "delete": {
+        "parameters": [
+          {
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          }
+        ],
+        "operationId": "delete_target_group"
       }
     },
     "/users": {
@@ -2937,6 +3154,10 @@
           "rate_limit_bytes_per_second": {
             "type": "integer",
             "format": "uint32"
+          },
+          "group_id": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },
@@ -2960,6 +3181,52 @@
           "rate_limit_bytes_per_second": {
             "type": "integer",
             "format": "uint32"
+          },
+          "group_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "TargetGroup": {
+        "type": "object",
+        "title": "TargetGroup",
+        "required": [
+          "id",
+          "name",
+          "description"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          }
+        }
+      },
+      "TargetGroupDataRequest": {
+        "type": "object",
+        "title": "TargetGroupDataRequest",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
           }
         }
       },

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate Web Admin",
-    "version": "v0.16.0-23-g4b37548-modified"
+    "version": "v0.16.0-24-gab5b93e-modified"
   },
   "servers": [
     {

--- a/warpgate-web/src/gateway/TargetList.svelte
+++ b/warpgate-web/src/gateway/TargetList.svelte
@@ -1,33 +1,71 @@
 <script lang="ts">
-import { Observable, from, map } from 'rxjs'
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
 import ConnectionInstructions from 'common/ConnectionInstructions.svelte'
-import ItemList, { type LoadOptions, type PaginatedResponse } from 'common/ItemList.svelte'
 import { api, type TargetSnapshot, TargetKind } from 'gateway/lib/api'
 import Fa from 'svelte-fa'
 import { Button, Modal, ModalBody, ModalFooter } from '@sveltestrap/sveltestrap'
 import { serverInfo } from './lib/store'
 import { firstBy } from 'thenby'
 import GettingStarted from 'common/GettingStarted.svelte'
-import EmptyState from 'common/EmptyState.svelte'
 
 let selectedTarget: TargetSnapshot|undefined = $state()
+let targets: TargetSnapshot[] = $state([])
+let groupedTargets: { [groupName: string]: TargetSnapshot[] } = $state({})
 
-function loadTargets (options: LoadOptions): Observable<PaginatedResponse<TargetSnapshot>> {
-    return from(api.getTargets({ search: options.search })).pipe(
-        map(result => {
-            result = result.sort(
-                firstBy<TargetSnapshot, boolean>(x => x.kind !== TargetKind.WebAdmin)
-                    .thenBy(x => x.name.toLowerCase())
-            )
-            return {
-                items: result,
-                offset: 0,
-                total: result.length,
-            }
+// Simple data loading
+api.getTargets({}).then(result => {
+    console.log('=== TARGET DEBUGGING ===')
+    console.log('Raw API response:', result)
+    console.log('Number of targets:', result.length)
+
+    if (result.length > 0) {
+        console.log('Sample target data:', result[0])
+        console.log('All targets group info:')
+        result.forEach((target, index) => {
+            console.log(`Target ${index + 1}:`, {
+                name: target.name,
+                groupId: target.groupId,
+                groupName: target.groupName,
+                groupColor: target.groupColor,
+                hasGroupId: !!target.groupId,
+                hasGroupName: !!target.groupName,
+                hasGroupColor: !!target.groupColor
+            })
         })
+    }
+
+    targets = result.sort(
+        firstBy<TargetSnapshot, boolean>(x => x.kind !== TargetKind.WebAdmin)
+            .thenBy(x => x.name.toLowerCase())
     )
-}
+
+    // Group targets by group name, but handle WebAdmin specially
+    groupedTargets = {}
+    let webAdminTarget: TargetSnapshot | undefined = undefined
+
+    for (const target of targets) {
+        if (target.kind === TargetKind.WebAdmin) {
+            webAdminTarget = target
+        } else {
+            const groupName = target.groupName || 'Ungrouped'
+            if (!groupedTargets[groupName]) {
+                groupedTargets[groupName] = []
+            }
+            groupedTargets[groupName].push(target)
+        }
+    }
+
+    // Add WebAdmin target to its own special section
+    if (webAdminTarget) {
+        groupedTargets['Administration'] = [webAdminTarget]
+    }
+
+    console.log('Final grouped targets:', groupedTargets)
+    console.log('Group names found:', Object.keys(groupedTargets))
+    console.log('=== END DEBUGGING ===')
+}).catch(e => {
+    console.error('Failed to load targets:', e)
+})
 
 function selectTarget (target: TargetSnapshot) {
     if (target.kind === TargetKind.WebAdmin) {
@@ -50,64 +88,68 @@ function loadURL (url: string) {
         setupState={$serverInfo?.setupState} />
 {/if}
 
-<ItemList load={loadTargets} showSearch={true}>
-    {#snippet empty()}
-        <EmptyState
-            title="You don't have access to any targets yet" />
-    {/snippet}
-    {#snippet item(target)}
-        <a
-            class="list-group-item list-group-item-action target-item"
-            href={
-                target.kind === TargetKind.WebAdmin
-                    ? '/@warpgate/admin'
-                    : target.kind === TargetKind.Http
-                        ? `/?warpgate-target=${target.name}`
-                        : '/@warpgate/admin'
-            }
-            onclick={e => {
-                if (e.metaKey || e.ctrlKey) {
-                    return
-                }
-                e.preventDefault()
-                selectTarget(target)
-            }}
-        >
-            <span class="me-auto">
-                {#if target.kind === TargetKind.WebAdmin}
-                    Manage Warpgate
-                {:else}
-                    <div>
-                        {target.name}
-                    </div>
-                    {#if target.description}
-                        <small class="d-block text-muted">{target.description}</small>
-                    {/if}
-                {/if}
-            </span>
-            <small class="protocol text-muted ms-auto">
-                {#if target.kind === TargetKind.Ssh}
-                    SSH
-                {/if}
-                {#if target.kind === TargetKind.MySql}
-                    MySQL
-                {/if}
-                {#if target.kind === TargetKind.Postgres}
-                    PostgreSQL
-                {/if}
-            </small>
-            {#if target.kind === TargetKind.Http || target.kind === TargetKind.WebAdmin}
-                <Fa icon={faArrowRight} fw />
-            {/if}
-        </a>
-    {/snippet}
-</ItemList>
-
-{#if $serverInfo?.setupState && !$serverInfo.setupState.hasTargets}
-    <EmptyState
-        hint="Once you add targets and assign access, they will appear here"
-        title="No other targets yet" />
-{/if}
+<div class="targets-container">
+    {#each Object.entries(groupedTargets).sort(([a], [b]) => {
+        // Administration section always comes first
+        if (a === 'Administration') return -1
+        if (b === 'Administration') return 1
+        return a.localeCompare(b)
+    }) as [groupName, groupTargets]}
+        <div class="target-group">
+            <div class="group-header" class:administration={groupName === 'Administration'} style:background-color={groupName === 'Administration' ? '#dc3545' : (groupTargets[0]?.groupColor || '#6c757d')}>
+                <h6 class="group-title">{groupName}</h6>
+            </div>
+            <div class="list-group">
+                {#each groupTargets as target}
+                    <a
+                        class="list-group-item list-group-item-action target-item"
+                        href={
+                            target.kind === TargetKind.WebAdmin
+                                ? '/@warpgate/admin'
+                                : target.kind === TargetKind.Http
+                                    ? `/?warpgate-target=${target.name}`
+                                    : '/@warpgate/admin'
+                        }
+                        onclick={e => {
+                            if (e.metaKey || e.ctrlKey) {
+                                return
+                            }
+                            e.preventDefault()
+                            selectTarget(target)
+                        }}
+                    >
+                        <span class="me-auto">
+                            {#if target.kind === TargetKind.WebAdmin}
+                                Manage Warpgate
+                            {:else}
+                                <div>
+                                    {target.name}
+                                </div>
+                                {#if target.description}
+                                    <small class="d-block text-muted">{target.description}</small>
+                                {/if}
+                            {/if}
+                        </span>
+                        <small class="protocol text-muted ms-auto">
+                            {#if target.kind === TargetKind.Ssh}
+                                SSH
+                            {/if}
+                            {#if target.kind === TargetKind.MySql}
+                                MySQL
+                            {/if}
+                            {#if target.kind === TargetKind.Postgres}
+                                PostgreSQL
+                            {/if}
+                        </small>
+                        {#if target.kind === TargetKind.Http || target.kind === TargetKind.WebAdmin}
+                            <Fa icon={faArrowRight} fw />
+                        {/if}
+                    </a>
+                {/each}
+            </div>
+        </div>
+    {/each}
+</div>
 
 <Modal isOpen={!!selectedTarget} toggle={() => selectedTarget = undefined}>
     <ModalBody>
@@ -130,8 +172,53 @@ function loadURL (url: string) {
 </Modal>
 
 <style lang="scss">
-    .target-item {
+    .targets-container {
         display: flex;
-        align-items: center;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    .target-group {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .group-header {
+        background-color: #6c757d;
+        color: white;
+        padding: 0.75rem 1rem;
+        border-radius: 0.375rem 0.375rem 0 0;
+        margin-bottom: 0;
+    }
+
+    .group-header.administration {
+        background-color: #dc3545 !important;
+        font-weight: 700;
+    }
+
+    .group-title {
+        margin: 0;
+        font-size: 0.875rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
+    .list-group {
+        border-radius: 0 0 0.375rem 0.375rem;
+        border: 1px solid #dee2e6;
+        border-top: none;
+    }
+
+    .list-group-item {
+        transition: background-color 0.2s ease-in-out;
+
+        &:hover {
+            background-color: #f8f9fa;
+        }
+
+        &:first-child {
+            border-top: none;
+        }
     }
 </style>

--- a/warpgate-web/src/gateway/lib/openapi-schema.json
+++ b/warpgate-web/src/gateway/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate HTTP proxy",
-    "version": "v0.16.0-23-g4b37548-modified"
+    "version": "v0.16.0-24-gab5b93e-modified"
   },
   "servers": [
     {

--- a/warpgate-web/src/gateway/lib/openapi-schema.json
+++ b/warpgate-web/src/gateway/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate HTTP proxy",
-    "version": "v0.16.0-24-gab5b93e-modified"
+    "version": "v0.16.0-25-gb50e035-modified"
   },
   "servers": [
     {
@@ -1168,6 +1168,16 @@
             "$ref": "#/components/schemas/TargetKind"
           },
           "external_host": {
+            "type": "string"
+          },
+          "group_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "group_name": {
+            "type": "string"
+          },
+          "group_color": {
             "type": "string"
           }
         }

--- a/warpgate-web/src/gateway/lib/openapi-schema.json
+++ b/warpgate-web/src/gateway/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate HTTP proxy",
-    "version": "v0.15.0-11-gd858319-modified"
+    "version": "v0.16.0-23-g4b37548-modified"
   },
   "servers": [
     {
@@ -98,7 +98,7 @@
             "description": ""
           }
         },
-        "operationId": "getDefaultAuthState"
+        "operationId": "get_default_auth_state"
       },
       "delete": {
         "responses": {
@@ -116,7 +116,7 @@
             "description": ""
           }
         },
-        "operationId": "cancelDefaultAuth"
+        "operationId": "cancel_default_auth"
       }
     },
     "/auth/web-auth-requests": {


### PR DESCRIPTION
This pull request introduces a new "Target Groups" feature to the Warpgate application, allowing targets to be organized into groups with associated metadata (name, description, color). It adds database support, API endpoints for managing target groups, and updates the targets to optionally reference a group. The HTTP protocol and web UI are also updated to expose and utilize this grouping functionality.

**Target Groups Feature**

* Added new `TargetGroup` entity, database migration, and ORM model, including fields for `id`, `name`, `description`, and `color`. [[1]](diffhunk://#diff-67a95652ef3f605b692272e63d2d51e22f14002a127119f4cba7113a30d2b0b9R1-R25) [[2]](diffhunk://#diff-175c343e2be9f946c88f9d90b1620c79403f0cca74afd7c4aa43f33e4dfda4c7R1-R102)
* Created REST API endpoints for listing, creating, retrieving, updating, and deleting target groups in `target_groups.rs`, and registered these endpoints in the main API module. [[1]](diffhunk://#diff-f9e2ce7e2efafd2fe1cb52ed5fc182854cbf148ec2a4f171405b3f787fb87110R1-R208) [[2]](diffhunk://#diff-ad95ed5547cb582058361b260d52dd0503ce7b1b0ae21974a238792189346b11R19) [[3]](diffhunk://#diff-ad95ed5547cb582058361b260d52dd0503ce7b1b0ae21974a238792189346b11R36)

**Targets Integration**

* Extended target models and database schema to include an optional `group_id` field, and added the relation between targets and target groups. [[1]](diffhunk://#diff-a5b6f836b60eb623474d99de60f74a3c8410b2b347dac087f0e5913b672b11e1R55) [[2]](diffhunk://#diff-a5b6f836b60eb623474d99de60f74a3c8410b2b347dac087f0e5913b672b11e1L68-R79) [[3]](diffhunk://#diff-a5b6f836b60eb623474d99de60f74a3c8410b2b347dac087f0e5913b672b11e1R95) [[4]](diffhunk://#diff-bb051c46669335f59bf38e0bfb2ad73458823bcaf5fc052b8c75fa1b06da86d3R29) [[5]](diffhunk://#diff-84d2e0037cb4184806d5bebb10807f5254713558c79a88cc66553a00ae3374eeR142) [[6]](diffhunk://#diff-b685c67434cc98c054511b9090996823ac710742328a0c136958d9282d2e741fR122) [[7]](diffhunk://#diff-175c343e2be9f946c88f9d90b1620c79403f0cca74afd7c4aa43f33e4dfda4c7R1-R102)
* Updated targets API endpoints to support filtering by group, setting group on create/update, and returning group information in responses. [[1]](diffhunk://#diff-bb051c46669335f59bf38e0bfb2ad73458823bcaf5fc052b8c75fa1b06da86d3R59) [[2]](diffhunk://#diff-bb051c46669335f59bf38e0bfb2ad73458823bcaf5fc052b8c75fa1b06da86d3R71-R74) [[3]](diffhunk://#diff-bb051c46669335f59bf38e0bfb2ad73458823bcaf5fc052b8c75fa1b06da86d3R117) [[4]](diffhunk://#diff-bb051c46669335f59bf38e0bfb2ad73458823bcaf5fc052b8c75fa1b06da86d3R214) [[5]](diffhunk://#diff-0535d25b685b2bfa4cd400006aef2c054ae137396bfa25e1417e662598c75cefR6-R10) [[6]](diffhunk://#diff-0535d25b685b2bfa4cd400006aef2c054ae137396bfa25e1417e662598c75cefR23-R25) [[7]](diffhunk://#diff-0535d25b685b2bfa4cd400006aef2c054ae137396bfa25e1417e662598c75cefL83-R143)

**Database Migration**

* Added migration `m00020_target_groups` to create the `target_groups` table and add the `group_id` column to the `targets` table. [[1]](diffhunk://#diff-ae45949a134d49f12101e8550287a30919f67e7efb84f5fafd11457996b6af0aR24) [[2]](diffhunk://#diff-ae45949a134d49f12101e8550287a30919f67e7efb84f5fafd11457996b6af0aR51) [[3]](diffhunk://#diff-175c343e2be9f946c88f9d90b1620c79403f0cca74afd7c4aa43f33e4dfda4c7R1-R102)

**Web UI Integration**

* Registered new routes for target group management in the admin Svelte application.

**Other**

* Registered the new entity and migration in the appropriate modules. [[1]](diffhunk://#diff-412ba1c63d322d1af11146676d0665c52e3f60ac2fb48a066bc4cd056fa16803R15) [[2]](diffhunk://#diff-ae45949a134d49f12101e8550287a30919f67e7efb84f5fafd11457996b6af0aR24)

These changes collectively enable users to manage target groups, associate targets with groups, and view group information throughout the API and UI.

<img width="1333" height="772" alt="CleanShot 2025-09-30 at 18 35 53" src="https://github.com/user-attachments/assets/d5329c0d-b569-4f1c-9052-82ad8098a802" />


<img width="1375" height="775" alt="CleanShot 2025-09-30 at 18 35 47" src="https://github.com/user-attachments/assets/a68fb42b-607c-4269-8873-b7ea56c38024" />


<img width="928" height="992" alt="CleanShot 2025-09-30 at 18 35 34" src="https://github.com/user-attachments/assets/3b5f9daa-ffe5-42ab-bc6f-7ea83fd605b1" />
