### PR TITLE
Fix #1558 - get username for API token

### DIFF
--- a/warpgate-protocol-http/src/api/info.rs
+++ b/warpgate-protocol-http/src/api/info.rs
@@ -242,7 +242,7 @@ impl Api {
 
         Ok(InstanceInfoResponse::Ok(Json(Info {
             version: auth_ctx.is_some().then(|| warpgate_version().to_string()),
-            username: session.get_username(),
+            username: auth_ctx.as_ref().and_then(|auth_ctx| auth_ctx.auth.username().map(ToString::to_string)),
             selected_target: session.get_target_name(),
             external_host,
             minimize_password_login: parameters.minimize_password_login,


### PR DESCRIPTION
fixes #1558 by grabbing the username from the authentication context instead of the session (which is not present when using an API Token)

I tested it on Linux