### PR TITLE
fix(ui): resolve config page layout regression caused by flex on main

### DIFF
--- a/warpgate-web/src/admin/App.svelte
+++ b/warpgate-web/src/admin/App.svelte
@@ -101,8 +101,6 @@
 
     main {
         flex: 1 0 0;
-        display: flex;
-        flex-direction: column;
     }
 
     header {

--- a/warpgate-web/src/admin/Log.svelte
+++ b/warpgate-web/src/admin/Log.svelte
@@ -29,31 +29,42 @@ let filters = $derived({
 })
 </script>
 
-<div class="page-summary-bar d-flex align-items-center justify-content-between">
-    <h1>
-    {#if filterKind === 'user'}
-        user audit log: UID <code>{params?.id}</code>
-    {:else if filterKind === 'access-role'}
-        access role audit log: ID <code>{params?.id}</code>
-    {:else if filterKind === 'admin-role'}
-        admin role audit log: ID <code>{params?.id}</code>
-    {:else}
-        log
-    {/if}
-    </h1>
-    <div class="d-flex align-items-center gap-3">
-        {#if !filterKind}
-            <Input
-                type="switch"
-                id="auditOnlyToggle"
-                label="Audit log only"
-                checked={$target === 'audit'}
-                on:change={toggleTarget}
-            />
+<div class="log-page">
+    <div class="page-summary-bar d-flex align-items-center justify-content-between">
+        <h1>
+        {#if filterKind === 'user'}
+            user audit log: UID <code>{params?.id}</code>
+        {:else if filterKind === 'access-role'}
+            access role audit log: ID <code>{params?.id}</code>
+        {:else if filterKind === 'admin-role'}
+            admin role audit log: ID <code>{params?.id}</code>
+        {:else}
+            log
         {/if}
+        </h1>
+        <div class="d-flex align-items-center gap-3">
+            {#if !filterKind}
+                <Input
+                    type="switch"
+                    id="auditOnlyToggle"
+                    label="Audit log only"
+                    checked={$target === 'audit'}
+                    on:change={toggleTarget}
+                />
+            {/if}
+        </div>
     </div>
+
+    {#key `${$target}-${filterKind}-${params?.id}`}
+        <LogViewer filters={filters} />
+    {/key}
 </div>
 
-{#key `${$target}-${filterKind}-${params?.id}`}
-    <LogViewer filters={filters} />
-{/key}
+<style lang="scss">
+    .log-page {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        min-height: 0;
+    }
+</style>


### PR DESCRIPTION
## Summary

Fixes a layout regression where the Config page nav items appeared vertically centered instead of top-aligned.

## Cause

Commit d14be5d added `display: flex; flex-direction: column` to `<main>` in `App.svelte` for the Log page's virtualized table. This caused `margin: auto` on `.container-max-md` to center content vertically in flex context, breaking Config and all config sub-pages.

## Fix

- **`App.svelte`**: Remove `display: flex; flex-direction: column` from `main`
- **`Log.svelte`**: Wrap content in a `.log-page` flex column container scoped to the Log page only

## Screenshots
- beta version 
<img width="1337" height="1290" alt="Screenshot 2026-04-09 at 15 15 06" src="https://github.com/user-attachments/assets/779235ee-befc-4f8c-8023-786313acb20e" />

- fixed version
<img width="1317" height="1050" alt="image" src="https://github.com/user-attachments/assets/e4553f3d-78f3-4523-a36e-5a653bb15282" />
