### PR TITLE
Allow for minimizing the password login menu

### DIFF
--- a/warpgate-admin/src/api/parameters.rs
+++ b/warpgate-admin/src/api/parameters.rs
@@ -19,6 +19,7 @@ struct ParameterValues {
     pub ssh_client_auth_publickey: bool,
     pub ssh_client_auth_password: bool,
     pub ssh_client_auth_keyboard_interactive: bool,
+    pub minimize_password_login: bool,
 }
 
 #[derive(Serialize, Object)]
@@ -28,6 +29,7 @@ struct ParameterUpdate {
     pub ssh_client_auth_publickey: Option<bool>,
     pub ssh_client_auth_password: Option<bool>,
     pub ssh_client_auth_keyboard_interactive: Option<bool>,
+    pub minimize_password_login: Option<bool>,
 }
 
 #[derive(ApiResponse)]
@@ -59,6 +61,7 @@ impl Api {
             ssh_client_auth_publickey: parameters.ssh_client_auth_publickey,
             ssh_client_auth_password: parameters.ssh_client_auth_password,
             ssh_client_auth_keyboard_interactive: parameters.ssh_client_auth_keyboard_interactive,
+            minimize_password_login: parameters.minimize_password_login,
         })))
     }
 
@@ -84,6 +87,7 @@ impl Api {
         parameters.ssh_client_auth_keyboard_interactive = body
             .ssh_client_auth_keyboard_interactive
             .map_or(NotSet, Set);
+        parameters.minimize_password_login = body.minimize_password_login.map_or(NotSet, Set);
 
         Parameters::Entity::update(parameters).exec(&*db).await?;
         drop(db);

--- a/warpgate-common/src/config/mod.rs
+++ b/warpgate-common/src/config/mod.rs
@@ -483,9 +483,6 @@ pub struct WarpgateConfigStore {
     #[serde(default)]
     pub external_host: Option<String>,
 
-    #[serde(default)]
-    pub minimize_password_login: bool,
-
     #[serde(default = "_default_database_url")]
     #[schemars(with = "String")]
     pub database_url: Secret<String>,
@@ -515,7 +512,6 @@ impl Default for WarpgateConfigStore {
             sso_providers: vec![],
             recordings: <_>::default(),
             external_host: None,
-            minimize_password_login: false,
             database_url: _default_database_url(),
             ssh: <_>::default(),
             http: <_>::default(),

--- a/warpgate-db-entities/src/Parameters.rs
+++ b/warpgate-db-entities/src/Parameters.rs
@@ -16,6 +16,7 @@ pub struct Model {
     pub ssh_client_auth_publickey: bool,
     pub ssh_client_auth_password: bool,
     pub ssh_client_auth_keyboard_interactive: bool,
+    pub minimize_password_login: bool,
 }
 
 impl ActiveModelBehavior for ActiveModel {}
@@ -37,6 +38,7 @@ impl Entity {
                     ssh_client_auth_publickey: Set(true),
                     ssh_client_auth_password: Set(true),
                     ssh_client_auth_keyboard_interactive: Set(true),
+                    minimize_password_login: Set(false),
                 }
                 .insert(db)
                 .await

--- a/warpgate-db-migrations/src/lib.rs
+++ b/warpgate-db-migrations/src/lib.rs
@@ -32,6 +32,7 @@ mod m00027_ca;
 mod m00028_certificate_credentials;
 mod m00029_certificate_revocation;
 mod m00030_add_recording_metadata;
+mod m00031_minimize_password_login;
 
 pub struct Migrator;
 
@@ -69,6 +70,7 @@ impl MigratorTrait for Migrator {
             Box::new(m00028_certificate_credentials::Migration),
             Box::new(m00029_certificate_revocation::Migration),
             Box::new(m00030_add_recording_metadata::Migration),
+            Box::new(m00031_minimize_password_login::Migration),
         ]
     }
 }

--- a/warpgate-db-migrations/src/m00031_hide_password_login.rs
+++ b/warpgate-db-migrations/src/m00031_hide_password_login.rs
@@ -1,0 +1,45 @@
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m00031_minimize_password_login"
+    }
+}
+
+use crate::m00010_parameters::parameters;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(parameters::Entity)
+                    .add_column(
+                        ColumnDef::new(Alias::new("minimize_password_login"))
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(parameters::Entity)
+                    .drop_column(Alias::new("minimize_password_login"))
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/warpgate-db-migrations/src/m00031_minimize_password_login.rs
+++ b/warpgate-db-migrations/src/m00031_minimize_password_login.rs
@@ -1,0 +1,45 @@
+use sea_orm_migration::prelude::*;
+
+use crate::m00010_parameters::parameters;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m00031_minimize_password_login"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(parameters::Entity)
+                    .add_column(
+                        ColumnDef::new(Alias::new("minimize_password_login"))
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(parameters::Entity)
+                    .drop_column(Alias::new("minimize_password_login"))
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/warpgate-protocol-http/src/api/info.rs
+++ b/warpgate-protocol-http/src/api/info.rs
@@ -120,7 +120,7 @@ impl Api {
             username: session.get_username(),
             selected_target: session.get_target_name(),
             external_host,
-            minimize_password_login: config.store.minimize_password_login,
+            minimize_password_login: parameters.minimize_password_login,
             authorized_via_ticket: matches!(
                 session.get_auth(),
                 Some(SessionAuthorization::Ticket { .. })

--- a/warpgate-web/src/admin/config/Parameters.svelte
+++ b/warpgate-web/src/admin/config/Parameters.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
     import { FormGroup, Input } from '@sveltestrap/sveltestrap'
     import { api, type ParameterValues } from 'admin/lib/api'
+    import { api as gatewayApi } from 'gateway/lib/api'
     import Loadable from 'common/Loadable.svelte'
     import RateLimitInput from 'common/RateLimitInput.svelte'
     import InfoBox from 'common/InfoBox.svelte'
 
     let parameters: ParameterValues | undefined = $state()
+    let hasSsoProviders = $state(false)
     const initPromise = init()
 
     async function init () {
         parameters = await api.getParameters({})
+        const ssoProviders = await gatewayApi.getSsoProviders()
+        hasSsoProviders = ssoProviders.length > 0
     }
 
     async function update() {
@@ -104,6 +108,28 @@
             Controls which authentication methods are offered to SSH clients.
             Disabling password authentication can help prevent brute-force attacks.
         </InfoBox>
+
+        {#if hasSsoProviders}
+        <h4 class="mt-4">Login</h4>
+        <label
+            for="minimizePasswordLogin"
+            class="d-flex align-items-center"
+        >
+            <Input
+                id="minimizePasswordLogin"
+                class="mb-0 me-2"
+                type="switch"
+                on:change={() => {
+                    parameters!.minimizePasswordLogin = !parameters!.minimizePasswordLogin
+                    update()
+                }}
+                checked={parameters.minimizePasswordLogin} />
+            <div>Minimize password login UI</div>
+        </label>
+        <InfoBox class="mt-3 mb-3">
+            When enabled, the username and password fields are hidden behind a link on the login page, with the focus on the SSO buttons.
+        </InfoBox>
+        {/if}
     {/if}
     </Loadable>
 </div>

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate Web Admin",
-    "version": "v0.20.2-7-g1cce72fe-modified"
+    "version": "v0.20.2-27-g52fb3b68-modified"
   },
   "servers": [
     {
@@ -4000,6 +4000,9 @@
           },
           "ssh_client_auth_keyboard_interactive": {
             "type": "boolean"
+          },
+          "minimize_password_login": {
+            "type": "boolean"
           }
         }
       },
@@ -4010,7 +4013,8 @@
           "allow_own_credential_management",
           "ssh_client_auth_publickey",
           "ssh_client_auth_password",
-          "ssh_client_auth_keyboard_interactive"
+          "ssh_client_auth_keyboard_interactive",
+          "minimize_password_login"
         ],
         "properties": {
           "allow_own_credential_management": {
@@ -4027,6 +4031,9 @@
             "type": "boolean"
           },
           "ssh_client_auth_keyboard_interactive": {
+            "type": "boolean"
+          },
+          "minimize_password_login": {
             "type": "boolean"
           }
         }

--- a/warpgate-web/src/gateway/Login.svelte
+++ b/warpgate-web/src/gateway/Login.svelte
@@ -20,6 +20,7 @@
     let otpInput: HTMLInputElement|undefined = $state()
     let authState: ApiAuthState|undefined = $state()
     let ssoProvidersPromise = api.getSsoProviders()
+    let showPasswordLogin = $state(false)
 
     const nextURL = new URLSearchParams(get(querystring)).get('next') ?? undefined
     const serverErrorMessage = new URLSearchParams(location.search).get('login_error')
@@ -208,7 +209,8 @@
                 </Button>
             </form>
         {/if}
-        {#if (authState === ApiAuthState.NotStarted || authState === ApiAuthState.PasswordNeeded || authState === ApiAuthState.Failed) && !$serverInfo?.minimizePasswordLogin}
+        {#if (authState === ApiAuthState.NotStarted || authState === ApiAuthState.PasswordNeeded || authState === ApiAuthState.Failed) && (!$serverInfo?.minimizePasswordLogin || showPasswordLogin)}
+            <!-- eslint-disable-next-line @typescript-eslint/no-confusing-void-expression -->
             {@render localLoginForm()}
         {/if}
 
@@ -252,14 +254,19 @@
         </Loadable>
     {/if}
 
-    {#if (authState === ApiAuthState.NotStarted || authState === ApiAuthState.PasswordNeeded || authState === ApiAuthState.Failed) && $serverInfo?.minimizePasswordLogin}
-        <div class="mt-3">
-            <details class="local-login-collapse">
-                <summary>Password login</summary>
-                <div class="mt-3">
-                    {@render localLoginForm()}
-                </div>
-            </details>
+    {#if (authState === ApiAuthState.NotStarted || authState === ApiAuthState.PasswordNeeded || authState === ApiAuthState.Failed) && $serverInfo?.minimizePasswordLogin && !showPasswordLogin}
+        <div class="mt-3 text-center">
+            <!-- svelte-ignore a11y_invalid_attribute -->
+            <a
+                href="#"
+                class="password-login-link"
+                onclick={e => {
+                    e.preventDefault()
+                    showPasswordLogin = true
+                }}
+            >
+                Password login
+            </a>
         </div>
     {/if}
 
@@ -292,7 +299,5 @@
         }
     }
 
-    .local-login-collapse summary {
-        cursor: pointer;
-    }
+
 </style>

--- a/warpgate-web/src/gateway/lib/openapi-schema.json
+++ b/warpgate-web/src/gateway/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate HTTP proxy",
-    "version": "v0.20.2-7-g1cce72fe-modified"
+    "version": "v0.20.2-27-g52fb3b68-modified"
   },
   "servers": [
     {


### PR DESCRIPTION
Within our warpgate usecase (and I can imagine there are many users with the exact same usecase), we want all our users to log in through SSO, with the username/password only being used for the admin login by the Warpgate administrator. It doesn't make sense to make the local login so big on the login page for this use case, and it will just cause users to try to enter their SSO credentials in the local login.

This PR adds a new config parameter to `warpgate.yaml`: minimize_password_login

When this value is set to true, the password login is moved to the bottom and hidden behind a collapsible menu. The default value is of course false, in which case nothing changes.

<img width="556" height="383" alt="Screenshot From 2026-03-05 12-59-25" src="https://github.com/user-attachments/assets/ddfbce6b-9ddf-4645-be85-e356d21ee1b6" />

<img width="541" height="613" alt="Screenshot From 2026-03-05 12-59-35" src="https://github.com/user-attachments/assets/f854d20d-2642-4cd9-b12b-2480f467e420" />

