### PR TITLE
fix(db): change varchar fields to TEXT to avoid insertion errors

### DIFF
--- a/warpgate-db-migrations/src/lib.rs
+++ b/warpgate-db-migrations/src/lib.rs
@@ -50,7 +50,7 @@ mod m00045_role_default_flag;
 mod m00046_max_api_token_duration;
 mod m00047_record_scp;
 mod m00048_target_click_action;
-mod m00049_session_target_snapshot_text;
+mod m00049_text_columns;
 
 pub(crate) mod helpers;
 
@@ -108,7 +108,7 @@ impl MigratorTrait for Migrator {
             Box::new(m00046_max_api_token_duration::Migration),
             Box::new(m00047_record_scp::Migration),
             Box::new(m00048_target_click_action::Migration),
-            Box::new(m00049_session_target_snapshot_text::Migration),
+            Box::new(m00049_text_columns::Migration),
         ]
     }
 }

--- a/warpgate-db-migrations/src/lib.rs
+++ b/warpgate-db-migrations/src/lib.rs
@@ -50,6 +50,7 @@ mod m00045_role_default_flag;
 mod m00046_max_api_token_duration;
 mod m00047_record_scp;
 mod m00048_target_click_action;
+mod m00049_session_target_snapshot_text;
 
 pub(crate) mod helpers;
 
@@ -107,6 +108,7 @@ impl MigratorTrait for Migrator {
             Box::new(m00046_max_api_token_duration::Migration),
             Box::new(m00047_record_scp::Migration),
             Box::new(m00048_target_click_action::Migration),
+            Box::new(m00049_session_target_snapshot_text::Migration),
         ]
     }
 }

--- a/warpgate-db-migrations/src/m00002_create_session.rs
+++ b/warpgate-db-migrations/src/m00002_create_session.rs
@@ -13,6 +13,7 @@ pub mod session {
     pub struct Model {
         #[sea_orm(primary_key, auto_increment = false)]
         pub id: Uuid,
+        #[sea_orm(column_type = "Text")]
         pub target_snapshot: Option<String>,
         pub username: Option<String>,
         pub remote_address: String,

--- a/warpgate-db-migrations/src/m00004_create_known_host.rs
+++ b/warpgate-db-migrations/src/m00004_create_known_host.rs
@@ -13,6 +13,7 @@ pub mod known_host {
         pub host: String,
         pub port: i32,
         pub key_type: String,
+        #[sea_orm(column_type = "Text")]
         pub key_base64: String,
     }
 

--- a/warpgate-db-migrations/src/m00049_text_columns.rs
+++ b/warpgate-db-migrations/src/m00049_text_columns.rs
@@ -1,0 +1,58 @@
+use sea_orm::DbBackend;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let connection = manager.get_connection();
+        if connection.get_database_backend() != DbBackend::Sqlite {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Alias::new("sessions"))
+                        .modify_column(ColumnDef::new(Alias::new("target_snapshot")).text().null())
+                        .to_owned(),
+                )
+                .await?;
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Alias::new("known_hosts"))
+                        .modify_column(ColumnDef::new(Alias::new("key_base64")).text())
+                        .to_owned(),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let connection = manager.get_connection();
+        if connection.get_database_backend() != DbBackend::Sqlite {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Alias::new("sessions"))
+                        .modify_column(
+                            ColumnDef::new(Alias::new("target_snapshot"))
+                                .string()
+                                .null(),
+                        )
+                        .to_owned(),
+                )
+                .await?;
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Alias::new("known_hosts"))
+                        .modify_column(ColumnDef::new(Alias::new("key_base64")).string())
+                        .to_owned(),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description

This PR updates the definition of several database fields from `VARCHAR` to `TEXT`. Some of these fields can occasionally store content longer than 255 characters. Since VARCHAR(255) was being used, records exceeding that limit could cause insertion failures or data truncation issues depending on the database configuration.

## AI Usage

Choose the level of AI involvement for this PR. 

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded 
* [x] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)
