### PR TITLE
fix(1883): initialize auth when null on target edit page

### DIFF
--- a/warpgate-web/src/admin/config/targets/Target.svelte
+++ b/warpgate-web/src/admin/config/targets/Target.svelte
@@ -218,7 +218,15 @@
                 </div>
                 <div class="col">
                     <FormGroup floating label="Authenticate using">
-                        <select class="form-control" bind:value={target.options.auth!.kind}>
+                        <select class="form-control"
+                            value={target.options.auth?.kind ?? 'Password'}
+                            onchange={e => {
+                                const kind = (e.target as HTMLSelectElement).value
+                                target!.options.auth = kind === 'IamRole'
+                                    ? { kind: 'IamRole' }
+                                    : { kind: 'Password', password: target!.options.auth?.password ?? '' }
+                            }}
+                        >
                             <option value="Password">Password</option>
                             {#if $serverInfo?.runningOnEc2}
                                 <option value="IamRole">IAM Role (experimental)</option>
@@ -228,9 +236,15 @@
                 </div>
             </div>
 
-            {#if target.options.auth!.kind === 'Password'}
+            {#if target.options.auth === null || target.options.auth?.kind === 'Password'}
                 <FormGroup floating label="Password">
-                    <input class="form-control" type="password" autocomplete="off" bind:value={target.options.auth!.password} />
+                    <input class="form-control" type="password" autocomplete="off"
+                        placeholder={target.options.auth === null ? 'Enter new password to replace legacy value' : undefined}
+                        value={target.options.auth?.password ?? ''}
+                        oninput={e => {
+                            target!.options.auth = { kind: 'Password', password: (e.target as HTMLInputElement).value }
+                        }}
+                    />
                 </FormGroup>
             {/if}
 


### PR DESCRIPTION
Targets created via the deprecated `password` field (e.g. by the Terraform provider) have `auth=null`. The edit form crashed with "Cannot read properties of undefined (reading 'kind')" because the template assumed `auth` is always set for Postgres/MySQL targets.

Initialize `auth` to `{ kind: 'Password' }` after loading the target if it is null, so the form can render correctly.