### PR TITLE
Feat: Bound SSH Web Approval for SSO users with Session Cookies With Expiry For Auto Approval without Prompt

### DIFF
--- a/tests/test_ssh_user_auth_web_session_fastpath.py
+++ b/tests/test_ssh_user_auth_web_session_fastpath.py
@@ -1,0 +1,240 @@
+"""
+E2E coverage for the ``active_web_session_ttl_seconds`` SSO option that lets
+an SSH ``WebUserApproval`` prompt be auto-satisfied when the same user already
+holds a fresh browser session (from the same IP).
+"""
+
+import subprocess
+import time
+from pathlib import Path
+from uuid import uuid4
+
+from .api_client import admin_client, sdk
+from .conftest import ProcessManager
+from .test_http_user_auth_oidc import (
+    _do_oidc_login,
+    _make_sso_provider_config,
+)
+from .util import alloc_port, wait_port
+
+
+OIDC_EMAIL = "sam.tailor@gmail.com"
+
+
+def _start_wg(processes, wg_http_port, oidc_port, *, ttl_seconds):
+    """Start warpgate with an SSO provider, optionally enabling the fast-path."""
+    sso_config = _make_sso_provider_config(oidc_port)
+    if ttl_seconds is not None:
+        sso_config["active_web_session_ttl_seconds"] = ttl_seconds
+    wg = processes.start_wg(
+        http_port=wg_http_port,
+        config_patch={
+            "sso_providers": [sso_config],
+            "external_host": "127.0.0.1",
+        },
+    )
+    wait_port(wg.http_port, for_process=wg.process, recv=False)
+    wait_port(wg.ssh_port, for_process=wg.process)
+    return wg
+
+
+def _provision(api, ssh_port, username):
+    role = api.create_role(sdk.RoleDataRequest(name=f"role-{uuid4()}"))
+    user = api.create_user(sdk.CreateUserRequest(username=username))
+    api.create_sso_credential(
+        user.id,
+        sdk.NewSsoCredential(email=OIDC_EMAIL, provider="test-oidc"),
+    )
+    api.add_user_role(user.id, role.id)
+    api.update_user(
+        user.id,
+        sdk.UserDataRequest(
+            username=user.username,
+            credential_policy=sdk.UserRequireCredentialsPolicy(
+                ssh=[sdk.CredentialKind.WEBUSERAPPROVAL],
+            ),
+        ),
+    )
+    target = api.create_target(
+        sdk.TargetDataRequest(
+            name=f"ssh-{uuid4()}",
+            options=sdk.TargetOptions(
+                sdk.TargetOptionsTargetSSHOptions(
+                    kind="Ssh",
+                    host="localhost",
+                    port=ssh_port,
+                    username="root",
+                    auth=sdk.SSHTargetAuth(
+                        sdk.SSHTargetAuthSshTargetPublicKeyAuth(kind="PublicKey")
+                    ),
+                )
+            ),
+        )
+    )
+    api.add_target_role(target.id, role.id)
+    return user, target
+
+
+def _start_ssh(processes, wg, user, target):
+    """Spawn an ssh client targeting wg, letting the client negotiate methods.
+
+    The user is provisioned with the ``WebUserApproval``-only credential
+    policy, so the client will fall through publickey/password and end up on
+    keyboard-interactive, where the fast-path (or the standard prompt) is
+    served.
+
+    Connects via ``127.0.0.1`` (not ``localhost``) so that the SSH peer's
+    address matches the IPv4 address the HTTP login was recorded against.
+    """
+    return processes.start_ssh_client(
+        f"{user.username}:{target.name}@127.0.0.1",
+        "-p",
+        str(wg.ssh_port),
+        "-o",
+        "IdentityFile=ssh-keys/id_ed25519",
+        "ls",
+        "/bin/sh",
+    )
+
+
+def _wait_for_pending(session, wg_url, attempts=40, delay=0.25):
+    """Poll the WebUserApproval pending-requests endpoint until non-empty."""
+    for _ in range(attempts):
+        resp = session.get(f"{wg_url}/@warpgate/api/auth/web-auth-requests")
+        if resp.status_code == 200:
+            pending = resp.json()
+            if pending:
+                return pending
+        time.sleep(delay)
+    return []
+
+
+class TestSshWebSessionFastPath:
+    def test_ssh_skipped_when_provider_ttl_set(
+        self,
+        processes: ProcessManager,
+        wg_c_ed25519_pubkey: Path,
+        timeout,
+    ):
+        """SSO web login should auto-satisfy the SSH WebUserApproval prompt."""
+        target_ssh_port = processes.start_ssh_server(
+            trusted_keys=[wg_c_ed25519_pubkey.read_text()]
+        )
+        wait_port(target_ssh_port)
+
+        wg_http_port = alloc_port()
+        oidc_port = processes.start_oidc_server(wg_http_port)
+        wg = _start_wg(processes, wg_http_port, oidc_port, ttl_seconds=300)
+        wg_url = f"https://127.0.0.1:{wg.http_port}"
+
+        with admin_client(wg_url) as api:
+            user, ssh_target = _provision(api, target_ssh_port, "sam_tailor")
+
+        # Drive the OIDC flow; this `touch`es active_web_sessions for the user.
+        _, resp = _do_oidc_login(wg_url, oidc_port)
+        assert resp.status_code in (302, 307)
+
+        ssh_client = _start_ssh(processes, wg, user, ssh_target)
+
+        # No prompt expected: SSH should connect and run `ls /bin/sh` directly.
+        stdout, _ = ssh_client.communicate(timeout=timeout)
+        assert ssh_client.returncode == 0, stdout
+        assert stdout == b"/bin/sh\n"
+
+    def test_ssh_still_prompts_when_provider_ttl_absent(
+        self,
+        processes: ProcessManager,
+        wg_c_ed25519_pubkey: Path,
+        timeout,
+    ):
+        """Without the new option, every SSH session must still request approval."""
+        target_ssh_port = processes.start_ssh_server(
+            trusted_keys=[wg_c_ed25519_pubkey.read_text()]
+        )
+        wait_port(target_ssh_port)
+
+        wg_http_port = alloc_port()
+        oidc_port = processes.start_oidc_server(wg_http_port)
+        wg = _start_wg(processes, wg_http_port, oidc_port, ttl_seconds=None)
+        wg_url = f"https://127.0.0.1:{wg.http_port}"
+
+        with admin_client(wg_url) as api:
+            user, ssh_target = _provision(api, target_ssh_port, "sam_tailor")
+
+        wg_session, resp = _do_oidc_login(wg_url, oidc_port)
+        assert resp.status_code in (302, 307)
+
+        ssh_client = _start_ssh(processes, wg, user, ssh_target)
+
+        # SSH should be sitting on a WebUserApproval prompt. Confirm by polling
+        # the authenticated `web-auth-requests` endpoint.
+        pending = _wait_for_pending(wg_session, wg_url)
+        assert pending, "expected at least one pending WebUserApproval"
+
+        approve = wg_session.post(
+            f"{wg_url}/@warpgate/api/auth/state/{pending[0]['id']}/approve"
+        )
+        assert approve.status_code == 200
+
+        # Release the "Press Enter when done" prompt and finish the SSH command.
+        ssh_client.stdin.write(b"\r\n")
+        ssh_client.stdin.flush()
+        stdout, _ = ssh_client.communicate(timeout=timeout)
+        assert ssh_client.returncode == 0, stdout
+        assert stdout == b"/bin/sh\n"
+
+    def test_logout_clears_fastpath(
+        self,
+        processes: ProcessManager,
+        wg_c_ed25519_pubkey: Path,
+        timeout,
+    ):
+        """After /auth/logout the in-memory entry must be forgotten.
+
+        We do not re-login (that would simply re-register the fast-path); we
+        only verify that the SSH attempt blocks waiting on browser approval
+        instead of being auto-accepted.
+        """
+        target_ssh_port = processes.start_ssh_server(
+            trusted_keys=[wg_c_ed25519_pubkey.read_text()]
+        )
+        wait_port(target_ssh_port)
+
+        wg_http_port = alloc_port()
+        oidc_port = processes.start_oidc_server(wg_http_port)
+        wg = _start_wg(processes, wg_http_port, oidc_port, ttl_seconds=300)
+        wg_url = f"https://127.0.0.1:{wg.http_port}"
+
+        with admin_client(wg_url) as api:
+            user, ssh_target = _provision(api, target_ssh_port, "sam_tailor")
+
+        wg_session, resp = _do_oidc_login(wg_url, oidc_port)
+        assert resp.status_code in (302, 307)
+
+        # Sanity check: the fresh login enables the fast-path.
+        ssh_pre = _start_ssh(processes, wg, user, ssh_target)
+        stdout_pre, _ = ssh_pre.communicate(timeout=timeout)
+        assert ssh_pre.returncode == 0, stdout_pre
+
+        # After logout the in-memory entry must be cleared.
+        logout = wg_session.post(f"{wg_url}/@warpgate/api/auth/logout")
+        assert logout.status_code in (200, 201, 204), logout.text
+
+        ssh_client = _start_ssh(processes, wg, user, ssh_target)
+
+        # SSH must NOT auto-accept; it should be blocked on the keyboard-
+        # interactive "Press Enter when done" prompt. We don't approve it --
+        # we just verify it is still running after a brief grace period and
+        # then terminate it.
+        time.sleep(2)
+        assert ssh_client.poll() is None, (
+            "ssh exited without WebUserApproval; "
+            "fast-path likely fired after logout"
+        )
+
+        ssh_client.terminate()
+        try:
+            ssh_client.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            ssh_client.kill()
+            ssh_client.communicate(timeout=5)

