### PR TITLE
fix: generate SSO login return URL based on request host

### DIFF
--- a/warpgate-protocol-http/src/api/sso_provider_detail.rs
+++ b/warpgate-protocol-http/src/api/sso_provider_detail.rs
@@ -61,7 +61,7 @@ impl Api {
             return Ok(StartSsoResponse::NotFound);
         };
         let mut return_url = config
-            .construct_external_url(None, provider_config.return_domain_whitelist.as_deref())?;
+            .construct_external_url(Some(req), provider_config.return_domain_whitelist.as_deref())?;
         return_url.set_path("@warpgate/api/sso/return");
         debug!("Return URL: {}", &return_url);
 


### PR DESCRIPTION
This change modifies how the SSO return URL is generated during the login process so that it takes into account the incoming request and its specific host.

By doing this, we could reach a possible solution to support multiple independent HTTP sessions without interfering with the original behavior that enables cookie sharing across domains (see #1553, #1626 and comment https://github.com/warp-tech/warpgate/issues/1626#issuecomment-3719613249).

Additionally, this approach appears to be the correct one, since during the SSO logout process the return URL construction already takes the request into account.

https://github.com/warp-tech/warpgate/blob/08722341af178f800a26b6ec92923dfd401f4071/warpgate-protocol-http/src/api/sso_provider_list.rs#L303-L317

I’m open to feedback and discussion on whether this is the most appropriate solution, and I’m happy to adapt the implementation if a better approach is suggested.