### PR TITLE
Terminate HTTP target WebSockets on logout

### DIFF
--- a/tests/test_http_websocket.py
+++ b/tests/test_http_websocket.py
@@ -1,6 +1,12 @@
 import ssl
+import time
+
 import requests
-from websocket import create_connection
+from websocket import (
+    WebSocketConnectionClosedException,
+    WebSocketTimeoutException,
+    create_connection,
+)
 from uuid import uuid4
 
 from .api_client import admin_client, sdk
@@ -58,4 +64,72 @@ class TestHTTPWebsocket:
         ws.send_binary(b"test")
         assert ws.recv() == b"test"
         ws.ping()
+        ws.close()
+
+    def test_logout_closes_connection(
+        self,
+        echo_server_port,
+        shared_wg: WarpgateProcess,
+    ):
+        url = f"https://localhost:{shared_wg.http_port}"
+        with admin_client(url) as api:
+            role = api.create_role(sdk.RoleDataRequest(name=f"role-{uuid4()}"))
+            user = api.create_user(sdk.CreateUserRequest(username=f"user-{uuid4()}"))
+            api.create_password_credential(
+                user.id, sdk.NewPasswordCredential(password="123")
+            )
+            api.add_user_role(user.id, role.id)
+            echo_target = api.create_target(sdk.TargetDataRequest(
+                name=f"echo-{uuid4()}",
+                options=sdk.TargetOptions(sdk.TargetOptionsTargetHTTPOptions(
+                    kind="Http",
+                    url=f"http://localhost:{echo_server_port}",
+                    tls=sdk.Tls(
+                        mode=sdk.TlsMode.DISABLED,
+                        verify=False,
+                    ),
+                )),
+            ))
+            api.add_target_role(echo_target.id, role.id)
+
+        session = requests.Session()
+        session.verify = False
+
+        response = session.post(
+            f"{url}/@warpgate/api/auth/login",
+            json={
+                "username": user.username,
+                "password": "123",
+            },
+        )
+        assert response.status_code // 100 == 2
+
+        cookies = session.cookies.get_dict()
+        cookie = "; ".join([f"{k}={v}" for k, v in cookies.items()])
+        ws = create_connection(
+            f"wss://localhost:{shared_wg.http_port}/socket?warpgate-target={echo_target.name}",
+            cookie=cookie,
+            sslopt={"cert_reqs": ssl.CERT_NONE},
+        )
+        ws.send("test")
+        assert ws.recv() == "test"
+
+        response = session.post(f"{url}/@warpgate/api/auth/logout")
+        assert response.status_code // 100 == 2
+
+        ws.settimeout(0.25)
+        deadline = time.monotonic() + 5
+        closed = False
+        while time.monotonic() < deadline:
+            try:
+                if ws.recv() == "":
+                    closed = True
+                    break
+            except WebSocketConnectionClosedException:
+                closed = True
+                break
+            except WebSocketTimeoutException:
+                continue
+
+        assert closed
         ws.close()

--- a/warpgate-protocol-http/src/proxy.rs
+++ b/warpgate-protocol-http/src/proxy.rs
@@ -7,12 +7,14 @@ use cookie::Cookie;
 use data_encoding::BASE64;
 use delegate::delegate;
 use futures::{StreamExt, TryStreamExt};
+use http::StatusCode;
 use http::header::HeaderName;
 use http::uri::{Authority, Scheme};
 use http::{HeaderValue, Uri};
 use poem::session::Session;
-use poem::web::websocket::WebSocket;
+use poem::web::{Data, websocket::WebSocket};
 use poem::{Body, FromRequest, IntoResponse, Request, Response};
+use tokio::sync::Mutex;
 use tokio_tungstenite::{Connector, connect_async_tls_with_config, tungstenite};
 use tracing::{debug, error, warn};
 use url::Url;
@@ -22,11 +24,14 @@ use warpgate_common::http_headers::{
 };
 use warpgate_common::{TargetHTTPOptions, WarpgateError, try_block};
 use warpgate_common_http::logging::{get_client_ip, log_request_result};
-use warpgate_common_http::{AuthenticatedRequestContext, SessionAuthorization};
+use warpgate_common_http::{
+    AuthenticatedRequestContext, RequestAuthorization, SessionAuthorization,
+};
 use warpgate_tls::{TlsMode, configure_tls_connector};
 use warpgate_web::lookup_built_file;
 
 use crate::common::SessionExt;
