### PR TITLE
fixed #1842 - tell the user when the session is closed due to inactivity

### DIFF
--- a/warpgate-protocol-ssh/src/client/mod.rs
+++ b/warpgate-protocol-ssh/src/client/mod.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::io;
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use bytes::Bytes;
@@ -539,7 +540,8 @@ impl RemoteClient {
         let mut config = russh::client::Config {
             preferred: algos,
             nodelay: true,
-            inactivity_timeout: Some(ssh_config.inactivity_timeout),
+            // Extra time for the "closing due to inactivity" message to be sent
+            inactivity_timeout: Some(ssh_config.inactivity_timeout + Duration::from_secs(10)),
             keepalive_interval: ssh_config.keepalive_interval,
             ..Default::default()
         };

--- a/warpgate-protocol-ssh/src/server/mod.rs
+++ b/warpgate-protocol-ssh/src/server/mod.rs
@@ -114,7 +114,8 @@ async fn _handle_connection(
         russh::server::Config {
             auth_rejection_time: Duration::from_secs(1),
             auth_rejection_time_initial: Some(Duration::from_secs(0)),
-            inactivity_timeout: Some(config.store.ssh.inactivity_timeout),
+            // Extra time for the "closing due to inactivity" message to be sent
+            inactivity_timeout: Some(config.store.ssh.inactivity_timeout + Duration::from_secs(10)),
             keepalive_interval: config.store.ssh.keepalive_interval,
             methods: get_allowed_auth_methods(&services).await?,
             keys: russh_config_init.keys.clone(),

--- a/warpgate-protocol-ssh/src/server/session.rs
+++ b/warpgate-protocol-ssh/src/server/session.rs
@@ -246,9 +246,22 @@ impl ServerSession {
             }
         })?;
 
+        let inactivity_timeout = services.config.lock().await.store.ssh.inactivity_timeout;
+
         Ok(async move {
-            while let Some(event) = this.get_next_event().await {
-                this.handle_event(event).await?;
+            loop {
+                let next_event_fut = this.get_next_event();
+                match tokio::time::timeout(inactivity_timeout, next_event_fut).await {
+                    Ok(Some(event)) => this.handle_event(event).await?,
+                    Ok(None) => break,
+                    Err(_) => {
+                        info!("Closing the session due to inactivity");
+                        let _ = this.emit_service_message("Closing the session due to inactivity");
+                        this.request_disconnect();
+                        this.disconnect_server().await;
+                        break;
+                    }
+                }
             }
             debug!("No more events");
             Ok::<_, anyhow::Error>(())


### PR DESCRIPTION
## Description

...

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
