### PR TITLE
Send messages to SSH terminal synchronously

### DIFF
--- a/warpgate-protocol-ssh/src/client/mod.rs
+++ b/warpgate-protocol-ssh/src/client/mod.rs
@@ -391,10 +391,6 @@ impl RemoteClient {
                 Err(e) => {
                     debug!("Connect error: {}", e);
                     let _ = self.tx.send(RCEvent::ConnectionError(e));
-
-                    // Allow some time for the SessionServer to process the ConnectionError and print a message to the terminal
-                    // before closing the session. If we don't wait, the session might close too quickly and the user won't see the error.
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                     self.set_disconnected();
 
                     return Ok(true);

--- a/warpgate-protocol-ssh/src/server/service_output.rs
+++ b/warpgate-protocol-ssh/src/server/service_output.rs
@@ -7,7 +7,6 @@ use tokio::sync::{broadcast, mpsc};
 
 pub const ERASE_PROGRESS_SPINNER: &str = "\r                        \r";
 pub const ERASE_PROGRESS_SPINNER_BUF: &[u8] = ERASE_PROGRESS_SPINNER.as_bytes();
-pub const LINEBREAK: &[u8] = "\n".as_bytes();
 
 #[derive(Clone)]
 pub struct ServiceOutput {
@@ -59,19 +58,13 @@ impl ServiceOutput {
             .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
-    pub async fn hide_progress(&mut self) {
+    pub fn stop_progress(&self) {
         self.progress_visible
             .store(false, std::sync::atomic::Ordering::Relaxed);
-        self.emit_output(Bytes::from_static(ERASE_PROGRESS_SPINNER_BUF));
-        self.emit_output(Bytes::from_static(LINEBREAK));
     }
 
     pub fn subscribe(&self) -> broadcast::Receiver<Bytes> {
         self.output_tx.subscribe()
-    }
-
-    pub fn emit_output(&mut self, output: Bytes) {
-        let _ = self.output_tx.send(output);
     }
 }
 

--- a/warpgate-protocol-ssh/src/server/session.rs
+++ b/warpgate-protocol-ssh/src/server/session.rs
@@ -302,12 +302,13 @@ impl ServerSession {
     pub async fn emit_service_message(&mut self, msg: &str) -> Result<()> {
         debug!("Service message: {}", msg);
 
-        self.service_output.emit_output(Bytes::from(format!(
+        let output = format!(
             "{}{} {}\r\n",
             ERASE_PROGRESS_SPINNER,
             Colour::Black.on(Colour::White).paint(" Warpgate "),
             msg.replace('\n', "\r\n"),
-        )));
+        );
+        self.emit_pty_output(output.as_bytes()).await?;
 
         Ok(())
     }
@@ -631,24 +632,25 @@ impl ServerSession {
                 self.rc_state = state;
                 match &self.rc_state {
                     RCState::Connected => {
-                        self.service_output.hide_progress().await;
-                        self.service_output.emit_output(Bytes::from(format!(
+                        self.service_output.stop_progress();
+                        let msg = format!(
                             "{}{}\r\n",
                             ERASE_PROGRESS_SPINNER,
                             Colour::Black
                                 .on(Colour::Green)
                                 .paint(" ✓ Warpgate connected ")
-                        )));
+                        );
+                        let _ = self.emit_pty_output(msg.as_bytes()).await;
                     }
                     RCState::Disconnected => {
-                        self.service_output.hide_progress().await;
+                        self.service_output.stop_progress();
                         self.disconnect_server().await;
                     }
                     _ => {}
                 }
             }
             RCEvent::ConnectionError(error) => {
-                self.service_output.hide_progress().await;
+                self.service_output.stop_progress();
 
                 match error {
                     ConnectionError::HostKeyMismatch {
@@ -679,26 +681,28 @@ impl ServerSession {
                         .await?;
                     }
                     ConnectionError::Authentication => {
-                        self.service_output.emit_output(Bytes::from(format!(
+                        let msg = format!(
                             "{}{}\r\n",
                             ERASE_PROGRESS_SPINNER,
                             Colour::Black
                                 .on(Colour::Red)
                                 .paint(" ✗ SSH target rejected Warpgate authentication request ")
-                        )));
+                        );
+                        let _ = self.emit_pty_output(msg.as_bytes()).await;
                     }
                     error => {
-                        self.service_output.emit_output(Bytes::from(format!(
+                        let msg = format!(
                             "{}{} {}\r\n",
                             ERASE_PROGRESS_SPINNER,
                             Colour::Black.on(Colour::Red).paint(" ✗ Connection failed "),
                             error
-                        )));
+                        );
+                        let _ = self.emit_pty_output(msg.as_bytes()).await;
                     }
                 }
             }
             RCEvent::Error(e) => {
-                self.service_output.hide_progress().await;
+                self.service_output.stop_progress();
                 let _ = self.emit_service_message(&format!("Error: {e}")).await;
                 self.disconnect_server().await;
             }
@@ -938,7 +942,7 @@ impl ServerSession {
         key: PublicKey,
         reply: oneshot::Sender<bool>,
     ) -> Result<()> {
-        self.service_output.hide_progress().await;
+        self.service_output.stop_progress();
 
         let mode = self
             .services
@@ -1883,6 +1887,11 @@ impl ServerSession {
     }
 
     async fn disconnect_server(&mut self) {
+        // Flush pending writes so that any messages emitted before
+        // disconnecting (e.g. error or timeout notices) are delivered
+        // to the client before the channels are closed.
+        let _ = self.channel_writer.flush().await;
+
         let all_channels = std::mem::take(&mut self.all_channels);
         let channels = all_channels
             .into_iter()


### PR DESCRIPTION
This is a followup of a conversation we had in an earlier PR: https://github.com/warp-tech/warpgate/pull/1677#issuecomment-3801666191

Here we decided to introduce a time::sleep to get around the async issues with closing the SSH connection. This is both ugly and brittle, and only worked for the very specific case that we hacked it into.

I've revisited it and found a better way to do it: There is actually a way to synchronously send messages to the terminal. So this PR does that for the critical places where messages may get lost due to disconnecting the SSH sessions, and then gets rid of the sleep timer.