### PR TITLE
Add support for overwriting and reusing existing conrfiguration files

### DIFF
--- a/warpgate/src/main.rs
+++ b/warpgate/src/main.rs
@@ -70,6 +70,10 @@ pub(crate) enum Commands {
         /// External host used to construct URLs (without a port or scheme)
         #[clap(long)]
         external_host: Option<String>,
+
+        /// Reuse existing config file if it exists
+        #[clap(long, action=ArgAction::SetTrue)]
+        reuse_existing_config: bool,
     },
     /// Show Warpgate's SSH client keys
     ClientKeys,


### PR DESCRIPTION
Currently, the behaviour of the setup is that if a config file already exists, the setup will fail and exit. This behaviour is problematic for us because we want to set up warpgate through cloud-init, where we first write the config file ourselves, and then run the warpgate setup after (we mainly need to set up an admin account, which you can only do through the setup).

The goal of this PR is to add support for reusing an existing configuration rather than exiting, however by default this is not very logical behaviour, since sensible default behaviour is to overwrite an existing config, so instead, I implemented this behaviour as follows:
- If a config file does not exist, proceed as normal.
- If a config file does exist, by default back up the old config file (to prevent data loss of users who didn't think about this behaviour) and overwrite the existing config
- If a config file does exist and the user sets the new `reuse_existing_config` flag, the existing config is reused, and our use case is supported.

Note that we only need the third case, but I think others may be interested in the second case, and it was easy to add to this PR.

Admittedly it was hard to implement this behaviour in the old codebase since the setup function was very large, so placing a lot of if-else statements everywhere made the code a lot more complex. I rewrote the setup function by splitting it into many smaller functions, such that implementing this feature is a lot easier and cleaner. I feel like the new function is a lot easier to work with and maintain, but I hope you agree.

Resolves #1505