### PR TITLE
perf: find targets using defined queries instead of doing it in memory

### DIFF
--- a/warpgate-core/src/config_providers/db.rs
+++ b/warpgate-core/src/config_providers/db.rs
@@ -3,9 +3,10 @@ use std::sync::Arc;
 
 use data_encoding::BASE64;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, ModelTrait, QueryFilter,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseBackend, DatabaseConnection, EntityTrait, ModelTrait, QueryFilter,
     QueryOrder, Set,
 };
+use sea_orm::sea_query::Expr;
 use time::OffsetDateTime;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
@@ -262,6 +263,32 @@ impl ConfigProvider for DatabaseConfigProvider {
 
         let targets = entities::Target::Entity::find()
             .filter(entities::Target::Column::Name.eq(name))
+            .all(&*db)
+            .await?;
+
+        let targets: Result<Vec<Target>, _> = targets.into_iter().map(|t| t.try_into()).collect();
+
+        Ok(targets?)
+    }
+
+    async fn list_targets_by_hostname(&mut self, hostname: &str) -> Result<Vec<Target>, WarpgateError> {
+        let db: tokio::sync::MutexGuard<'_, DatabaseConnection> = self.db.lock().await;
+
+        // generate JSON filter query based on the underlying backend
+        let hostname_query = match db.get_database_backend() {
+            DatabaseBackend::MySql => {
+                Expr::cust("options->>'$.http.external_host'")
+            }
+            DatabaseBackend::Postgres => {
+                Expr::cust(r#"options->'http'->>'external_host'"#)
+            }
+            DatabaseBackend::Sqlite => {
+                Expr::cust(r#"json_extract(options, '$.http.external_host')"#)
+            }
+        };
+
+        let targets = entities::Target::Entity::find()
+            .filter(hostname_query.eq(hostname))
             .all(&*db)
             .await?;
 

--- a/warpgate-core/src/config_providers/db.rs
+++ b/warpgate-core/src/config_providers/db.rs
@@ -257,6 +257,19 @@ impl ConfigProvider for DatabaseConfigProvider {
         Ok(targets?)
     }
 
+    async fn list_targets_by_name(&mut self, name: &str) -> Result<Vec<Target>, WarpgateError> {
+        let db = self.db.lock().await;
+
+        let targets = entities::Target::Entity::find()
+            .filter(entities::Target::Column::Name.eq(name))
+            .all(&*db)
+            .await?;
+
+        let targets: Result<Vec<Target>, _> = targets.into_iter().map(|t| t.try_into()).collect();
+
+        Ok(targets?)
+    }
+
     async fn get_credential_policy(
         &mut self,
         username: &str,

--- a/warpgate-core/src/config_providers/mod.rs
+++ b/warpgate-core/src/config_providers/mod.rs
@@ -26,6 +26,8 @@ pub trait ConfigProvider {
 
     async fn list_targets(&mut self) -> Result<Vec<Target>, WarpgateError>;
 
+    async fn list_targets_by_name(&mut self, name: &str) -> Result<Vec<Target>, WarpgateError>;
+
     async fn validate_credential(
         &mut self,
         username: &str,

--- a/warpgate-core/src/config_providers/mod.rs
+++ b/warpgate-core/src/config_providers/mod.rs
@@ -28,6 +28,8 @@ pub trait ConfigProvider {
 
     async fn list_targets_by_name(&mut self, name: &str) -> Result<Vec<Target>, WarpgateError>;
 
+    async fn list_targets_by_hostname(&mut self, hostname: &str) -> Result<Vec<Target>, WarpgateError>;
+
     async fn validate_credential(
         &mut self,
         username: &str,

--- a/warpgate-protocol-http/src/catchall.rs
+++ b/warpgate-protocol-http/src/catchall.rs
@@ -78,16 +78,10 @@ async fn get_target_for_request(
             .config_provider
             .lock()
             .await
-            .list_targets()
+            .list_targets_by_hostname(host.as_str())
             .await?
-            .iter()
-            .filter_map(|t| match t.options {
-                TargetOptions::Http(ref options) => Some((t, options)),
-                _ => None,
-            })
-            .find(|(_, o)| o.external_host.as_deref() == Some(&host))
-            .map(|(t, _)| t.name.clone());
-
+            .first()
+            .map(|t| t.name.clone());
         if found.is_some() {
             debug!(
                 "Domain rebinding detected: host={} -> target={:?}",

--- a/warpgate-protocol-http/src/catchall.rs
+++ b/warpgate-protocol-http/src/catchall.rs
@@ -135,10 +135,9 @@ async fn get_target_for_request(
                 .config_provider
                 .lock()
                 .await
-                .list_targets()
+                .list_targets_by_name(target_name.as_str())
                 .await?
                 .iter()
-                .filter(|t| t.name == target_name)
                 .find_map(|t| match t.options {
                     TargetOptions::Http(ref options) => Some((t, options)),
                     _ => None,


### PR DESCRIPTION
## Description

This PR improves Warpgate's performance when the backend stores a large number of targets. Previously, when resolving the target associated with an incoming request, Warpgate would query the database for the complete list of targets and then perform the filtering in memory. This approach becomes increasingly inefficient as the number of stored targets grows.

With this change, the filtering is performed directly at the database level, reducing the amount of data retrieved and improving lookup performance. The filter by `hostname` inside the `options` JSON column is a little bit more complex because the query syntax varies based on the underlying backend. I have performed the test for the MySQL backend but I couldn't test it with neither Postgres or SQLite (this should be done).

As a potential future optimization, we could also add a database index on the `name` column of the targets table. In my own Warpgate instance, I have manually created this index and observed additional performance improvements for target lookups.

I'm not proficient with Rust so any improvement or suggestion is welcomed. 

## AI Usage

Choose the level of AI involvement for this PR. 

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded 
* [x] Human-designed, human-coded (except `hostname` filter queries for Postgres and SQLite)
