### PR TITLE
Bridge log crate to tracing for russh debug output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5289,6 +5289,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5532,6 +5543,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "uuid",
  "warpgate-admin",

--- a/warpgate/Cargo.toml
+++ b/warpgate/Cargo.toml
@@ -27,6 +27,7 @@ sea-orm.workspace = true
 time = { version = "0.3", default-features = false }
 tokio.workspace = true
 tracing.workspace = true
+tracing-log = { version = "0.2" }
 tracing-subscriber = { version = "0.3", features = [
     "ansi",
     "env-filter",

--- a/warpgate/src/main.rs
+++ b/warpgate/src/main.rs
@@ -100,7 +100,7 @@ pub(crate) enum Commands {
 async fn _main() -> Result<()> {
     let cli = Cli::parse();
 
-    init_logging(load_config(&cli.config, false).ok().as_ref(), &cli).await;
+    init_logging(load_config(&cli.config, false).ok().as_ref(), &cli).await?;
 
     #[allow(clippy::unwrap_used)]
     rustls::crypto::aws_lc_rs::default_provider()


### PR DESCRIPTION
russh uses the log crate for all debug logging, but warpgate uses tracing. Without a bridge, russh debug messages (enabled via -d -d) were silently discarded.

Added tracing-log's LogTracer to forward log crate messages to the tracing subscriber, and propagated initialization errors to the CLI.

Fixes https://github.com/warp-tech/warpgate/issues/1525