### PR TITLE
Add configurable groups_claim for custom OIDC providers

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -574,6 +574,13 @@
             "client_secret": {
               "type": "string"
             },
+            "groups_claim": {
+              "description": "OIDC claim to read group memberships from (e.g. \"groups\").\nIts values are mapped to roles via role_mappings / admin_role_mappings.\nWhen unset, the warpgate_roles / warpgate_admin_roles claims are used.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "issuer_url": {
               "type": "string"
             },

--- a/config-schema.json
+++ b/config-schema.json
@@ -568,18 +568,17 @@
                 "$ref": "#/$defs/RoleMapping"
               }
             },
+            "admin_roles_claim": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "client_id": {
               "type": "string"
             },
             "client_secret": {
               "type": "string"
-            },
-            "groups_claim": {
-              "description": "OIDC claim to read group memberships from (e.g. \"groups\").\nIts values are mapped to roles via role_mappings / admin_role_mappings.\nWhen unset, the warpgate_roles / warpgate_admin_roles claims are used.",
-              "type": [
-                "string",
-                "null"
-              ]
             },
             "issuer_url": {
               "type": "string"
@@ -592,6 +591,13 @@
               "additionalProperties": {
                 "$ref": "#/$defs/RoleMapping"
               }
+            },
+            "roles_claim": {
+              "description": "OIDC claim to read group memberships from (e.g. \"groups\").\nIts values are mapped to roles via role_mappings / admin_role_mappings.\nWhen unset, the warpgate_roles / warpgate_admin_roles claims are used.",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "scopes": {
               "type": "array",

--- a/tests/test_http_user_auth_oidc.py
+++ b/tests/test_http_user_auth_oidc.py
@@ -42,7 +42,8 @@ def _make_sso_provider_config(
     admin_role_mappings=None,
     extra_scopes=None,
     return_url_domain=None,
-    groups_claim=None,
+    roles_claim=None,
+    admin_roles_claim=None,
 ):
     """Build an ``sso_providers`` entry for warpgate config."""
     scopes = list(DEFAULT_OIDC_SCOPES)
@@ -59,8 +60,10 @@ def _make_sso_provider_config(
         provider["role_mappings"] = role_mappings
     if admin_role_mappings is not None:
         provider["admin_role_mappings"] = admin_role_mappings
-    if groups_claim is not None:
-        provider["groups_claim"] = groups_claim
+    if roles_claim is not None:
+        provider["roles_claim"] = roles_claim
+    if admin_roles_claim is not None:
+        provider["admin_roles_claim"] = admin_roles_claim
     sso_entry = {
         "name": "test-oidc",
         "label": "OIDC Test",
@@ -1012,7 +1015,7 @@ def _json_groups(value):
     return [{"Value": json.dumps(value), "ValueType": "json"}]
 
 
-def _run_groups_claim_test(
+def _run_roles_claim_test(
     processes,
     group_entries,
     *,
@@ -1034,7 +1037,8 @@ def _run_groups_claim_test(
         wg_http_port,
         oidc_port,
         auto_create_users=True,
-        groups_claim="groups",
+        roles_claim="groups",
+        admin_roles_claim="groups",
         role_mappings=role_mappings,
         admin_role_mappings=admin_role_mappings,
         extra_scopes=["groups"],
@@ -1062,7 +1066,7 @@ class TestHTTPUserAuthOIDCGroupsClaim:
     to access/admin roles via role_mappings / admin_role_mappings."""
 
     def test_access_role_mapping(self, echo_server_port, processes: ProcessManager):
-        access, admin = _run_groups_claim_test(
+        access, admin = _run_roles_claim_test(
             processes,
             _str_groups("grp-ssh"),
             role_mappings={"grp-ssh": "ssh-access-role"},
@@ -1073,7 +1077,7 @@ class TestHTTPUserAuthOIDCGroupsClaim:
 
     def test_admin_role_mapping(self, echo_server_port, processes: ProcessManager):
         # "warpgate:admin" is warpgate's built-in admin role (always present).
-        access, admin = _run_groups_claim_test(
+        access, admin = _run_roles_claim_test(
             processes,
             _str_groups("grp-admin"),
             admin_role_mappings={"grp-admin": "warpgate:admin"},
@@ -1084,7 +1088,7 @@ class TestHTTPUserAuthOIDCGroupsClaim:
     def test_combined_access_and_admin(
         self, echo_server_port, processes: ProcessManager
     ):
-        access, admin = _run_groups_claim_test(
+        access, admin = _run_roles_claim_test(
             processes,
             _str_groups("grp-admin", "grp-ssh"),
             role_mappings={"grp-ssh": "ssh-access-role"},
@@ -1097,7 +1101,7 @@ class TestHTTPUserAuthOIDCGroupsClaim:
     def test_group_name_with_spaces(
         self, echo_server_port, processes: ProcessManager
     ):
-        access, admin = _run_groups_claim_test(
+        access, admin = _run_roles_claim_test(
             processes,
             _str_groups("remote ssh users"),
             role_mappings={"remote ssh users": "ssh-access-role"},
@@ -1108,7 +1112,7 @@ class TestHTTPUserAuthOIDCGroupsClaim:
     def test_duplicate_group_names_dedup(
         self, echo_server_port, processes: ProcessManager
     ):
-        access, admin = _run_groups_claim_test(
+        access, admin = _run_roles_claim_test(
             processes,
             _str_groups("grp-ssh", "grp-ssh"),
             role_mappings={"grp-ssh": "ssh-access-role"},
@@ -1120,7 +1124,7 @@ class TestHTTPUserAuthOIDCGroupsClaim:
     def test_multiple_groups_some_unmapped(
         self, echo_server_port, processes: ProcessManager
     ):
-        access, admin = _run_groups_claim_test(
+        access, admin = _run_roles_claim_test(
             processes,
             _str_groups("grp-ssh", "grp-admin", "grp-extra", "grp-noise"),
             role_mappings={"grp-ssh": "ssh-access-role"},
@@ -1134,7 +1138,7 @@ class TestHTTPUserAuthOIDCGroupsClaim:
         self, echo_server_port, processes: ProcessManager
     ):
         # SCIM-style object array; map on the stable `value` (id), not the name.
-        access, admin = _run_groups_claim_test(
+        access, admin = _run_roles_claim_test(
             processes,
             _json_groups([{"value": "id-ssh", "display": "grp-ssh"}]),
             role_mappings={"id-ssh": "ssh-access-role"},
@@ -1145,7 +1149,7 @@ class TestHTTPUserAuthOIDCGroupsClaim:
     def test_mapping_by_id_and_name_mixed(
         self, echo_server_port, processes: ProcessManager
     ):
-        access, admin = _run_groups_claim_test(
+        access, admin = _run_roles_claim_test(
             processes,
             _json_groups(
                 [
@@ -1166,7 +1170,7 @@ class TestHTTPUserAuthOIDCGroupsClaim:
         # value/display collisions across entries, a value with a space, and a
         # string entry equal to another entry's display. Flattened set is:
         #   bla, bla2, dis1, dis2, val 3, val1, val2
-        access, admin = _run_groups_claim_test(
+        access, admin = _run_roles_claim_test(
             processes,
             _json_groups(
                 [

--- a/tests/test_http_user_auth_oidc.py
+++ b/tests/test_http_user_auth_oidc.py
@@ -1,4 +1,5 @@
 import html
+import json
 import re
 import socket
 import requests
@@ -41,6 +42,7 @@ def _make_sso_provider_config(
     admin_role_mappings=None,
     extra_scopes=None,
     return_url_domain=None,
+    groups_claim=None,
 ):
     """Build an ``sso_providers`` entry for warpgate config."""
     scopes = list(DEFAULT_OIDC_SCOPES)
@@ -57,6 +59,8 @@ def _make_sso_provider_config(
         provider["role_mappings"] = role_mappings
     if admin_role_mappings is not None:
         provider["admin_role_mappings"] = admin_role_mappings
+    if groups_claim is not None:
+        provider["groups_claim"] = groups_claim
     sso_entry = {
         "name": "test-oidc",
         "label": "OIDC Test",
@@ -974,3 +978,214 @@ class TestHTTPUserAuthOIDC:
             active_role_names = {r.name for r in user_roles if r.is_active}
             assert "role-keep" in active_role_names
             assert "role-remove" not in active_role_names
+
+
+# ---------------------------------------------------------------------------
+# `groups_claim`: source group memberships from a configurable OIDC claim
+# (e.g. the standard-ish `groups` claim) and map them to roles via
+# role_mappings / admin_role_mappings. Group names are generic placeholders.
+# ---------------------------------------------------------------------------
+
+def _user_with_group_claims(entries):
+    """Build a single OIDC mock user whose `groups` claim is built from
+    *entries* (a list of ``{"Value":..., "ValueType":...}`` dicts)."""
+    claims = [
+        {"Type": "name", "Value": "Sam Tailor", "ValueType": "string"},
+        {"Type": "email", "Value": "sam.tailor@gmail.com", "ValueType": "string"},
+        {"Type": "preferred_username", "Value": "sam_tailor", "ValueType": "string"},
+    ]
+    for e in entries:
+        claims.append({"Type": "groups", **e})
+    return [
+        {"SubjectId": "1", "Username": "User1", "Password": "pwd", "Claims": claims}
+    ]
+
+
+def _str_groups(*names):
+    """Emit each group name as a repeated string-valued `groups` claim
+    (the OIDC mock's representation of an array of strings)."""
+    return [{"Value": n, "ValueType": "string"} for n in names]
+
+
+def _json_groups(value):
+    """Emit a single JSON-valued `groups` claim (array of strings/objects)."""
+    return [{"Value": json.dumps(value), "ValueType": "json"}]
+
+
+def _run_groups_claim_test(
+    processes,
+    group_entries,
+    *,
+    role_mappings=None,
+    admin_role_mappings=None,
+    pre_create_roles=(),
+):
+    """Drive a full OIDC login with a configurable `groups` claim and return
+    ``(access_role_names, admin_role_names)`` for the auto-created user."""
+    wg_http_port = alloc_port()
+    oidc_port = processes.start_oidc_server(
+        wg_http_port,
+        extra_scopes=["groups"],
+        users_override=_user_with_group_claims(group_entries),
+        extra_identity_resources=[{"Name": "groups", "ClaimTypes": ["groups"]}],
+    )
+    wg = _start_wg_with_oidc(
+        processes,
+        wg_http_port,
+        oidc_port,
+        auto_create_users=True,
+        groups_claim="groups",
+        role_mappings=role_mappings,
+        admin_role_mappings=admin_role_mappings,
+        extra_scopes=["groups"],
+    )
+    wg_url = f"https://127.0.0.1:{wg.http_port}"
+
+    with admin_client(wg_url) as api:
+        for rn in pre_create_roles:
+            api.create_role(sdk.RoleDataRequest(name=rn))
+
+    _, resp = _do_oidc_login(wg_url, oidc_port)
+    assert resp.status_code in (302, 307), (
+        f"Expected redirect after login, got {resp.status_code}: {resp.text[:300]}"
+    )
+
+    with admin_client(wg_url) as api:
+        user = next(u for u in api.get_users() if u.username == "sam_tailor")
+        access = sorted(r.name for r in api.get_user_roles(user.id))
+        admin = sorted(r.name for r in api.get_user_admin_roles(user.id))
+    return access, admin
+
+
+class TestHTTPUserAuthOIDCGroupsClaim:
+    """Group memberships sourced from a configurable `groups` claim and mapped
+    to access/admin roles via role_mappings / admin_role_mappings."""
+
+    def test_access_role_mapping(self, echo_server_port, processes: ProcessManager):
+        access, admin = _run_groups_claim_test(
+            processes,
+            _str_groups("grp-ssh"),
+            role_mappings={"grp-ssh": "ssh-access-role"},
+            pre_create_roles=["ssh-access-role"],
+        )
+        assert access == ["ssh-access-role"]
+        assert admin == []
+
+    def test_admin_role_mapping(self, echo_server_port, processes: ProcessManager):
+        # "warpgate:admin" is warpgate's built-in admin role (always present).
+        access, admin = _run_groups_claim_test(
+            processes,
+            _str_groups("grp-admin"),
+            admin_role_mappings={"grp-admin": "warpgate:admin"},
+        )
+        assert access == []
+        assert "warpgate:admin" in admin
+
+    def test_combined_access_and_admin(
+        self, echo_server_port, processes: ProcessManager
+    ):
+        access, admin = _run_groups_claim_test(
+            processes,
+            _str_groups("grp-admin", "grp-ssh"),
+            role_mappings={"grp-ssh": "ssh-access-role"},
+            admin_role_mappings={"grp-admin": "warpgate:admin"},
+            pre_create_roles=["ssh-access-role"],
+        )
+        assert access == ["ssh-access-role"]
+        assert "warpgate:admin" in admin
+
+    def test_group_name_with_spaces(
+        self, echo_server_port, processes: ProcessManager
+    ):
+        access, admin = _run_groups_claim_test(
+            processes,
+            _str_groups("remote ssh users"),
+            role_mappings={"remote ssh users": "ssh-access-role"},
+            pre_create_roles=["ssh-access-role"],
+        )
+        assert access == ["ssh-access-role"]
+
+    def test_duplicate_group_names_dedup(
+        self, echo_server_port, processes: ProcessManager
+    ):
+        access, admin = _run_groups_claim_test(
+            processes,
+            _str_groups("grp-ssh", "grp-ssh"),
+            role_mappings={"grp-ssh": "ssh-access-role"},
+            pre_create_roles=["ssh-access-role"],
+        )
+        # role assigned exactly once despite the duplicate group
+        assert access == ["ssh-access-role"]
+
+    def test_multiple_groups_some_unmapped(
+        self, echo_server_port, processes: ProcessManager
+    ):
+        access, admin = _run_groups_claim_test(
+            processes,
+            _str_groups("grp-ssh", "grp-admin", "grp-extra", "grp-noise"),
+            role_mappings={"grp-ssh": "ssh-access-role"},
+            admin_role_mappings={"grp-admin": "warpgate:admin"},
+            pre_create_roles=["ssh-access-role"],
+        )
+        assert access == ["ssh-access-role"]
+        assert "warpgate:admin" in admin
+
+    def test_mapping_by_group_id_object(
+        self, echo_server_port, processes: ProcessManager
+    ):
+        # SCIM-style object array; map on the stable `value` (id), not the name.
+        access, admin = _run_groups_claim_test(
+            processes,
+            _json_groups([{"value": "id-ssh", "display": "grp-ssh"}]),
+            role_mappings={"id-ssh": "ssh-access-role"},
+            pre_create_roles=["ssh-access-role"],
+        )
+        assert access == ["ssh-access-role"]
+
+    def test_mapping_by_id_and_name_mixed(
+        self, echo_server_port, processes: ProcessManager
+    ):
+        access, admin = _run_groups_claim_test(
+            processes,
+            _json_groups(
+                [
+                    {"value": "id-ssh", "display": "grp-ssh"},
+                    {"value": "id-admin", "display": "grp-admin"},
+                ]
+            ),
+            role_mappings={"id-ssh": "ssh-access-role"},  # by id
+            admin_role_mappings={"grp-admin": "warpgate:admin"},  # by name
+            pre_create_roles=["ssh-access-role"],
+        )
+        assert access == ["ssh-access-role"]
+        assert "warpgate:admin" in admin
+
+    def test_complex_objects_cross_dedup_and_spaces(
+        self, echo_server_port, processes: ProcessManager
+    ):
+        # value/display collisions across entries, a value with a space, and a
+        # string entry equal to another entry's display. Flattened set is:
+        #   bla, bla2, dis1, dis2, val 3, val1, val2
+        access, admin = _run_groups_claim_test(
+            processes,
+            _json_groups(
+                [
+                    "bla",
+                    {"value": "val1", "display": "dis1"},
+                    {"value": "val2", "display": "dis1"},
+                    {"value": "val1", "display": "dis2"},
+                    "bla2",
+                    {"value": "val 3", "display": "bla2"},
+                ]
+            ),
+            # map several flattened keys; "dis1" (shared display) and "bla2"
+            # (string + display) must each yield their role exactly once.
+            role_mappings={
+                "dis1": "ssh-access-role",
+                "val 3": "spaced-role",
+            },
+            admin_role_mappings={"bla2": "warpgate:admin"},
+            pre_create_roles=["ssh-access-role", "spaced-role"],
+        )
+        assert access == ["spaced-role", "ssh-access-role"]
+        assert "warpgate:admin" in admin

--- a/warpgate-sso/src/config.rs
+++ b/warpgate-sso/src/config.rs
@@ -140,7 +140,8 @@ pub enum SsoInternalProviderConfig {
         /// OIDC claim to read group memberships from (e.g. "groups").
         /// Its values are mapped to roles via role_mappings / admin_role_mappings.
         /// When unset, the warpgate_roles / warpgate_admin_roles claims are used.
-        groups_claim: Option<String>,
+        roles_claim: Option<String>,
+        admin_roles_claim: Option<String>,
         additional_trusted_audiences: Option<Vec<String>>,
         #[serde(default)]
         trust_unknown_audiences: bool,
@@ -319,11 +320,23 @@ impl SsoInternalProviderConfig {
     }
 
     #[inline]
-    pub fn groups_claim(&self) -> Option<String> {
+    pub fn roles_claim(&self) -> &str {
         match self {
-            Self::Custom { groups_claim, .. } => groups_claim.clone(),
+            Self::Custom { roles_claim, .. } => roles_claim.as_deref(),
             _ => None,
         }
+        .unwrap_or("warpgate_roles")
+    }
+
+    #[inline]
+    pub fn admin_roles_claim(&self) -> &str {
+        match self {
+            Self::Custom {
+                admin_roles_claim, ..
+            } => admin_roles_claim.as_deref(),
+            _ => None,
+        }
+        .unwrap_or("warpgate_admin_roles")
     }
 
     #[inline]

--- a/warpgate-sso/src/config.rs
+++ b/warpgate-sso/src/config.rs
@@ -137,6 +137,10 @@ pub enum SsoInternalProviderConfig {
         scopes: Vec<String>,
         role_mappings: Option<HashMap<String, RoleMapping>>,
         admin_role_mappings: Option<HashMap<String, RoleMapping>>,
+        /// OIDC claim to read group memberships from (e.g. "groups").
+        /// Its values are mapped to roles via role_mappings / admin_role_mappings.
+        /// When unset, the warpgate_roles / warpgate_admin_roles claims are used.
+        groups_claim: Option<String>,
         additional_trusted_audiences: Option<Vec<String>>,
         #[serde(default)]
         trust_unknown_audiences: bool,
@@ -310,6 +314,14 @@ impl SsoInternalProviderConfig {
                 admin_role_mappings,
                 ..
             } => admin_role_mappings.clone(),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn groups_claim(&self) -> Option<String> {
+        match self {
+            Self::Custom { groups_claim, .. } => groups_claim.clone(),
             _ => None,
         }
     }

--- a/warpgate-sso/src/request.rs
+++ b/warpgate-sso/src/request.rs
@@ -4,7 +4,10 @@ use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 use tracing::{debug, error};
 
-use crate::{SsoClient, SsoError, SsoInternalProviderConfig, SsoLoginResponse};
+use crate::{
+    GroupClaim, SsoClient, SsoError, SsoInternalProviderConfig, SsoLoginResponse, SsoResult,
+    flatten_group_claim,
+};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SsoLoginRequest {
@@ -76,33 +79,14 @@ impl SsoLoginRequest {
 
         let email_verified = get_claim!(email_verified);
 
-        let info_claims = result.userinfo_claims.as_ref();
-
-        macro_rules! get_additional_claim {
-            ($method:ident) => {
-                result
-                    .claims
-                    .additional_claims()
-                    .$method
-                    .clone()
-                    .or(info_claims.and_then(|x| x.additional_claims().$method.clone()))
-            };
-        }
-
         let (access_groups, admin_groups) =
             match crate::google_groups::fetch_groups_if_configured(&config, email.as_deref()).await
             {
                 Ok(Some(google_groups)) => (Some(google_groups.clone()), Some(google_groups)),
-                Ok(None) => match config.groups_claim() {
-                    Some(claim) => {
-                        let groups = extract_groups(&result, &claim);
-                        (groups.clone(), groups)
-                    }
-                    None => (
-                        get_additional_claim!(warpgate_roles),
-                        get_additional_claim!(warpgate_admin_roles),
-                    ),
-                },
+                Ok(None) => (
+                    extract_groups(&result, config.roles_claim()),
+                    extract_groups(&result, config.admin_roles_claim()),
+                ),
                 Err(e) => {
                     error!("Failed to fetch Google groups: {e}");
                     (None, None)
@@ -123,15 +107,14 @@ impl SsoLoginRequest {
 
 /// Read a configurable group claim from the token (ID token first, then
 /// userinfo) and flatten it to a list of role-name strings.
-fn extract_groups(result: &crate::SsoResult, claim: &str) -> Option<Vec<String>> {
-    let get = |c: &crate::WarpgateClaims| c.additional.get(claim).cloned();
-    let raw = get(result.claims.additional_claims()).or_else(|| {
+fn extract_groups(result: &SsoResult, claim: &str) -> Option<Vec<String>> {
+    let raw = result.claims.additional_claims().0.get(claim).or_else(|| {
         result
             .userinfo_claims
             .as_ref()
-            .and_then(|u| get(u.additional_claims()))
+            .and_then(|u| u.additional_claims().0.get(claim))
     })?;
-    serde_json::from_value::<crate::GroupClaim>(raw)
+    serde_json::from_value::<GroupClaim>(raw.clone())
         .ok()
-        .map(crate::flatten_group_claim)
+        .map(flatten_group_claim)
 }

--- a/warpgate-sso/src/request.rs
+++ b/warpgate-sso/src/request.rs
@@ -93,10 +93,16 @@ impl SsoLoginRequest {
             match crate::google_groups::fetch_groups_if_configured(&config, email.as_deref()).await
             {
                 Ok(Some(google_groups)) => (Some(google_groups.clone()), Some(google_groups)),
-                Ok(None) => (
-                    get_additional_claim!(warpgate_roles),
-                    get_additional_claim!(warpgate_admin_roles),
-                ),
+                Ok(None) => match config.groups_claim() {
+                    Some(claim) => {
+                        let groups = extract_groups(&result, &claim);
+                        (groups.clone(), groups)
+                    }
+                    None => (
+                        get_additional_claim!(warpgate_roles),
+                        get_additional_claim!(warpgate_admin_roles),
+                    ),
+                },
                 Err(e) => {
                     error!("Failed to fetch Google groups: {e}");
                     (None, None)
@@ -113,4 +119,19 @@ impl SsoLoginRequest {
             id_token: result.token.clone(),
         })
     }
+}
+
+/// Read a configurable group claim from the token (ID token first, then
+/// userinfo) and flatten it to a list of role-name strings.
+fn extract_groups(result: &crate::SsoResult, claim: &str) -> Option<Vec<String>> {
+    let get = |c: &crate::WarpgateClaims| c.additional.get(claim).cloned();
+    let raw = get(result.claims.additional_claims()).or_else(|| {
+        result
+            .userinfo_claims
+            .as_ref()
+            .and_then(|u| get(u.additional_claims()))
+    })?;
+    serde_json::from_value::<crate::GroupClaim>(raw)
+        .ok()
+        .map(crate::flatten_group_claim)
 }

--- a/warpgate-sso/src/sso.rs
+++ b/warpgate-sso/src/sso.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 use openidconnect::core::{
     CoreAuthDisplay, CoreAuthPrompt, CoreAuthenticationFlow, CoreErrorResponseType,
@@ -41,7 +42,7 @@ pub(crate) enum GroupClaimEntry {
 /// value as a bare scalar rather than a one-element array; both are accepted.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
-pub enum GroupClaim {
+pub(crate) enum GroupClaim {
     One(GroupClaimEntry),
     Many(Vec<GroupClaimEntry>),
 }
@@ -52,7 +53,7 @@ pub enum GroupClaim {
 /// so role mappings may be keyed on either the stable group ID or its name.
 /// (A collision between one group's `display` and another's `value` would map
 /// both -- effectively impossible with opaque IDs.)
-pub fn flatten_group_claim(claim: GroupClaim) -> Vec<String> {
+pub(crate) fn flatten_group_claim(claim: GroupClaim) -> Vec<String> {
     let entries = match claim {
         GroupClaim::One(e) => vec![e],
         GroupClaim::Many(v) => v,
@@ -71,27 +72,12 @@ pub fn flatten_group_claim(claim: GroupClaim) -> Vec<String> {
     out
 }
 
-/// serde adapter so the typed `warpgate_roles` / `warpgate_admin_roles` fields
-/// accept the same shapes (string, array, object, mixed) as a dynamic group
-/// claim.
-fn deserialize_group_claim<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    Ok(Option::<GroupClaim>::deserialize(deserializer)?.map(flatten_group_claim))
-}
-
 #[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct WarpgateClaims {
-    #[serde(default, deserialize_with = "deserialize_group_claim")]
-    pub warpgate_roles: Option<Vec<String>>,
-    #[serde(default, deserialize_with = "deserialize_group_claim")]
-    pub warpgate_admin_roles: Option<Vec<String>>,
-    /// Any other claims present in the token; used to read a configurable
-    /// group claim (e.g. "groups") by name at runtime.
-    #[serde(flatten)]
-    pub additional: std::collections::HashMap<String, serde_json::Value>,
-}
+#[serde(transparent)]
+pub struct WarpgateClaims(
+    /// Flat map of claims since role claim names are configurable
+    pub HashMap<String, serde_json::Value>,
+);
 
 impl AdditionalClaims for WarpgateClaims {}
 
@@ -335,8 +321,9 @@ impl SsoClient {
 
 #[cfg(test)]
 mod tests {
-    use super::{flatten_group_claim, GroupClaim};
     use serde_json::json;
+
+    use super::{GroupClaim, flatten_group_claim};
 
     fn flat(j: serde_json::Value) -> Vec<String> {
         flatten_group_claim(serde_json::from_value::<GroupClaim>(j).unwrap())
@@ -349,7 +336,10 @@ mod tests {
 
     #[test]
     fn array_of_strings_sorted() {
-        assert_eq!(flat(json!(["b", "a"])), vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(
+            flat(json!(["b", "a"])),
+            vec!["a".to_string(), "b".to_string()]
+        );
     }
 
     #[test]

--- a/warpgate-sso/src/sso.rs
+++ b/warpgate-sso/src/sso.rs
@@ -21,36 +21,76 @@ use crate::SsoError;
 use crate::config::SsoInternalProviderConfig;
 use crate::request::SsoLoginRequest;
 
-/// Deserialize a value that may be either a single string or a sequence of strings.
+/// A single entry in a group-style claim: either a bare string, or a
+/// SCIM-style object (RFC 7643) from which we take `value` (stable group ID)
+/// and `display` (human-readable name).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum GroupClaimEntry {
+    Str(String),
+    Obj {
+        #[serde(default)]
+        value: Option<String>,
+        #[serde(default)]
+        display: Option<String>,
+    },
+}
+
+/// A group-style claim value: a single entry, or an array of entries
+/// (strings and/or objects, mixed). Some OIDC providers return a single
+/// value as a bare scalar rather than a one-element array; both are accepted.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum GroupClaim {
+    One(GroupClaimEntry),
+    Many(Vec<GroupClaimEntry>),
+}
+
+/// Flatten a group claim into a sorted, de-duplicated list of strings.
 ///
-/// Some OIDC providers (e.g. oidc-mock) return a single claim value
-/// as a bare string rather than a one-element array.
-/// This deserializer accepts both forms.
-fn string_or_vec<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+/// For object entries BOTH `value` and `display` are emitted (when present),
+/// so role mappings may be keyed on either the stable group ID or its name.
+/// (A collision between one group's `display` and another's `value` would map
+/// both -- effectively impossible with opaque IDs.)
+pub fn flatten_group_claim(claim: GroupClaim) -> Vec<String> {
+    let entries = match claim {
+        GroupClaim::One(e) => vec![e],
+        GroupClaim::Many(v) => v,
+    };
+    let mut out: Vec<String> = entries
+        .into_iter()
+        .flat_map(|e| match e {
+            GroupClaimEntry::Str(s) => vec![s],
+            GroupClaimEntry::Obj { value, display } => {
+                [value, display].into_iter().flatten().collect()
+            }
+        })
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// serde adapter so the typed `warpgate_roles` / `warpgate_admin_roles` fields
+/// accept the same shapes (string, array, object, mixed) as a dynamic group
+/// claim.
+fn deserialize_group_claim<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum StringOrVec {
-        String(String),
-        Vec(Vec<String>),
-    }
-
-    Option::<StringOrVec>::deserialize(deserializer).map(|opt| {
-        opt.map(|sv| match sv {
-            StringOrVec::String(s) => vec![s],
-            StringOrVec::Vec(v) => v,
-        })
-    })
+    Ok(Option::<GroupClaim>::deserialize(deserializer)?.map(flatten_group_claim))
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct WarpgateClaims {
-    #[serde(default, deserialize_with = "string_or_vec")]
+    #[serde(default, deserialize_with = "deserialize_group_claim")]
     pub warpgate_roles: Option<Vec<String>>,
-    #[serde(default, deserialize_with = "string_or_vec")]
+    #[serde(default, deserialize_with = "deserialize_group_claim")]
     pub warpgate_admin_roles: Option<Vec<String>>,
+    /// Any other claims present in the token; used to read a configurable
+    /// group claim (e.g. "groups") by name at runtime.
+    #[serde(flatten)]
+    pub additional: std::collections::HashMap<String, serde_json::Value>,
 }
 
 impl AdditionalClaims for WarpgateClaims {}
@@ -290,5 +330,99 @@ impl SsoClient {
         req = req.set_client_id(self.config.client_id().clone());
         req = req.set_post_logout_redirect_uri(PostLogoutRedirectUrl::from_url(redirect_url));
         Ok(req.http_get_url())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{flatten_group_claim, GroupClaim};
+    use serde_json::json;
+
+    fn flat(j: serde_json::Value) -> Vec<String> {
+        flatten_group_claim(serde_json::from_value::<GroupClaim>(j).unwrap())
+    }
+
+    #[test]
+    fn bare_string() {
+        assert_eq!(flat(json!("a")), vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn array_of_strings_sorted() {
+        assert_eq!(flat(json!(["b", "a"])), vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn single_object_value_and_display() {
+        assert_eq!(
+            flat(json!({"value": "id1", "display": "Admins"})),
+            vec!["Admins".to_string(), "id1".to_string()]
+        );
+    }
+
+    #[test]
+    fn array_of_objects() {
+        assert_eq!(
+            flat(json!([
+                {"value": "id1", "display": "Admins"},
+                {"value": "id2", "display": "Users"}
+            ])),
+            vec![
+                "Admins".to_string(),
+                "Users".to_string(),
+                "id1".to_string(),
+                "id2".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn mixed_strings_and_partial_objects() {
+        assert_eq!(
+            flat(json!(["x", {"display": "D"}, {"value": "V"}])),
+            vec!["D".to_string(), "V".to_string(), "x".to_string()]
+        );
+    }
+
+    #[test]
+    fn deduplicates() {
+        assert_eq!(flat(json!(["a", "a"])), vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn empty_array() {
+        assert!(flat(json!([])).is_empty());
+    }
+
+    #[test]
+    fn object_without_value_or_display() {
+        assert!(flat(json!([{"foo": "bar"}])).is_empty());
+    }
+
+    #[test]
+    fn complex_mixed_objects_with_cross_dedup_and_spaces() {
+        // value/display collisions across entries (e.g. two groups sharing a
+        // display, a display equal to another entry's string) must all collapse
+        // to a single sorted, de-duplicated set. A value containing a space
+        // sorts before non-space characters.
+        assert_eq!(
+            flat(json!([
+                "bla",
+                {"value": "val1", "display": "dis1"},
+                {"value": "val2", "display": "dis1"},
+                {"value": "val1", "display": "dis2"},
+                "bla2",
+                {"value": "val 3", "display": "bla2"}
+            ])),
+            vec![
+                "bla".to_string(),
+                "bla2".to_string(),
+                "dis1".to_string(),
+                "dis2".to_string(),
+                "val 3".to_string(),
+                "val1".to_string(),
+                "val2".to_string(),
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Description

### Problem

Some providers (e.g. Okta with an org authorization server) can only emit a `groups` claim and cannot add arbitrarily-named custom claims.
Hence, warpgate can't perform automatic role mapping from `warpgatew_roles` & `warpgate_admin_roles`.

### Proposed solution

Map IdP group memberships from a configurable token claim (e.g. the standard `groups` claim) to Warpgate roles via the existing role_mappings / admin_role_mappings, instead of requiring the IdP to emit dedicated `warpgate_roles` / `warpgate_admin_roles` claims. 

- config: new optional `groups_claim` field on the `custom` SSO provider plus a `groups_claim()` accessor.
- sso: introduce `GroupClaim` / `flatten_group_claim`, accepting a bare string, an array of strings, or SCIM-style objects (RFC 7643) from which both `value` (stable id) and `display` (name) are emitted; results are sorted and de-duplicated. The typed `warpgate_roles` / `warpgate_admin_roles` fields reuse the same parsing.
- request: when `groups_claim` is set, source access and admin groups from that claim (ID token first, then userinfo).
- tests: unit tests for claim flattening (string/array/object/mixed/ dedup/spaces) and e2e tests covering access/admin/combined mapping, spaces, duplicates, unmapped groups, and mapping by id or name.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [x] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
