### PR TITLE
fixed #2066 - offer hmac-sha1 when insecure algorithms are allowed

### DIFF
--- a/warpgate-protocol-ssh/src/client/mod.rs
+++ b/warpgate-protocol-ssh/src/client/mod.rs
@@ -18,7 +18,7 @@ use futures::{FutureExt, pin_mut};
 use handler::ClientHandler;
 use russh::client::{AuthResult, Handle, KeyboardInteractiveAuthResponse};
 use russh::keys::{PrivateKeyWithHashAlg, PublicKey};
-use russh::{MethodKind, Preferred, Sig, kex};
+use russh::{MethodKind, Preferred, Sig, kex, mac};
 use serde::Serialize;
 use tokio::sync::mpsc::{
     Receiver, Sender, UnboundedReceiver, UnboundedSender, channel, unbounded_channel,
@@ -529,6 +529,17 @@ impl RemoteClient {
                     russh::cipher::AES_128_CTR,
                     russh::cipher::AES_128_CBC,
                     russh::cipher::TRIPLE_DES_CBC,
+                ]),
+                // The secure defaults exclude SHA-1 MACs; append them here for
+                // legacy devices (e.g. older network switches that only offer
+                // hmac-sha1). https://github.com/warp-tech/warpgate/issues/2066
+                mac: Cow::Borrowed(&[
+                    mac::HMAC_SHA512_ETM,
+                    mac::HMAC_SHA256_ETM,
+                    mac::HMAC_SHA512,
+                    mac::HMAC_SHA256,
+                    mac::HMAC_SHA1_ETM,
+                    mac::HMAC_SHA1,
                 ]),
                 ..<_>::default()
             }


### PR DESCRIPTION
## Description

...

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
