### PR TITLE
Helm : Roll deployment when config or referenced secrets change

### DIFF
--- a/helm/warpgate/templates/_helpers.tpl
+++ b/helm/warpgate/templates/_helpers.tpl
@@ -51,6 +51,31 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Checksum of inputs that produce /data/warpgate.yaml: the override ConfigMap
+and, when config_env_var_replace is set, the resolved env Secret values.
+Empty when nothing applies or lookup is unavailable (helm template / dry-run).
+*/}}
+{{- define "warpgate.configChecksum" -}}
+{{- $configContent := "" -}}
+{{- if .Values.overrides_config -}}
+  {{- $configContent = include (print $.Template.BasePath "/configmap.yaml") . -}}
+{{- end -}}
+{{- $envParts := list -}}
+{{- if and .Values.config_env_var_replace .Values.setup.envFromSecret -}}
+  {{- range $key, $val := .Values.setup.envFromSecret -}}
+    {{- $ref := split "/" $val -}}
+    {{- $secret := lookup "v1" "Secret" $.Release.Namespace $ref._0 -}}
+    {{- if and $secret (hasKey ($secret.data | default dict) $ref._1) -}}
+      {{- $envParts = append $envParts (printf "%s=%s" $key (index $secret.data $ref._1)) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if or $configContent $envParts -}}
+{{- printf "%s\n%s" $configContent ($envParts | sortAlpha | join "\n") | sha256sum -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "warpgate.serviceAccountName" -}}

--- a/helm/warpgate/templates/deployment.yaml
+++ b/helm/warpgate/templates/deployment.yaml
@@ -18,9 +18,15 @@ spec:
       {{- include "warpgate.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- $configChecksum := include "warpgate.configChecksum" . }}
+      {{- if or $configChecksum .Values.podAnnotations }}
       annotations:
+        {{- if $configChecksum }}
+        checksum/config: {{ $configChecksum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "warpgate.labels" . | nindent 8 }}


### PR DESCRIPTION
## Problem

When `overrides_config` is edited (or when the contents of a Secret referenced by `setup.envFromSecret` change while `config_env_var_replace` is in use), `helm upgrade` correctly updates the ConfigMap on the Kubernetes side, but the Warpgate pod is not restarted. As a result, `/data/warpgate.yaml`, which is produced by the init container from the mounted ConfigMap and the substituted environment variables, keeps the old configuration until a manual rollout is triggered.

The reason is that none of these inputs are referenced in the pod template, so Kubernetes has nothing to reconcile.

## Fix

A `checksum/config` annotation is added to the pod template. Its value is a hash that aggregates two inputs:

- the rendered override ConfigMap, when `overrides_config` is set;
- the resolved values of the Secrets referenced by `setup.envFromSecret`, read via `lookup`, when `config_env_var_replace` is in use (this is the mode where those values are actually substituted into `warpgate.yaml` by the init container).


## Limitations

`lookup` returns nothing during `helm template` or `--dry-run`, so the annotation is simply omitted in those contexts; this has no impact on actual install or upgrade operations. In addition, Secret changes performed outside of a Helm cycle (for example via External Secrets) will not trigger a rollout on their own 