### PR TITLE
fix(http): prioritize ?warpgate-target= query param over host-based domain binding

### DIFF
--- a/warpgate-protocol-http/src/catchall.rs
+++ b/warpgate-protocol-http/src/catchall.rs
@@ -112,10 +112,10 @@ async fn get_target_for_request(
         RequestAuthorization::Session(SessionAuthorization::User { username, .. }) => {
             need_role_auth = true;
 
-            selected_target_name = if let Some(ref rebound_target) = host_based_target_name {
-                Some(rebound_target.clone())
-            } else if let Some(warpgate_target) = params.warpgate_target {
+            selected_target_name = if let Some(warpgate_target) = params.warpgate_target {
                 Some(warpgate_target)
+            } else if let Some(ref rebound_target) = host_based_target_name {
+                Some(rebound_target.clone())
             } else {
                 session.get_target_name()
             };


### PR DESCRIPTION
### Problem         
When an HTTP target has an external_host matching the request's `Host` header, that domain binding overrides an explicit `?warpgate-target=X` query param. On a domain-bound host, clicking a different  target in the selection page bounces the user back to the domain-bound target - selection appears broken.
                                                                                                                                                                                                          
### Fix
Reorder precedence in get_target_for_request() for SessionAuthorization::User: explicit `?warpgate-target=` query param wins, then host-based external_host match, then session's last target. An explicit request should always win against an inferred one.