### PR TITLE
fixed #2005 - prefer external_hosts.http as return host in the embedd…

### DIFF
--- a/warpgate-web/src/embed/EmbeddedUI.svelte
+++ b/warpgate-web/src/embed/EmbeddedUI.svelte
@@ -19,7 +19,7 @@ if (localStorage.warpgateMenuLocation) {
 onMount(async () => {
     ready = true
     const info = await api.getInfo()
-    externalHost = info.externalHost
+    externalHost = `${info.externalHosts?.http ?? info.externalHost}:${info.ports.http ?? 443}`
 })
 
 function drag (e: MouseEvent) {


### PR DESCRIPTION
…ed menu, if set

## Description

...

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
