### PR TITLE
feat: Add HTTPRoute template to Helm chart

### DIFF
--- a/helm/warpgate/Chart.yaml
+++ b/helm/warpgate/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # version: 0.1.3
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/warpgate/templates/httproute.yaml
+++ b/helm/warpgate/templates/httproute.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "warpgate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "warpgate.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "warpgate.fullname" . }}
+          port: {{ .Values.service.ports.http }}
+{{- end }}

--- a/helm/warpgate/values.yaml
+++ b/helm/warpgate/values.yaml
@@ -134,3 +134,14 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts: []
   tls: []
+
+# HTTPRoute configuration
+httpRoute:
+  enabled: false
+  annotations: {}
+  parentRefs: []
+  # - name: gateway-name
+  #   namespace: gateway-namespace
+  #   sectionName: gateway-section-name
+  hostnames: []
+  # - warpgate.example.com


### PR DESCRIPTION
These changes add the ability to create an `HTTPRoute` resource via `values.yaml`. The Gateway API (to which the `HTTPRoute` resource belongs) is a modern [successor](https://kubernetes.io/docs/concepts/services-networking/gateway/#migrating-from-ingress) to the Ingress API.