### PR TITLE
 ci(docker): sign and attest (SBOM, provenance) the published image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -146,11 +146,27 @@ jobs:
             type=schedule
 
       - name: Create manifest list and push
+        id: push
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+          # Capture the immutable multi-arch index digest to attach signatures /
+          # attestations to (all tags above point at this same digest).
+          digest="$(docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} \
+            --format '{{ .Manifest.Digest }}')"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign the image (keyless)
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: cosign sign --yes --recursive "${IMAGE}@${DIGEST}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -170,3 +170,25 @@ jobs:
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           DIGEST: ${{ steps.push.outputs.digest }}
         run: cosign sign --yes --recursive "${IMAGE}@${DIGEST}"
+
+      - name: Generate SBOM (CycloneDX) from the published image
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          sbom-path: sbom.cdx.json
+          push-to-registry: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
## Description

### Context

This PR came from some issues (https://github.com/warp-tech/warpgate/issues/2080#issuecomment-4746071795) I was reading and the idea to add back signature, attestation, SBOM directly in the OCI image and maybe Vex ignore list (see below findings on this matter)

### Summary
Adds supply-chain metadata to `ghcr.io/warp-tech/warpgate`, attached to the merged multi-arch **index digest** as OCI referrers in the `merge` job:

- cosign keyless **signature**
- **CycloneDX SBOM** + **SLSA build-provenance** attestations

### Why
The image currently ships with no signature or attestations — provenance was disabled in #1255 because buildx's generation broke the multi-arch manifest. This adds the metadata back **without** re-enabling buildx provenance.

### How (and why it won't reopen #1255)
Everything is attached **after** `imagetools create`, against the captured index digest, as separate referrers — the manifest list itself is never touched, and the `build` job keeps `provenance: false` / `attests: ''`. The `merge` job already had the needed `id-token` / `attestations` / `packages: write`.

### Pieces (2 commits)
1. capture index digest + `cosign sign --recursive`
2. CycloneDX SBOM (syft) via `actions/attest-sbom` + `actions/attest-build-provenance`

### Note on VEX (intentionally left out)
I also prototyped an OpenVEX attestation but dropped it from this PR on purpose. VEX is **per-CVE**, so for base-image packages Warpgate doesn't use (e.g. GnuTLS — which can't be removed anyway, since `apt` depends on `libgnutls30`) it turns into a per-CVE maintenance work for little benefit. The mechanism is trivial to add later (one `cosign attest --type openvex` step + a JSON file) if a specific CVE is ever worth annotating — I think it just isn't worth the upkeep now. Recurring base-image CVE noise is better handled by the existing Dependabot base bumps, and longer term solution could be a distroless/static base.

### Tested
Validated end-to-end on a fork build ([run](https://github.com/mathieuHa/warpgate/actions/runs/27835173122)) publishing to `ghcr.io/mathieuha/warpgate`: the multi-arch image builds + pushes, and the `Sign` / `Attest SBOM` / `Attest build provenance` steps all succeed; the signature and attestations verify with `cosign verify` / `gh attestation verify`.

Verify on the real image with:

```bash
gh attestation verify oci://ghcr.io/warp-tech/warpgate:latest --repo warp-tech/warpgate \
  --predicate-type https://slsa.dev/provenance/v1
gh attestation verify oci://ghcr.io/warp-tech/warpgate:latest --repo warp-tech/warpgate \
  --predicate-type https://cyclonedx.org/bom
```
## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [x] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
