### PR TITLE
fixed #2039 - allow setting Postgres protocol version explicitly

### DIFF
--- a/warpgate-common/src/config/target.rs
+++ b/warpgate-common/src/config/target.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use poem_openapi::{Object, Union};
+use poem_openapi::{Enum, Object, Union};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use warpgate_tls::TlsMode;
@@ -188,6 +188,17 @@ impl TargetMySqlOptions {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Default, Enum)]
+pub enum PostgresProtocolVersion {
+    #[serde(rename = "3.0")]
+    #[oai(rename = "3.0")]
+    V3_0,
+    #[default]
+    #[serde(rename = "3.2")]
+    #[oai(rename = "3.2")]
+    V3_2,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, Object)]
 pub struct TargetPostgresOptions {
     #[serde(default = "_default_empty_string")]
@@ -215,6 +226,9 @@ pub struct TargetPostgresOptions {
 
     #[serde(default)]
     pub default_database_name: Option<String>,
+
+    #[serde(default)]
+    pub protocol_version: Option<PostgresProtocolVersion>,
 }
 
 impl TargetPostgresOptions {

--- a/warpgate-protocol-postgres/src/session.rs
+++ b/warpgate-protocol-postgres/src/session.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 use warpgate_common::auth::{
     AuthCredential, AuthResult, AuthSelector, AuthStateUserInfo, CredentialKind,
 };
-use warpgate_common::{Secret, TargetOptions, TargetPostgresOptions};
+use warpgate_common::{PostgresProtocolVersion, Secret, TargetOptions, TargetPostgresOptions};
 use warpgate_common_http::ext::construct_external_url;
 use warpgate_core::auth::validate_and_add_credential;
 use warpgate_core::{
@@ -414,10 +414,15 @@ impl<S: AsyncRead + AsyncWrite + Send + Unpin> PostgresSession<S> {
         startup: pgwire::messages::startup::Startup,
         options: TargetPostgresOptions,
     ) -> Result<(), PostgresError> {
+        let target_protocol_version = match options.protocol_version.unwrap_or_default() {
+            PostgresProtocolVersion::V3_0 => ProtocolVersion::PROTOCOL3_0,
+            PostgresProtocolVersion::V3_2 => ProtocolVersion::PROTOCOL3_2,
+        };
+
         let mut client = match PostgresClient::connect(
             &options,
             ConnectionOptions {
-                protocol_version: ProtocolVersion::PROTOCOL3_2,
+                protocol_version: target_protocol_version,
                 parameters: startup.parameters,
             },
         )

--- a/warpgate-web/src/admin/config/targets/Target.svelte
+++ b/warpgate-web/src/admin/config/targets/Target.svelte
@@ -38,6 +38,9 @@
             api.getTarget({ id: params.id }),
             api.listTargetGroups(),
         ])
+        if (target.options.kind === 'Postgres') {
+            target.options.protocolVersion ??= '3.2'
+        }
     }
 
     async function loadRoles () {
@@ -354,6 +357,16 @@
             {#if target.options.kind === 'MySql' || target.options.kind === 'Postgres'}
                 <Section id="advanced" title="Advanced">
                     {#if target.options.kind === 'Postgres'}
+                        <FormGroup floating label="Protocol version">
+                            <select class="form-control" bind:value={target.options.protocolVersion}>
+                                <option value="3.2">3.2</option>
+                                <option value="3.0">3.0</option>
+                            </select>
+                            <small class="form-text text-muted">
+                                Postgres protocol version for the target connection. You might have to choose 3.0 here for some non-compliant Postgres proxies that do not implement automatic version negotiation.
+                            </small>
+                        </FormGroup>
+
                         <FormGroup floating label="Idle timeout">
                             <input
                                 class="form-control"

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate Web Admin",
-    "version": "v0.24.0-30-gcc876528-modified"
+    "version": "v0.25.3-modified"
   },
   "servers": [
     {
@@ -5176,6 +5176,13 @@
           "MissingSpecial"
         ]
       },
+      "PostgresProtocolVersion": {
+        "type": "string",
+        "enum": [
+          "3.0",
+          "3.2"
+        ]
+      },
       "Recording": {
         "type": "object",
         "title": "Recording",
@@ -5859,6 +5866,9 @@
           },
           "default_database_name": {
             "type": "string"
+          },
+          "protocol_version": {
+            "$ref": "#/components/schemas/PostgresProtocolVersion"
           }
         }
       },

--- a/warpgate-web/src/gateway/lib/openapi-schema.json
+++ b/warpgate-web/src/gateway/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate HTTP proxy",
-    "version": "v0.24.0-30-gcc876528-modified"
+    "version": "v0.25.3-modified"
   },
   "servers": [
     {


### PR DESCRIPTION
## Description

...

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
