### PR TITLE
Use warpgate.yaml for Container Healthcheck

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,7 @@ COPY --from=build /opt/warpgate/target/release/warpgate /usr/local/bin/warpgate
 
 VOLUME /data
 
-HEALTHCHECK CMD warpgate healthcheck
+HEALTHCHECK CMD warpgate --config /data/warpgate.yaml healthcheck
 
 ENV DOCKER=1
 


### PR DESCRIPTION
This pull request implements a health check mechanism for the container using the warpgate.yaml configuration file. Without a specified path to the configuration, the health check currently looks for its settings under /etc/warpgate.yaml. However, if the config path is set as in all examples to /data, the container health status will always remain unhealthy. This change ensures that the health check correctly references the configuration, allowing for accurate health status reporting for the container.