### PR TITLE
Undo API-incompatible TlsMode change

### DIFF
--- a/warpgate-tls/src/mode.rs
+++ b/warpgate-tls/src/mode.rs
@@ -3,9 +3,12 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, Enum, PartialEq, Eq, Default)]
 pub enum TlsMode {
+    #[serde(rename = "disabled")]
     Disabled,
+    #[serde(rename = "preferred")]
     #[default]
     Preferred,
+    #[serde(rename = "required")]
     Required,
 }
 

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate Web Admin",
-    "version": "v0.18.0-11-g422b4f76-modified"
+    "version": "v0.18.0-39-gcbbeb71b-modified"
   },
   "servers": [
     {
@@ -3135,13 +3135,13 @@
             "default": "(objectClass=person)"
           },
           "tls_mode": {
-            "default": "preferred",
+            "default": "Preferred",
             "allOf": [
               {
                 "$ref": "#/components/schemas/TlsMode"
               },
               {
-                "default": "preferred"
+                "default": "Preferred"
               }
             ]
           },

--- a/warpgate-web/src/gateway/lib/openapi-schema.json
+++ b/warpgate-web/src/gateway/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate HTTP proxy",
-    "version": "v0.18.0-11-g422b4f76-modified"
+    "version": "v0.18.0-39-gcbbeb71b-modified"
   },
   "servers": [
     {


### PR DESCRIPTION
With the LDAP user sync PR (https://github.com/warp-tech/warpgate/pull/1603), the API of the TlsMode enum was changed from capitalised to non-capitalised (e.g. you now need to specify "disabled" rather than "Disabled"). This breaks all API tools including Terraform in Warpgate 0.19.0, where the official Warpgate Terraform provider is now unusable since it enforces you to choose between Preferred, Disabled or Required, and doesn't allow the lowercase variant, which makes it impossible to create an HTTP target for us.

Of course the Terraform provider can be updated, but I don't see the reason to have this be lowercase, especially since all other enums in the Warpgate API are capitalised (e.g. TargetGroup.color = Primary, Secondary etc...), so this PR proposes to revert the api-breaking change.

If this is indeed accepted, it would be incredibly useful to have a 0.19.1 patch release, such that we don't end up with a situation where 0.18 has a certain API, 0.19 has an API-breaking change, and then 0.20 has the old 0.18 API again.