--- a/warpgate-core/src/active_web_sessions.rs
+++ b/warpgate-core/src/active_web_sessions.rs
@@ -1,0 +1,134 @@
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::time::{Duration, Instant};
+
+struct Entry {
+    at: Instant,
+    ttl: Duration,
+    ip: IpAddr,
+}
+
+impl Entry {
+    fn is_fresh(&self) -> bool {
+        self.at.elapsed() <= self.ttl
+    }
+}
+
+fn canonical_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => IpAddr::V4(v4),
+            None => IpAddr::V6(v6),
+        },
+        v4 => v4,
+    }
+}
+
+#[derive(Default)]
+pub struct ActiveWebSessions {
+    by_user: HashMap<String, Entry>,
+}
+
+impl ActiveWebSessions {
+    pub fn touch(&mut self, username: &str, ttl: Duration, ip: IpAddr) {
+        self.by_user.insert(
+            username.to_string(),
+            Entry {
+                at: Instant::now(),
+                ttl,
+                ip: canonical_ip(ip),
+            },
+        );
+    }
+
+    pub fn forget(&mut self, username: &str) {
+        self.by_user.remove(username);
+    }
+
+    pub fn has_fresh(&self, username: &str, ip: IpAddr) -> bool {
+        let ip = canonical_ip(ip);
+        self.by_user
+            .get(username)
+            .map(|e| e.is_fresh() && e.ip == ip)
+            .unwrap_or(false)
+    }
+
+    pub fn vacuum(&mut self) {
+        self.by_user.retain(|_, e| e.is_fresh());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    const MIN: Duration = Duration::from_secs(60);
+    const NS: Duration = Duration::from_nanos(1);
+    const IP1: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    const IP2: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+    #[test]
+    fn matches_same_ip() {
+        let mut s = ActiveWebSessions::default();
+        s.touch("ssh.user", MIN, IP1);
+        assert!(s.has_fresh("ssh.user", IP1));
+    }
+
+    #[test]
+    fn rejects_different_ip() {
+        let mut s = ActiveWebSessions::default();
+        s.touch("ssh.user", MIN, IP1);
+        assert!(!s.has_fresh("ssh.user", IP2));
+    }
+
+    #[test]
+    fn rejects_unknown_user() {
+        let mut s = ActiveWebSessions::default();
+        s.touch("ssh.user", MIN, IP1);
+        assert!(!s.has_fresh("ssh.unknown", IP1));
+    }
+
+    #[test]
+    fn expires_after_ttl() {
+        let mut s = ActiveWebSessions::default();
+        s.touch("ssh.user", NS, IP1);
+        assert!(!s.has_fresh("ssh.user", IP1));
+    }
+
+    #[test]
+    fn touch_overrides_ip_and_ttl() {
+        let mut s = ActiveWebSessions::default();
+        s.touch("ssh.user", NS, IP1);
+        s.touch("ssh.user", MIN, IP2);
+        assert!(!s.has_fresh("ssh.user", IP1));
+        assert!(s.has_fresh("ssh.user", IP2));
+    }
+
+    #[test]
+    fn vacuum_drops_stale() {
+        let mut s = ActiveWebSessions::default();
+        s.touch("ssh.user", NS, IP1);
+        s.vacuum();
+        assert!(!s.has_fresh("ssh.user", IP1));
+    }
+
+    #[test]
+    fn forget_drops_entry() {
+        let mut s = ActiveWebSessions::default();
+        s.touch("ssh.user", MIN, IP1);
+        s.forget("ssh.user");
+        assert!(!s.has_fresh("ssh.user", IP1));
+    }
+
+    #[test]
+    fn ipv4_mapped_ipv6_matches_ipv4() {
+        use std::net::Ipv6Addr;
+        let mut s = ActiveWebSessions::default();
+        // Stored over a dual-stack IPv6 socket as ::ffff:10.0.0.1
+        let mapped = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x0a00, 0x0001));
+        s.touch("ssh.user", MIN, mapped);
+        // Looked up with the plain IPv4 form -> must still match.
+        assert!(s.has_fresh("ssh.user", IP1));
+    }
+}

