### PR TITLE
Use constant time comparison for admin tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6844,6 +6844,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
+ "subtle",
  "time",
  "tokio",
  "tokio-tungstenite",

--- a/warpgate-protocol-http/Cargo.toml
+++ b/warpgate-protocol-http/Cargo.toml
@@ -34,6 +34,7 @@ warpgate-db-entities = { path = "../warpgate-db-entities", default-features = fa
 warpgate-web = { path = "../warpgate-web", default-features = false }
 warpgate-sso = { path = "../warpgate-sso", default-features = false }
 percent-encoding = { version = "2.1", default-features = false }
+subtle = "2"
 uuid.workspace = true
 regex.workspace = true
 url = { version = "2.4", default-features = false }

--- a/warpgate-protocol-http/src/common.rs
+++ b/warpgate-protocol-http/src/common.rs
@@ -11,6 +11,7 @@ use poem::web::{Data, Redirect};
 use poem::{Endpoint, EndpointExt, FromRequest, IntoResponse, Request, Response};
 use sea_orm::{ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter};
 use serde::{Deserialize, Serialize};
+use subtle::ConstantTimeEq;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 use warpgate_common::auth::{AuthState, AuthStateUserInfo, CredentialKind};
@@ -295,7 +296,17 @@ pub async fn inject_request_authorization<E: Endpoint + 'static>(
                 let token_from_header = token_from_header
                     .to_str()
                     .map_err(poem::error::BadRequest)?;
-                if Some(token_from_header) == ctx.services.admin_token.lock().await.as_deref() {
+                if ctx
+                    .services
+                    .admin_token
+                    .lock()
+                    .await
+                    .as_deref()
+                    .is_some_and(|admin_token| {
+                        // Use constant time comparison to prevent timing attacks
+                        admin_token.as_bytes().ct_eq(token_from_header.as_bytes()).into()
+                    })
+                {
                     Some(RequestAuthorization::AdminToken)
                 } else if let Some(user) = ctx
                     .services


### PR DESCRIPTION
This prevents a very hard but technically possible timing attack