### PR TITLE
fix: modify GEX parameters in SSH key exchange configuration so that it uses 2048 bits

### DIFF
--- a/warpgate-protocol-ssh/src/client/mod.rs
+++ b/warpgate-protocol-ssh/src/client/mod.rs
@@ -488,12 +488,17 @@ impl RemoteClient {
             Preferred::default()
         };
 
-        let config = russh::client::Config {
+        let mut config = russh::client::Config {
             preferred: algos,
             nodelay: true,
-            gex: russh::client::GexParams::new(2048, 2048, 8192)?,
             ..Default::default()
         };
+        if ssh_options.allow_insecure_algos.unwrap_or(false) {
+            if let Ok(gex) = russh::client::GexParams::new(2048, 2048, 8192) {
+                config.gex = gex;
+            }
+        }
+
         let config = Arc::new(config);
 
         let (event_tx, mut event_rx) = unbounded_channel();


### PR DESCRIPTION
This PR modifies the default SSH client configuration related to key exchange algorithms.

When using GEX (Group Exchange) algorithms, the underlying SSH library enforces a minimum key size greater than 3000 bits ([reference](https://docs.rs/russh/latest/src/russh/client/mod.rs.html#1656)). This causes the key exchange negotiation to fail on some legacy devices (p.e, MikroTik routers running older versions of RouterOS). These devices only support a maximum of 2048 bits.

With this change, the SSH client configuration is adjusted to allow compatibility with these systems, enabling successful SSH connections while maintaining existing behavior for supported environments.