--- a/warpgate-core/src/lib.rs
+++ b/warpgate-core/src/lib.rs
@@ -1,3 +1,4 @@
+mod active_web_sessions;
 pub mod auth;
 mod auth_state_store;
 mod config_providers;
@@ -11,6 +12,7 @@ pub mod recordings;
 mod services;
 mod state;
 pub mod ticket_requests;
+pub use active_web_sessions::ActiveWebSessions;
 pub use auth_state_store::*;
 pub use config_providers::*;
 pub use data::*;

--- a/warpgate-core/src/services.rs
+++ b/warpgate-core/src/services.rs
@@ -9,7 +9,7 @@ use warpgate_common::{GlobalParams, WarpgateConfig};
 use crate::db::{connect_to_db, populate_db};
 use crate::rate_limiting::RateLimiterRegistry;
 use crate::recordings::SessionRecordings;
-use crate::{AuthStateStore, ConfigProviderEnum, DatabaseConfigProvider, State};
+use crate::{ActiveWebSessions, AuthStateStore, ConfigProviderEnum, DatabaseConfigProvider, State};
 
 #[derive(Clone)]
 pub struct Services {
@@ -21,6 +21,7 @@ pub struct Services {
     pub auth_state_store: Arc<Mutex<AuthStateStore>>,
     pub admin_token: Arc<Mutex<Option<String>>>,
     pub rate_limiter_registry: Arc<Mutex<RateLimiterRegistry>>,
+    pub active_web_sessions: Arc<Mutex<ActiveWebSessions>>,
     pub global_params: Arc<GlobalParams>,
 }
 
@@ -57,6 +58,17 @@ impl Services {
         rate_limiter_registry.refresh().await?;
         let rate_limiter_registry = Arc::new(Mutex::new(rate_limiter_registry));
 
+        let active_web_sessions = Arc::new(Mutex::new(ActiveWebSessions::default()));
+        tokio::spawn({
+            let active_web_sessions = active_web_sessions.clone();
+            async move {
+                loop {
+                    active_web_sessions.lock().await.vacuum();
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                }
+            }
+        });
+
         Ok(Self {
             db: db.clone(),
             recordings,
@@ -66,6 +78,7 @@ impl Services {
             config_provider,
             auth_state_store,
             admin_token: Arc::new(Mutex::new(admin_token)),
+            active_web_sessions,
             global_params: Arc::new(params),
         })
     }

--- a/warpgate-protocol-http/src/api/auth.rs
+++ b/warpgate-protocol-http/src/api/auth.rs
@@ -255,8 +255,16 @@ impl Api {
     async fn api_auth_logout(
         &self,
         session: &Session,
+        ctx: Data<&UnauthenticatedRequestContext>,
         session_middleware: Data<&Arc<Mutex<SessionStore>>>,
     ) -> poem::Result<LogoutResponse> {
+        if let Some(SessionAuthorization::User { username, .. }) = session.get_auth() {
+            ctx.services()
+                .active_web_sessions
+                .lock()
+                .await
+                .forget(&username);
+        }
         logout(session, &mut *session_middleware.lock().await);
         Ok(LogoutResponse::Success)
     }

--- a/warpgate-protocol-http/src/api/sso_provider_list.rs
+++ b/warpgate-protocol-http/src/api/sso_provider_list.rs
@@ -13,6 +13,7 @@ use warpgate_common::WarpgateError;
 use warpgate_common::auth::{AuthCredential, AuthResult};
 use warpgate_common_http::auth::UnauthenticatedRequestContext;
 use warpgate_common_http::ext::construct_external_url;
+use warpgate_common_http::SessionAuthorization;
 use warpgate_core::ConfigProvider;
 use warpgate_core::auth::validate_and_add_credential;
 use warpgate_sso::{RoleMapping, SsoClient, SsoInternalProviderConfig};
@@ -315,7 +316,22 @@ impl Api {
         }
 
         if let AuthResult::Accepted { user_info } = state.verify() {
+            let username_for_ttl = user_info.username.clone();
             authorize_session(req, &ctx, user_info).await?;
+            if let (Some(secs), Some(ip)) = (
+                provider_config.active_web_session_ttl_seconds,
+                remote_ip,
+            ) {
+                ctx.services()
+                    .active_web_sessions
+                    .lock()
+                    .await
+                    .touch(
+                        &username_for_ttl,
+                        std::time::Duration::from_secs(secs),
+                        ip,
+                    );
+            }
             state.emit_authenticated_event_once();
             let state_id = *state.id();
             drop(state);
@@ -455,6 +471,13 @@ impl Api {
         let client = SsoClient::new(provider_config.provider.clone())?;
         let logout_url = client.logout(state.token, return_url).await?;
 
+        if let Some(SessionAuthorization::User { username, .. }) = session.get_auth() {
+            ctx.services()
+                .active_web_sessions
+                .lock()
+                .await
+                .forget(&username);
+        }
         logout(session, &mut *session_middleware.lock().await);
 
         Ok(StartSloResponse::Ok(Json(StartSloResponseParams {

--- a/warpgate-protocol-http/src/common.rs
+++ b/warpgate-protocol-http/src/common.rs
@@ -292,6 +292,7 @@ pub async fn authorize_session(
         .await
         .set_user_info(user_info.clone())
         .await?;
+
     session.set_auth(SessionAuthorization::User {
         user_id: user_info.id,
         username: user_info.username,

--- a/warpgate-protocol-ssh/src/server/session.rs
+++ b/warpgate-protocol-ssh/src/server/session.rs
@@ -1703,7 +1703,7 @@ impl ServerSession {
                 let mut auth_instructions = String::new();
                 let mut auth_prompts = vec![];
 
-                let Some(auth_state) = self.auth_state.as_ref() else {
+                let Some(auth_state) = self.auth_state.as_ref().cloned() else {
                     return Ok(russh::server::Auth::Reject {
                         proceed_with_methods: None,
                         partial_success: false,
@@ -1722,6 +1722,37 @@ impl ServerSession {
                 }
 
                 if kinds.contains(&CredentialKind::WebUserApproval) {
+                    let username = auth_state.lock().await.user_info().username.clone();
+                    let has_web_session = self
+                        .services
+                        .active_web_sessions
+                        .lock()
+                        .await
+                        .has_fresh(&username, self.remote_address.ip());
+
+                    if has_web_session {
+                        let auth_id = {
+                            let mut state = auth_state.lock().await;
+                            state.add_valid_credential(AuthCredential::WebUserApproval);
+                            *state.id()
+                        };
+                        info!(
+                            user = %username,
+                            "Auto-approving SSH WebUserApproval via active browser session"
+                        );
+                        if let AuthResult::Accepted { .. } =
+                            self.try_auth_lazy(&selector, None).await?
+                        {
+                            self.services
+                                .auth_state_store
+                                .lock()
+                                .await
+                                .complete(&auth_id)
+                                .await;
+                            return Ok(russh::server::Auth::Accept);
+                        }
+                    }
+
                     let identification_string =
                         auth_state.lock().await.identification_string().to_owned();
 

--- a/warpgate-sso/src/config.rs
+++ b/warpgate-sso/src/config.rs
@@ -79,6 +79,11 @@ pub struct SsoProviderConfig {
     /// Keys: "http", "ssh", "mysql", "postgres"
     /// Values: list of credential kinds e.g. ["sso"], ["web"], []
     pub default_credential_policy: Option<serde_json::Value>,
+    /// How long (seconds) a successful SSO web login should be trusted to
+    /// auto-approve subsequent SSH `WebUserApproval` prompts for the same user
+    /// **from the same source IP**. If unset, every SSH session continues to
+    /// require explicit browser approval.
+    pub active_web_session_ttl_seconds: Option<u64>,
 }
 
 impl SsoProviderConfig {


### PR DESCRIPTION
## Description
Description
Add an opt-in SSO-driven fast-path that lets a user skip the per-session [WebUserApproval]. SSH prompt when they already hold a fresh browser cookie session from the same IP.

Why: 
Today, every SSH connection that resolves to a [WebUserApproval]  policy requires the user to click "Approve" in a browser and type the matching security code. For organisations that have already authenticated the user via SSO in the web UI, that extra round-trip is noisy and adds no security signal. There was no way to lower friction without weakening other protocols (Postgres/MySQL/HTTP still need the prompt).

What:

1. New per-provider YAML field active_web_session_ttl_seconds (integer, seconds) on each entry in sso_providers. Omit it and behaviour is unchanged — every SSH session still prompts for browser approval. Set it to enable the fast-path for users who authenticate through that provider, for that many seconds after their SSO login.
2. New in-memory registry, ActiveWebSessions, attached to Services. It maps username to (created_at, ttl, source_ip) and is vacuumed every 60 seconds by a background task.
3.  On successful SSO callback, when a user finishes the OIDC flow Warpgate records an entry in the registry with that request's source IP and the provider's configured TTL.
4.  On SSH keyboard-interactive auth, if the user's credential policy needs WebUserApproval, Warpgate first checks the registry for a fresh entry that matches both the username and the SSH client's source IP. On hit it marks WebUserApproval satisfied, completes the auth state, and accepts the SSH session with no prompt. On miss it falls back to the existing browser approval flow unchanged.
5.  On /auth/logout and /sso/logout, the user's registry entry is removed, so the next SSH attempt prompts again.

Config example

```
sso_providers:
- name: okta
provider:
type: custom
client_id: ...
client_secret: ...
issuer_url: https://example.okta.com
# New parameter: enables the SSH WebUserApproval fast-path for 5 minutes
# after a successful SSO web login, from the same source IP only.
active_web_session_ttl_seconds: 300
```

Concerns:
People sharing same IP would still be able to login, but I am not sure here how I can add a fast path for same IP network, other than using a x059 certificate to handshake between the SSH and HTTP sessions.  The browser obtains the cert (via the authenticated SSO session), and the SSH client presents it (with the matching private key). The cert is the proof that the SSH client was authorized by the same browser that did SSO.


## AI Usage

* [X] Human-designed, human-coded (includes AI autocompletions and boilerplate gen and test generations)