+use crate::session::SessionStore;
 
 static X_WARPGATE_USERNAME: HeaderName = HeaderName::from_static("x-warpgate-username");
 static X_WARPGATE_AUTHENTICATION_TYPE: HeaderName =
@@ -442,6 +447,20 @@ async fn proxy_ws_inner(
     ctx: &AuthenticatedRequestContext,
     options: &TargetHTTPOptions,
 ) -> poem::Result<impl IntoResponse> {
+    let session_middleware = Data::<&Arc<Mutex<SessionStore>>>::from_request_without_body(req)
+        .await?
+        .clone();
+    let session = <&Session>::from_request_without_body(req).await?;
+    let mut close_rx = session_middleware.lock().await.close_receiver_for(session);
+    if close_rx.is_none()
+        && matches!(
+            &ctx.auth,
+            RequestAuthorization::Session(SessionAuthorization::User { .. })
+        )
+    {
+        return Err(poem::Error::from_status(StatusCode::UNAUTHORIZED));
+    }
+
     let (authorization_header, uri) = extract_basic_auth(uri)?;
     let mut client_request = http::request::Builder::new()
         .uri(uri.clone())
@@ -494,7 +513,7 @@ async fn proxy_ws_inner(
             let (server_sink, server_source) = socket.split();
 
             if let Err(error) = {
-                let server_to_client =
+                let mut server_to_client =
                     tokio::spawn(pump_websocket(server_source, client_sink, |msg| {
                         Box::pin(async {
                             tracing::debug!("Server: {:?}", msg);
@@ -502,7 +521,7 @@ async fn proxy_ws_inner(
                         })
                     }));
 
-                let client_to_server =
+                let mut client_to_server =
                     tokio::spawn(pump_websocket(client_source, server_sink, |msg| {
                         Box::pin(async {
                             tracing::debug!("Client: {:?}", msg);
@@ -510,8 +529,47 @@ async fn proxy_ws_inner(
                         })
                     }));
 
-                server_to_client.await??;
-                client_to_server.await??;
+                let (server_finished, pump_result): (
+                    bool,
+                    Option<Result<anyhow::Result<()>, tokio::task::JoinError>>,
+                ) = tokio::select! {
+                    result = &mut server_to_client => {
+                        (true, Some(result))
+                    }
+                    result = &mut client_to_server => {
+                        (false, Some(result))
+                    }
+                    _ = async {
+                        match close_rx.as_mut() {
+                            Some(close_rx) => {
+                                let _ = close_rx.recv().await;
+                            }
+                            None => std::future::pending::<()>().await,
+                        }
+                    } => {
+                        (false, None)
+                    }
+                };
+
+                match pump_result {
+                    Some(result) if server_finished => {
+                        client_to_server.abort();
+                        let _ = client_to_server.await;
+                        result.context("server-to-client WebSocket pump task failed")??;
+                    }
+                    Some(result) => {
+                        server_to_client.abort();
+                        let _ = server_to_client.await;
+                        result.context("client-to-server WebSocket pump task failed")??;
+                    }
+                    None => {
+                        debug!("Closing WebSocket stream after HTTP session ended");
+                        server_to_client.abort();
+                        client_to_server.abort();
+                        let _ = server_to_client.await;
+                        let _ = client_to_server.await;
+                    }
+                }
                 debug!("Closing Websocket stream");
 
                 Ok::<_, anyhow::Error>(())

--- a/warpgate-protocol-http/src/session.rs
+++ b/warpgate-protocol-http/src/session.rs
@@ -6,7 +6,7 @@ use poem::session::{MemoryStorage, Session, SessionStorage};
 use poem::web::{Data, RemoteAddr};
 use poem::{FromRequest, Request};
 use serde_json::Value;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, broadcast};
 use tracing::info;
 use warpgate_common::SessionId;
 use warpgate_common_http::auth::UnauthenticatedRequestContext;
@@ -58,6 +58,7 @@ impl SessionStorage for SharedSessionStorage {
 
 pub struct SessionStore {
     session_handles: HashMap<SessionId, Arc<Mutex<WarpgateServerHandle>>>,
+    session_close_senders: HashMap<SessionId, broadcast::Sender<()>>,
     session_timestamps: HashMap<SessionId, Instant>,
     this: Weak<Mutex<Self>>,
 }
@@ -70,6 +71,7 @@ impl SessionStore {
         Arc::new_cyclic(|me| {
             Mutex::new(Self {
                 session_handles: HashMap::new(),
+                session_close_senders: HashMap::new(),
                 session_timestamps: HashMap::new(),
                 this: me.clone(),
             })
@@ -119,7 +121,9 @@ impl SessionStore {
         .await?;
 
         let id = server_handle.lock().await.id();
+        let (session_close_sender, _) = broadcast::channel(1);
         self.session_handles.insert(id, server_handle.clone());
+        self.session_close_senders.insert(id, session_close_sender);
 
         session.set(SESSION_ID_SESSION_KEY, id);
 
@@ -138,8 +142,7 @@ impl SessionStore {
                             }
                             info!(%id, "Removed HTTP session");
                             let mut that = this.lock().await;
-                            that.session_handles.remove(&id);
-                            that.session_timestamps.remove(&id);
+                            that.remove_session_by_id(id);
                         }
                     }
                 }
@@ -158,10 +161,19 @@ impl SessionStore {
             .and_then(|id| self.session_handles.get(&id).cloned())
     }
 
+    pub fn close_receiver_for(&self, session: &Session) -> Option<broadcast::Receiver<()>> {
+        session
+            .get::<SessionId>(SESSION_ID_SESSION_KEY)
+            .and_then(|id| {
+                self.session_close_senders
+                    .get(&id)
+                    .map(|sender| sender.subscribe())
+            })
+    }
+
     pub fn remove_session(&mut self, session: &Session) {
         if let Some(id) = session.get::<SessionId>(SESSION_ID_SESSION_KEY) {
-            self.session_handles.remove(&id);
-            self.session_timestamps.remove(&id);
+            self.remove_session_by_id(id);
         }
     }
 
@@ -174,8 +186,15 @@ impl SessionStore {
             }
         }
         for id in to_remove {
-            self.session_handles.remove(&id);
-            self.session_timestamps.remove(&id);
+            self.remove_session_by_id(id);
         }
+    }
+
+    fn remove_session_by_id(&mut self, id: SessionId) {
+        if let Some(sender) = self.session_close_senders.remove(&id) {
+            let _ = sender.send(());
+        }
+        self.session_handles.remove(&id);
+        self.session_timestamps.remove(&id);
     }
 }


### PR DESCRIPTION
## Description

Fixes #2106.

HTTP target WebSockets now subscribe to the owning HTTP session before the upstream WebSocket handshake starts. When logout or another session removal path removes that session, the proxy aborts both WebSocket pump tasks so the active target connection is torn down instead of staying usable after logout.

This also keeps ticket-based HTTP WebSocket access working: ticket sessions without a SessionStore close receiver are allowed through, while normal user sessions still require a tracked session handle.

Added regression coverage for an HTTP target WebSocket that echoes successfully, logs out through `/@warpgate/api/auth/logout`, then observes the WebSocket closing.

Validation:

* `git diff --check`
* `rustfmt --edition 2024 --check warpgate-protocol-http/src/session.rs warpgate-protocol-http/src/proxy.rs`
* `python3 -m py_compile tests/test_http_websocket.py`
* `RUSTC_BOOTSTRAP=1 CARGO_HOME=$PWD/../cargo-home CARGO_TARGET_DIR=$PWD/../cargo-target cargo check -p warpgate-protocol-http --all-features`
* `RUSTC_BOOTSTRAP=1 CARGO_HOME=$PWD/../cargo-home CARGO_TARGET_DIR=$PWD/../cargo-target cargo test -p warpgate-protocol-http --all-features`
* `RUSTC_BOOTSTRAP=1 CARGO_HOME=$PWD/../cargo-home CARGO_TARGET_DIR=$PWD/../cargo-target cargo clippy -p warpgate-protocol-http --all-features --no-deps`
* `RUSTC_BOOTSTRAP=1 CARGO_HOME=$PWD/../cargo-home cargo build --all-features`
* local smoke: start Warpgate, open HTTP target WebSocket, logout, verify the active WebSocket closes

Note: `cargo clippy -p warpgate-protocol-http --all-features --no-deps -- -D warnings` still fails on an existing warning in `warpgate-protocol-http/src/api/sso_provider_list.rs:358` (`clippy::iter_kv_map`), outside this PR's changes.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
