### PR TITLE
Downgrade build environment to Ubuntu 22.04, addresses #1678

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,6 @@ jobs:
       - name: Install tools
         run: |
           cargo install --locked just
-          cargo install --locked cargo-deny@0.18.9
           cargo install --locked cargo-cyclonedx@^0.5
           rm -rf ~/.cargo/registry
 
@@ -82,9 +81,7 @@ jobs:
           npm i -g @cyclonedx/cyclonedx-npm@4.1.2
 
       - name: cargo-deny
-        run: |
-          cargo deny --version
-          cargo deny check
+        uses: EmbarkStudios/cargo-deny-action@v2.0.14
 
       - name: Install admin UI deps
         run: |


### PR DESCRIPTION
Partial revert of https://github.com/warp-tech/warpgate/commit/a42c3fd3ea318078cac6c6e8414a87f6e151d8c6

Ubuntu 24.04 ships with glibc incompatible with still supported OSes like Debian 12 (or Ubuntu 22.04 LTS for that matter).

This effectively downgrades build env to the one from 0.18.0 release.

Fixes #1678