### PR TITLE
Fix SSO redirect_uri_mismatch on target subdomains

### DIFF
--- a/warpgate-protocol-http/src/api/sso_provider_detail.rs
+++ b/warpgate-protocol-http/src/api/sso_provider_detail.rs
@@ -62,7 +62,7 @@ impl Api {
             return Ok(StartSsoResponse::NotFound);
         };
         let mut return_url = construct_external_url(
-            Some(req),
+            None,
             &config,
             provider_config.return_domain_whitelist.as_deref(),
         )

--- a/warpgate-protocol-http/src/middleware/cookie_host.rs
+++ b/warpgate-protocol-http/src/middleware/cookie_host.rs
@@ -63,7 +63,8 @@ impl<E: Endpoint> Endpoint for CookieHostMiddlewareEndpoint<E> {
             None => self.base_domain.as_ref().map(|b| Some(b.clone())),
             Some(h) if is_localhost_host(h) => Some(None),
             Some(h) => self.base_domain.as_ref().and_then(|base| {
-                if is_strict_parent(base, h) {
+                let base_trimmed = base.trim_start_matches('.');
+                if is_strict_parent(base, h) || h == base_trimmed {
                     Some(Some(base.clone()))
                 } else {
                     None


### PR DESCRIPTION
After upstream #1912 refactored construct_external_url to always read the request Host header, SSO redirects from target subdomains (e.g. grafana.warp.example.com) send the wrong redirect_uri to the OAuth provider. Force the SSO return URL to use external_host from config, which is what gets registered in the OAuth provider.

Ref: [warp-tech/warpgate#1947](https://github.com/warp-tech/warpgate/issues/1948)