### PR TITLE
feat: add jump host ssh option

### DIFF
--- a/warpgate-admin/src/api/ssh_connection_test.rs
+++ b/warpgate-admin/src/api/ssh_connection_test.rs
@@ -15,9 +15,14 @@ use crate::api::common::require_admin_permission;
 pub struct Api;
 
 #[derive(Object)]
+#[oai(rename_all = "camelCase")]
 struct CheckSshHostKeyRequest {
     host: String,
     port: u16,
+    username: Option<String>,
+    allow_insecure_algos: Option<bool>,
+    auth: Option<SSHTargetAuth>,
+    jump_host: Option<warpgate_common::SSHJumpHostOptions>,
 }
 
 #[derive(Object)]
@@ -55,11 +60,14 @@ impl Api {
             RCCommand::Connect(TargetSSHOptions {
                 host: body.host.clone(),
                 port: body.port,
-                username: String::new(),
-                allow_insecure_algos: None,
-                auth: SSHTargetAuth::Password(SshTargetPasswordAuth {
-                    password: String::new().into(),
+                username: body.username.clone().unwrap_or_default(),
+                allow_insecure_algos: body.allow_insecure_algos,
+                auth: body.auth.clone().unwrap_or_else(|| {
+                    SSHTargetAuth::Password(SshTargetPasswordAuth {
+                        password: String::new().into(),
+                    })
                 }),
+                jump_host: body.jump_host.clone(),
             }),
             None,
         ));
@@ -68,6 +76,10 @@ impl Api {
             let key = loop {
                 match handles.event_rx.recv().await {
                     Some(RCEvent::HostKeyReceived(key)) => break key,
+                    Some(RCEvent::HostKeyUnknown(key, reply)) => {
+                        let _ = reply.send(true);
+                        break key;
+                    },
                     Some(RCEvent::ConnectionError(err)) => return Err(anyhow::Error::from(err)),
                     Some(RCEvent::Error(err)) => return Err(err),
                     None => anyhow::bail!("Failed to connect to target"),

--- a/warpgate-common/src/config/target.rs
+++ b/warpgate-common/src/config/target.rs
@@ -26,7 +26,20 @@ impl Default for KubernetesTargetCertificateAuth {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, Object, Default)]
+#[oai(rename_all = "camelCase")]
+pub struct SSHJumpHostOptions {
+    pub host: String,
+    #[serde(default = "_default_ssh_port")]
+    pub port: u16,
+    #[serde(default = "_default_username")]
+    pub username: String,
+    #[serde(default)]
+    pub auth: SSHTargetAuth,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, Object)]
+#[oai(rename_all = "camelCase")]
 pub struct TargetSSHOptions {
     pub host: String,
     #[serde(default = "_default_ssh_port")]
@@ -37,6 +50,8 @@ pub struct TargetSSHOptions {
     pub allow_insecure_algos: Option<bool>,
     #[serde(default)]
     pub auth: SSHTargetAuth,
+    #[serde(default)]
+    pub jump_host: Option<SSHJumpHostOptions>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Union)]

--- a/warpgate-protocol-ssh/src/client/mod.rs
+++ b/warpgate-protocol-ssh/src/client/mod.rs
@@ -508,15 +508,106 @@ impl RemoteClient {
 
         let config = Arc::new(config);
 
-        let (event_tx, mut event_rx) = unbounded_channel();
-        let handler = ClientHandler {
-            ssh_options: ssh_options.clone(),
-            event_tx,
-            services: self.services.clone(),
-            session_id: self.id,
+        let (session, mut event_rx) = if let Some(jump_host) = &ssh_options.jump_host {
+            let jump_address_str = format!("{}:{}", jump_host.host, jump_host.port);
+            let jump_address = match jump_address_str
+                .to_socket_addrs()
+                .map_err(ConnectionError::Io)
+                .and_then(|mut x| x.next().ok_or(ConnectionError::Resolve))
+            {
+                Ok(address) => address,
+                Err(error) => {
+                    error!(?error, address=%jump_address_str, "Cannot resolve jump host address");
+                    self.set_disconnected();
+                    return Err(error);
+                }
+            };
+
+            info!(?jump_address, username = &jump_host.username[..], "Connecting to Jump Host");
+
+            let jump_ssh_options = TargetSSHOptions {
+                host: jump_host.host.clone(),
+                port: jump_host.port,
+                username: jump_host.username.clone(),
+                auth: jump_host.auth.clone(),
+                allow_insecure_algos: ssh_options.allow_insecure_algos,
+                jump_host: None,
+            };
+
+            let (jump_event_tx, jump_event_rx) = unbounded_channel();
+            let jump_handler = ClientHandler {
+                ssh_options: jump_ssh_options.clone(),
+                event_tx: jump_event_tx,
+                services: self.services.clone(),
+                session_id: self.id,
+            };
+
+            let fut_connect = russh::client::connect(config.clone(), jump_address, jump_handler);
+            let (jump_session, _jump_event_rx) = self.wait_for_connection(&jump_ssh_options, fut_connect, jump_event_rx, true).await?;
+
+            info!("Connected to Jump Host, opening direct-tcpip channel to target");
+            let channel = jump_session.channel_open_direct_tcpip(
+                ssh_options.host.clone(),
+                ssh_options.port as u32,
+                "localhost".to_string(),
+                0,
+            ).await.map_err(ConnectionError::Ssh)?;
+
+            let stream = channel.into_stream();
+
+            let (event_tx, event_rx) = unbounded_channel();
+            let handler = ClientHandler {
+                ssh_options: ssh_options.clone(),
+                event_tx,
+                services: self.services.clone(),
+                session_id: self.id,
+            };
+
+            info!(?address, username = &ssh_options.username[..], "Connecting to target via Jump Host");
+            let fut_connect = russh::client::connect_stream(config, stream, handler);
+            self.wait_for_connection(&ssh_options, fut_connect, event_rx, false).await?
+        } else {
+            let (event_tx, event_rx) = unbounded_channel();
+            let handler = ClientHandler {
+                ssh_options: ssh_options.clone(),
+                event_tx,
+                services: self.services.clone(),
+                session_id: self.id,
+            };
+
+            info!(?address, username = &ssh_options.username[..], "Connecting directly to target");
+            let fut_connect = russh::client::connect(config, address, handler);
+            self.wait_for_connection(&ssh_options, fut_connect, event_rx, false).await?
         };
 
-        let fut_connect = russh::client::connect(config, address, handler);
+        self.session = Some(Arc::new(Mutex::new(session)));
+
+        info!(?address, "Connected");
+
+        tokio::spawn({
+            let inner_event_tx = self.inner_event_tx.clone();
+            async move {
+                while let Some(e) = event_rx.recv().await {
+                    info!("{:?}", e);
+                    inner_event_tx.send(InnerEvent::ClientHandlerEvent(e))?;
+                }
+                Ok::<(), anyhow::Error>(())
+            }
+        }.instrument(Span::current()));
+
+        return Ok(())
+    }
+
+    async fn wait_for_connection<Fut>(
+        &mut self,
+        ssh_options: &TargetSSHOptions,
+        fut_connect: Fut,
+        mut event_rx: UnboundedReceiver<ClientHandlerEvent>,
+        is_jump_host: bool,
+    ) -> Result<(Handle<ClientHandler>, UnboundedReceiver<ClientHandlerEvent>), ConnectionError>
+    where
+        Fut: std::future::Future<Output = Result<Handle<ClientHandler>, ClientHandlerError>>,
+    {
         pin_mut!(fut_connect);
 
         loop {
@@ -524,10 +615,16 @@ impl RemoteClient {
                 Some(event) = event_rx.recv() => {
                     match event {
                         ClientHandlerEvent::HostKeyReceived(key) => {
-                            self.tx.send(RCEvent::HostKeyReceived(key)).map_err(|_| ConnectionError::Internal)?;
+                            if !is_jump_host {
+                                self.tx.send(RCEvent::HostKeyReceived(key)).map_err(|_| ConnectionError::Internal)?;
+                            }
                         }
                         ClientHandlerEvent::HostKeyUnknown(key, reply) => {
-                            self.tx.send(RCEvent::HostKeyUnknown(key, reply)).map_err(|_| ConnectionError::Internal)?;
+                            if is_jump_host {
+                                let _ = reply.send(true);
+                            } else {
+                                self.tx.send(RCEvent::HostKeyUnknown(key, reply)).map_err(|_| ConnectionError::Internal)?;
+                            }
                         }
                         _ => {}
                     }
@@ -551,157 +648,155 @@ impl RemoteClient {
                         }
                     };
 
-                    let mut auth_result = false;
-                    let mut auth_error_msg: Option<String> = None;
-                    match ssh_options.auth {
-                        SSHTargetAuth::Password(auth) => {
-                            let response = session
-                                    .authenticate_password(
-                                        ssh_options.username.clone(),
-                                        auth.password.expose_secret()
-                                    )
-                                    .await?;
-                            auth_result = self._handle_auth_result(
-                                &mut session,
-                                ssh_options.username.clone(),
-                                response
-                            ).await.unwrap_or(false);
-                            if auth_result {
-                                debug!(username=&ssh_options.username[..], "Authenticated with password");
-                            } else {
-                                auth_error_msg = Some("Password authentication was rejected by the SSH target".to_string());
-                            }
-                        }
-                        SSHTargetAuth::PublicKey(_) => {
-                            let best_hash = session.best_supported_rsa_hash().await?.flatten();
-                            #[allow(clippy::explicit_auto_deref)]
-                            let keys = load_keys(
-                                &*self.services.config.lock().await,
-                                &self.services.global_params,
-                                "client"
-                            )?;
-                            let allow_insecure_algos = ssh_options.allow_insecure_algos.unwrap_or(false);
-                            for key in keys {
-                                let key = Arc::new(key);
-                                if key.key_data().is_rsa() && best_hash.is_none() && !allow_insecure_algos {
-                                    info!("Skipping ssh-rsa (SHA1) key authentication since insecure SSH algos are not allowed for this target");
-                                    continue;
-                                }
-                                let key_str = key.public_key().to_openssh().map_err(russh::Error::from)?;
-                                let mut response  = session
-                                    .authenticate_publickey(
-                                        ssh_options.username.clone(),
-                                        PrivateKeyWithHashAlg::new(key.clone(), best_hash),
-                                    )
-                                    .await?;
+                    self.authenticate_session(
+                        &mut session,
+                        &ssh_options.host,
+                        &ssh_options.username,
+                        &ssh_options.auth,
+                        ssh_options.allow_insecure_algos.unwrap_or(false)
+                    ).await?;
 
-                                auth_result = self._handle_auth_result(
-                                    &mut session,
-                                    ssh_options.username.clone(),
-                                    response
-                                ).await.unwrap_or(false);
-
-                                if !auth_result && key.key_data().is_rsa() && best_hash.is_some() && allow_insecure_algos {
-                                    // Corner case: OpenSSH advertising rsa2-sha-* through server-sig-algs, but it being
-                                    // disabled via PubkeyAcceptedAlgorithms. So far the only case is our own test suite.
-                                    // In this case we retry with ssh-rsa (SHA1)
-                                    response = session
-                                        .authenticate_publickey(
-                                            ssh_options.username.clone(),
-                                            PrivateKeyWithHashAlg::new(key.clone(), None),
-                                        ).await?;
-
-                                    auth_result = self._handle_auth_result(
-                                        &mut session,
-                                        ssh_options.username.clone(),
-                                        response
-                                    ).await.unwrap_or(false);
-                                }
-
-                                if auth_result {
-                                    debug!(username=&ssh_options.username[..], key=%key_str, "Authenticated with key");
-                                    break;
-                                }
-                                auth_error_msg = Some("Public key authentication was rejected by the SSH target".into());
-                            }
-                        }
-                        SSHTargetAuth::IamRole(_) => {
-                            let instance_info = warpgate_aws::find_instance_by_ip(&ssh_options.host).await?;
-
-                            let key = load_preferred_key(
-                                &*self.services.config.lock().await,
-                                &self.services.global_params,
-                                "client"
-                            )?;
-
-                            let pub_key_str = key.public_key().to_openssh().map_err(russh::Error::from)?;
-
-                            // Push the public key via EC2 Instance Connect
-                            warpgate_aws::send_ssh_public_key(
-                                &instance_info.instance_id,
-                                &instance_info.availability_zone,
-                                &instance_info.region,
-                                &ssh_options.username,
-                                &pub_key_str,
-                            ).await?;
-
-                            // Now authenticate with this key (key is valid for 60 seconds)
-                            let key = Arc::new(key.clone());
-                            let best_hash = session.best_supported_rsa_hash().await?.flatten();
-                            let response = session
-                                .authenticate_publickey(
-                                    ssh_options.username.clone(),
-                                    PrivateKeyWithHashAlg::new(key.clone(), best_hash),
-                                )
-                                .await?;
-
-                            auth_result = self._handle_auth_result(
-                                &mut session,
-                                ssh_options.username.clone(),
-                                response
-                            ).await.unwrap_or(false);
-
-                            if auth_result {
-                                debug!(username=&ssh_options.username[..], "Authenticated via EC2 Instance Connect");
-                            }
-
-                            if !auth_result {
-                                auth_error_msg = Some("EC2 Instance Connect authentication was rejected by the SSH target".into());
-                            }
-                        }
-                    }
-
-                    if !auth_result {
-                        let reason = auth_error_msg.unwrap_or_else(|| "Authentication was rejected by the SSH target".to_string());
-                        error!(%reason, "Warpgate could not authenticate with SSH target");
-                        let _ = session
-                            .disconnect(russh::Disconnect::ByApplication, "", "")
-                            .await;
-                        return Err(ConnectionError::Authentication);
-                    }
-
-                    self.session = Some(Arc::new(Mutex::new(session)));
-
-                    info!(?address, "Connected");
-
-                    tokio::spawn({
-                        let inner_event_tx = self.inner_event_tx.clone();
-                        async move {
-                            while let Some(e) = event_rx.recv().await {
-                                info!("{:?}", e);
-                                inner_event_tx.send(InnerEvent::ClientHandlerEvent(e))?;
-                            }
-                            Ok::<(), anyhow::Error>(())
-                        }
-                    }.instrument(Span::current()));
-
-                    return Ok(())
+                    return Ok((session, event_rx));
                 }
             }
         }
     }
 
-    /// Handles an AuthResult from a password or public key authentication attempt.
+    async fn authenticate_session(
+        &self,
+        session: &mut Handle<ClientHandler>,
+        host: &str,
+        username: &str,
+        auth: &SSHTargetAuth,
+        allow_insecure_algos: bool,
+    ) -> Result<(), ConnectionError> {
+        let mut auth_result = false;
+        let mut auth_error_msg: Option<String> = None;
+        match auth {
+            SSHTargetAuth::Password(auth) => {
+                let response = session
+                        .authenticate_password(
+                            username.to_string(),
+                            auth.password.expose_secret()
+                        )
+                        .await?;
+                auth_result = self._handle_auth_result(
+                    session,
+                    username.to_string(),
+                    response
+                ).await.unwrap_or(false);
+                if auth_result {
+                    debug!(username=username, "Authenticated with password");
+                } else {
+                    auth_error_msg = Some("Password authentication was rejected by the SSH target".to_string());
+                }
+            }
+            SSHTargetAuth::PublicKey(_) => {
+                let best_hash = session.best_supported_rsa_hash().await?.flatten();
+                #[allow(clippy::explicit_auto_deref)]
+                let keys = load_keys(
+                    &*self.services.config.lock().await,
+                    &self.services.global_params,
+                    "client"
+                )?;
+                for key in keys {
+                    let key = Arc::new(key);
+                    if key.key_data().is_rsa() && best_hash.is_none() && !allow_insecure_algos {
+                        info!("Skipping ssh-rsa (SHA1) key authentication since insecure SSH algos are not allowed for this target");
+                        continue;
+                    }
+                    let key_str = key.public_key().to_openssh().map_err(russh::Error::from)?;
+                    let mut response  = session
+                        .authenticate_publickey(
+                            username.to_string(),
+                            PrivateKeyWithHashAlg::new(key.clone(), best_hash),
+                        )
+                        .await?;
+
+                    auth_result = self._handle_auth_result(
+                        session,
+                        username.to_string(),
+                        response
+                    ).await.unwrap_or(false);
+
+                    if !auth_result && key.key_data().is_rsa() && best_hash.is_some() && allow_insecure_algos {
+                        response = session
+                            .authenticate_publickey(
+                                username.to_string(),
+                                PrivateKeyWithHashAlg::new(key.clone(), None),
+                            ).await?;
+
+                        auth_result = self._handle_auth_result(
+                            session,
+                            username.to_string(),
+                            response
+                        ).await.unwrap_or(false);
+                    }
+
+                    if auth_result {
+                        debug!(username=username, key=%key_str, "Authenticated with key");
+                        break;
+                    }
+                    auth_error_msg = Some("Public key authentication was rejected by the SSH target".into());
+                }
+            }
+            SSHTargetAuth::IamRole(_) => {
+                let instance_info = warpgate_aws::find_instance_by_ip(host).await?;
+
+                let key = load_preferred_key(
+                    &*self.services.config.lock().await,
+                    &self.services.global_params,
+                    "client"
+                )?;
+
+                let pub_key_str = key.public_key().to_openssh().map_err(russh::Error::from)?;
+
+                // Push the public key via EC2 Instance Connect
+                warpgate_aws::send_ssh_public_key(
+                    &instance_info.instance_id,
+                    &instance_info.availability_zone,
+                    &instance_info.region,
+                    username,
+                    &pub_key_str,
+                ).await?;
+
+                // Now authenticate with this key (key is valid for 60 seconds)
+                let key = Arc::new(key.clone());
+                let best_hash = session.best_supported_rsa_hash().await?.flatten();
+                let response = session
+                    .authenticate_publickey(
+                        username.to_string(),
+                        PrivateKeyWithHashAlg::new(key.clone(), best_hash),
+                    )
+                    .await?;
+
+                auth_result = self._handle_auth_result(
+                    session,
+                    username.to_string(),
+                    response
+                ).await.unwrap_or(false);
+
+                if auth_result {
+                    debug!(username=username, "Authenticated via EC2 Instance Connect");
+                }
+
+                if !auth_result {
+                    auth_error_msg = Some("EC2 Instance Connect authentication was rejected by the SSH target".into());
+                }
+            }
+        }
+
+        if !auth_result {
+            let reason = auth_error_msg.unwrap_or_else(|| "Authentication was rejected by the SSH target".to_string());
+            error!(%reason, "Warpgate could not authenticate with SSH target");
+            let _ = session
+                .disconnect(russh::Disconnect::ByApplication, "", "")
+                .await;
+            return Err(ConnectionError::Authentication);
+        }
+
+        Ok(())
+    }
     /// If presented with an additional keyboard-interactive challenge it will respond with empty
     /// strings. This ensures optional 2fa is respected, where this extra challenge always happens.
     ///

--- a/warpgate-web/src/admin/config/targets/ssh/Options.svelte
+++ b/warpgate-web/src/admin/config/targets/ssh/Options.svelte
@@ -39,7 +39,66 @@
     </div>
 </div>
 
-<h4 class="mt-4">Authentication</h4>
+<h4 class="mt-4">Jump Host</h4>
+
+<div class="d-flex mb-3">
+    <Input
+        class="mb-0 me-2"
+        type="switch"
+        label="Use a Jump Host"
+        checked={!!options.jumpHost}
+        onchange={(e) => {
+            if (e.target.checked) {
+                options.jumpHost = {
+                    host: '',
+                    port: 22,
+                    username: '',
+                    auth: { kind: 'PublicKey' }
+                }
+            } else {
+                options.jumpHost = null
+            }
+            hostKeyCheckInvalidated = true
+        }} />
+</div>
+
+{#if options.jumpHost}
+<div class="border rounded p-3 mb-4 bg-body-tertiary">
+    <div class="row">
+        <div class="col-8">
+            <FormGroup floating label="Jump Host address">
+                <input class="form-control" bind:value={options.jumpHost.host} />
+            </FormGroup>
+        </div>
+        <div class="col-4">
+            <FormGroup floating label="Jump Host port">
+                <input class="form-control" type="number" bind:value={options.jumpHost.port} min="1" max="65535" step="1" />
+            </FormGroup>
+        </div>
+    </div>
+
+    <FormGroup floating label="Jump Host username">
+        <input class="form-control" bind:value={options.jumpHost.username} />
+    </FormGroup>
+
+    <div class="d-flex">
+        <FormGroup floating label="Authenticate using" class="w-100">
+            <select bind:value={options.jumpHost.auth.kind} class="form-control">
+                <option value="PublicKey">Warpgate's own private keys</option>
+                <option value="Password">Password</option>
+                {#if $serverInfo?.runningOnEc2}
+                    <option value="IamRole">IAM Role (experimental)</option>
+                {/if}
+            </select>
+        </FormGroup>
+        {#if options.jumpHost.auth.kind === 'Password'}
+            <FormGroup floating label="Password" class="w-100 ms-3">
+                <input class="form-control" type="password" autocomplete="off" bind:value={options.jumpHost.auth.password} />
+            </FormGroup>
+        {/if}
+    </div>
+</div>
+{/if}
 
 {#if $adminPermissions.targetsEdit}
 <div class="mb-3">

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate Web Admin",
-    "version": "v0.22.0-beta.6-6-gfde9e530-modified"
+    "version": "unknown"
   },
   "servers": [
     {
@@ -4028,6 +4028,18 @@
           "port": {
             "type": "integer",
             "format": "uint16"
+          },
+          "username": {
+            "type": "string"
+          },
+          "allowInsecureAlgos": {
+            "type": "boolean"
+          },
+          "auth": {
+            "$ref": "#/components/schemas/SSHTargetAuth"
+          },
+          "jumpHost": {
+            "$ref": "#/components/schemas/SSHJumpHostOptions"
           }
         }
       },
@@ -4987,6 +4999,31 @@
           }
         }
       },
+      "SSHJumpHostOptions": {
+        "type": "object",
+        "title": "SSHJumpHostOptions",
+        "required": [
+          "host",
+          "port",
+          "username",
+          "auth"
+        ],
+        "properties": {
+          "host": {
+            "type": "string"
+          },
+          "port": {
+            "type": "integer",
+            "format": "uint16"
+          },
+          "username": {
+            "type": "string"
+          },
+          "auth": {
+            "$ref": "#/components/schemas/SSHTargetAuth"
+          }
+        }
+      },
       "SSHKey": {
         "type": "object",
         "title": "SSHKey",
@@ -5566,11 +5603,14 @@
           "username": {
             "type": "string"
           },
-          "allow_insecure_algos": {
+          "allowInsecureAlgos": {
             "type": "boolean"
           },
           "auth": {
             "$ref": "#/components/schemas/SSHTargetAuth"
+          },
+          "jumpHost": {
+            "$ref": "#/components/schemas/SSHJumpHostOptions"
           }
         }
       },


### PR DESCRIPTION
Hi everyone,

When deploying Warpgate into our infrastructure, we faced a problem. We have multiple environments not sharing the same subnet. Each environment has a machine with a public ip that we are using as a "gateway" while the other machines only have private ips.

We didn't want to add complexity our maintenance process so having multiple Warpgate wasn't a solution.
We first tried to do ProxyJump using our client ssh config. It was working as expected but we lost a key feature : Session Recordings as Warpgate was just seeing a TCP flow.

What we wanted was the option to configure server side ProxyJump. This is a key feature for us to deploy Warpgate in our company. 

Before submitting a feature request, we wanted to see if it was possible.
To be honest, we aren't Rust developers so we used AI assistance during development.

We built it and deployed it on a test environment and our needs are 100% satisfied. We are now able to configure ProxyJump for a target, session recordings work perfectly.

We believe this feature could benefit the community.

Let me know if you have any questions or suggestions.

Kind regards,
Romain