### PR TITLE
Cache show_session_menu on HTTP requests

### DIFF
--- a/warpgate-admin/src/api/parameters.rs
+++ b/warpgate-admin/src/api/parameters.rs
@@ -284,6 +284,9 @@ impl Api {
         parameters.analytics_normal = body.analytics_normal.map_or(NotSet, Set);
 
         Parameters::Entity::update(parameters).exec(&*db).await?;
+        if let Some(show_session_menu) = body.show_session_menu {
+            services.set_show_session_menu(show_session_menu);
+        }
         drop(db);
 
         services

--- a/warpgate-core/src/services.rs
+++ b/warpgate-core/src/services.rs
@@ -1,10 +1,10 @@
 use std::net::IpAddr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::Result;
-use sea_orm::DatabaseConnection;
+use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection};
 use tokio::sync::Mutex;
 use tracing::warn;
 use uuid::Uuid;
@@ -44,8 +44,35 @@ impl Services {
     ) -> Result<Self> {
         let db = connect_to_db_and_migrate(&config, &params).await?;
         populate_db(&db, &mut config).await?;
-        let show_session_menu = Parameters::Entity::get(&db).await?.show_session_menu;
+        let show_session_menu = Arc::new(AtomicBool::new(
+            Parameters::Entity::get(&db).await?.show_session_menu,
+        ));
+        let should_periodically_sync_show_session_menu =
+            db.get_database_backend() != DatabaseBackend::Sqlite;
         let db = Arc::new(Mutex::new(db));
+
+        if should_periodically_sync_show_session_menu {
+            tokio::spawn({
+                let db = db.clone();
+                let show_session_menu = show_session_menu.clone();
+                async move {
+                    loop {
+                        tokio::time::sleep(Duration::from_secs(60)).await;
+                        let result = {
+                            let db = db.lock().await;
+                            Parameters::Entity::get(&db).await
+                        };
+                        match result {
+                            Ok(parameters) => show_session_menu
+                                .store(parameters.show_session_menu, Ordering::Relaxed),
+                            Err(error) => {
+                                warn!(?error, "Failed to refresh the session menu setting")
+                            }
+                        }
+                    }
+                }
+            });
+        }
 
         let recordings = SessionRecordings::new(db.clone(), &config, &params)?;
         let recordings = Arc::new(Mutex::new(recordings));
@@ -104,7 +131,7 @@ impl Services {
             login_protection,
             global_params: Arc::new(params),
             listener_status: Default::default(),
-            show_session_menu: Arc::new(AtomicBool::new(show_session_menu)),
+            show_session_menu,
         })
     }
 

--- a/warpgate-core/src/services.rs
+++ b/warpgate-core/src/services.rs
@@ -1,4 +1,5 @@
 use std::net::IpAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -32,6 +33,7 @@ pub struct Services {
     pub login_protection: Arc<LoginProtectionService>,
     pub global_params: Arc<GlobalParams>,
     pub listener_status: ListenerStatusRegistry,
+    show_session_menu: Arc<AtomicBool>,
 }
 
 impl Services {
@@ -42,6 +44,7 @@ impl Services {
     ) -> Result<Self> {
         let db = connect_to_db_and_migrate(&config, &params).await?;
         populate_db(&db, &mut config).await?;
+        let show_session_menu = Parameters::Entity::get(&db).await?.show_session_menu;
         let db = Arc::new(Mutex::new(db));
 
         let recordings = SessionRecordings::new(db.clone(), &config, &params)?;
@@ -101,7 +104,21 @@ impl Services {
             login_protection,
             global_params: Arc::new(params),
             listener_status: Default::default(),
+            show_session_menu: Arc::new(AtomicBool::new(show_session_menu)),
         })
+    }
+
+    /// Returns whether proxied HTML responses should include the session menu.
+    ///
+    /// This value mirrors the parameters row without requiring a database query
+    /// on every proxied HTTP request.
+    pub fn show_session_menu(&self) -> bool {
+        self.show_session_menu.load(Ordering::Relaxed)
+    }
+
+    /// Updates the cached session-menu setting after the parameters row changes.
+    pub fn set_show_session_menu(&self, show: bool) {
+        self.show_session_menu.store(show, Ordering::Relaxed);
     }
 
     /// Resolves the user/policy (without the store lock) and inserts a new

--- a/warpgate-protocol-http/src/proxy.rs
+++ b/warpgate-protocol-http/src/proxy.rs
@@ -339,13 +339,11 @@ pub async fn proxy_normal_request(
 
     copy_client_response(&client_response, &mut response);
 
-    let embed_session_menu = {
-        let db = ctx.services().db.lock().await;
-        warpgate_db_entities::Parameters::Entity::get(&db)
-            .await
-            .map(|p| p.show_session_menu)
-            .unwrap_or(true)
-    };
+    let embed_session_menu = response.status() == StatusCode::OK
+        && response
+            .content_type()
+            .is_some_and(|content_type| content_type.starts_with("text/html"))
+        && ctx.services().show_session_menu();
     copy_client_body(client_response, &mut response, embed_session_menu).await?;
 
     log_request_result(
@@ -364,12 +362,7 @@ async fn copy_client_body(
     response: &mut Response,
     embed_session_menu: bool,
 ) -> Result<()> {
-    if embed_session_menu
-        && response
-            .content_type()
-            .is_some_and(|c| c.starts_with("text/html"))
-        && response.status() == 200
-    {
+    if embed_session_menu {
         copy_client_body_and_embed(client_response, response).await?;
         return Ok(());
     }


### PR DESCRIPTION
## Description
show_session_menu is implemented quite inefficiently on a very hot path (HTTP requests for HTTP targets). There are 2 problems with the implementation:
1. show_session_menu is queried from the DB on every HTTP request
2. show_session_menu is queried even when it's not needed (non-HTML content, non-200 status codes)

This PR adds an in-memory cache for show_session_menu and short-circuits the logic such that the value is not even looked up if the request is not relevant (non-HTML, non-200). This second part is, of course, barely relevant anymore when you do an in-memory lookup, but it's still a free improvement over unnecessarily reading an atomic bool.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [x] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
