### PR TITLE
Reuse HTTP clients across requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8445,6 +8445,7 @@ dependencies = [
  "poem-openapi",
  "regex",
  "reqwest 0.13.4",
+ "rustls 0.23.41",
  "sea-orm",
  "serde",
  "serde_json",

--- a/warpgate-protocol-http/Cargo.toml
+++ b/warpgate-protocol-http/Cargo.toml
@@ -41,3 +41,6 @@ warpgate-db-entities = { path = "../warpgate-db-entities", default-features = fa
 warpgate-sso = { path = "../warpgate-sso", default-features = false }
 warpgate-tls = { path = "../warpgate-tls", default-features = false }
 warpgate-web = { path = "../warpgate-web", default-features = false }
+
+[dev-dependencies]
+rustls = { workspace = true, features = ["aws_lc_rs"] }

--- a/warpgate-protocol-http/src/catchall.rs
+++ b/warpgate-protocol-http/src/catchall.rs
@@ -13,6 +13,7 @@ use warpgate_common_http::{
 };
 use warpgate_core::{ConfigProvider, WarpgateServerHandle};
 
+use crate::client_cache::HttpClientCache;
 use crate::common::SessionExt;
 use crate::proxy::{proxy_normal_request, proxy_websocket_request};
 
@@ -33,6 +34,7 @@ pub async fn catchall_endpoint(
     session: &Session,
     body: Body,
     ctx: Data<&AuthenticatedRequestContext>,
+    http_client_cache: Data<&HttpClientCache>,
     server_handle: Option<Data<&Arc<Mutex<WarpgateServerHandle>>>>,
 ) -> poem::Result<Response> {
     let target_and_options = get_target_for_request(req, &ctx).await?;
@@ -53,7 +55,7 @@ pub async fn catchall_endpoint(
             .instrument(span)
             .await?
             .into_response(),
-        None => proxy_normal_request(req, *ctx, body, &options)
+        None => proxy_normal_request(req, *ctx, body, &target.name, &options, *http_client_cache)
             .instrument(span)
             .await?
             .into_response(),

--- a/warpgate-protocol-http/src/client_cache.rs
+++ b/warpgate-protocol-http/src/client_cache.rs
@@ -68,15 +68,16 @@ impl HttpClientCache {
     ) -> Result<reqwest::Client> {
         let now = Instant::now();
         let configuration = ClientConfiguration::from(options);
-        let mut clients = self.clients.lock().await;
 
-        clients.retain(|_, entry| now.duration_since(entry.last_used) < self.idle_ttl);
-
-        if let Some(entry) = clients.get_mut(target_name)
-            && entry.configuration == configuration
+        // Don't hold the lock while building the client.
         {
-            entry.last_used = now;
-            return Ok(entry.client.clone());
+            let mut clients = self.clients.lock().await;
+            if let Some(entry) = clients.get_mut(target_name)
+                && entry.configuration == configuration
+            {
+                entry.last_used = now;
+                return Ok(entry.client.clone());
+            }
         }
 
         let client = build_client(&configuration)?;
@@ -84,7 +85,7 @@ impl HttpClientCache {
         self.build_count
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        clients.insert(
+        self.clients.lock().await.insert(
             target_name.to_string(),
             CachedClient {
                 configuration,
@@ -193,12 +194,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rebuilds_client_after_idle_ttl() {
+    async fn vacuum_evicts_idle_client_forcing_rebuild() {
         install_crypto_provider();
         let cache = HttpClientCache::new(Duration::ZERO);
         let options = make_options("https://example.com");
 
         cache.client_for("target", &options).await.unwrap();
+        cache.vacuum().await;
         cache.client_for("target", &options).await.unwrap();
 
         assert_eq!(

--- a/warpgate-protocol-http/src/client_cache.rs
+++ b/warpgate-protocol-http/src/client_cache.rs
@@ -1,0 +1,209 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use reqwest::redirect::Policy;
+use tokio::sync::Mutex;
+use warpgate_common::TargetHTTPOptions;
+use warpgate_tls::TlsMode;
+
+pub const HTTP_CLIENT_IDLE_TTL: Duration = Duration::from_secs(10 * 60);
+pub const HTTP_CLIENT_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
+pub const HTTP_CLIENT_CACHE_VACUUM_INTERVAL: Duration = Duration::from_secs(60);
+
+const HTTP_CLIENT_POOL_MAX_IDLE_PER_HOST: usize = 16;
+
+#[derive(PartialEq, Eq)]
+struct ClientConfiguration {
+    url: String,
+    tls_mode: TlsMode,
+    tls_verify: bool,
+}
+
+impl From<&TargetHTTPOptions> for ClientConfiguration {
+    fn from(options: &TargetHTTPOptions) -> Self {
+        Self {
+            url: options.url.clone(),
+            tls_mode: options.tls.mode,
+            tls_verify: options.tls.verify,
+        }
+    }
+}
+
+struct CachedClient {
+    configuration: ClientConfiguration,
+    client: reqwest::Client,
+    last_used: Instant,
+}
+
+#[derive(Clone)]
+pub struct HttpClientCache {
+    clients: Arc<Mutex<HashMap<String, CachedClient>>>,
+    idle_ttl: Duration,
+    #[cfg(test)]
+    build_count: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl Default for HttpClientCache {
+    fn default() -> Self {
+        Self::new(HTTP_CLIENT_IDLE_TTL)
+    }
+}
+
+impl HttpClientCache {
+    fn new(idle_ttl: Duration) -> Self {
+        Self {
+            clients: Arc::new(Mutex::new(HashMap::new())),
+            idle_ttl,
+            #[cfg(test)]
+            build_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        }
+    }
+
+    pub async fn client_for(
+        &self,
+        target_name: &str,
+        options: &TargetHTTPOptions,
+    ) -> Result<reqwest::Client> {
+        let now = Instant::now();
+        let configuration = ClientConfiguration::from(options);
+        let mut clients = self.clients.lock().await;
+
+        clients.retain(|_, entry| now.duration_since(entry.last_used) < self.idle_ttl);
+
+        if let Some(entry) = clients.get_mut(target_name)
+            && entry.configuration == configuration
+        {
+            entry.last_used = now;
+            return Ok(entry.client.clone());
+        }
+
+        let client = build_client(&configuration)?;
+        #[cfg(test)]
+        self.build_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        clients.insert(
+            target_name.to_string(),
+            CachedClient {
+                configuration,
+                client: client.clone(),
+                last_used: now,
+            },
+        );
+
+        Ok(client)
+    }
+
+    pub async fn vacuum(&self) {
+        let now = Instant::now();
+        self.clients
+            .lock()
+            .await
+            .retain(|_, entry| now.duration_since(entry.last_used) < self.idle_ttl);
+    }
+}
+
+fn build_client(configuration: &ClientConfiguration) -> Result<reqwest::Client> {
+    let tls_mode = configuration.tls_mode;
+    let mut client = reqwest::Client::builder()
+        .gzip(true)
+        .connection_verbose(true)
+        .pool_idle_timeout(HTTP_CLIENT_POOL_IDLE_TIMEOUT)
+        .pool_max_idle_per_host(HTTP_CLIENT_POOL_MAX_IDLE_PER_HOST)
+        .redirect(Policy::custom(move |attempt| {
+            let started_with_http = attempt
+                .previous()
+                .first()
+                .is_some_and(|url| url.scheme() == "http");
+
+            if tls_mode == TlsMode::Preferred
+                && started_with_http
+                && attempt.url().scheme() == "https"
+            {
+                tracing::debug!("Following HTTP->HTTPS redirect");
+                attempt.follow()
+            } else {
+                attempt.stop()
+            }
+        }));
+
+    if configuration.tls_mode == TlsMode::Required {
+        client = client.https_only(true);
+    }
+
+    if !configuration.tls_verify {
+        client = client.danger_accept_invalid_certs(true);
+    }
+
+    client.build().context("Could not build HTTP target client")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn install_crypto_provider() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    }
+
+    fn make_options(url: &str) -> TargetHTTPOptions {
+        TargetHTTPOptions {
+            url: url.to_string(),
+            tls: Default::default(),
+            headers: None,
+            external_host: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn reuses_client_for_unchanged_target() {
+        install_crypto_provider();
+        let cache = HttpClientCache::default();
+        let options = make_options("https://example.com");
+
+        cache.client_for("target", &options).await.unwrap();
+        cache.client_for("target", &options).await.unwrap();
+
+        assert_eq!(
+            cache.build_count.load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn rebuilds_client_when_target_configuration_changes() {
+        install_crypto_provider();
+        let cache = HttpClientCache::default();
+
+        cache
+            .client_for("target", &make_options("https://example.com"))
+            .await
+            .unwrap();
+        cache
+            .client_for("target", &make_options("https://example.org"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            cache.build_count.load(std::sync::atomic::Ordering::Relaxed),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn rebuilds_client_after_idle_ttl() {
+        install_crypto_provider();
+        let cache = HttpClientCache::new(Duration::ZERO);
+        let options = make_options("https://example.com");
+
+        cache.client_for("target", &options).await.unwrap();
+        cache.client_for("target", &options).await.unwrap();
+
+        assert_eq!(
+            cache.build_count.load(std::sync::atomic::Ordering::Relaxed),
+            2
+        );
+    }
+}

--- a/warpgate-protocol-http/src/lib.rs
+++ b/warpgate-protocol-http/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api;
 mod catchall;
+mod client_cache;
 mod common;
 mod error;
 mod middleware;
@@ -9,7 +10,6 @@ mod session_handle;
 
 use std::fmt::Debug;
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::{Context, Result};
 use common::inject_request_authorization;
@@ -43,6 +43,7 @@ use warpgate_web_desktop::api::ws_handler as desktop_web_client_ws_handler;
 use warpgate_web_ssh::WebSshClientManager;
 use warpgate_web_ssh::api::ws_handler as ssh_web_client_ws_handler;
 
+use crate::client_cache::{HTTP_CLIENT_CACHE_VACUUM_INTERVAL, HttpClientCache};
 use crate::common::{SESSION_COOKIE_NAME, endpoint_auth, page_auth};
 use crate::error::error_page;
 use crate::middleware::{
@@ -93,6 +94,7 @@ impl ProtocolServer for HTTPProtocolServer {
     ) -> Result<BoxFuture<'static, Result<()>>> {
         let session_storage = make_session_storage();
         let session_store = SessionStore::new();
+        let http_client_cache = HttpClientCache::default();
 
         let cache_bust = || {
             SetHeader::new().overriding(
@@ -290,13 +292,15 @@ impl ProtocolServer for HTTPProtocolServer {
             ))
             .with(CookieHostMiddleware::new(base_cookie_domain))
             .data(UnauthenticatedRequestContext::new(self.services.clone()).await)
+            .data(http_client_cache.clone())
             .data(session_store.clone())
             .data(session_storage);
 
         tokio::spawn(async move {
             loop {
                 session_store.lock().await.vacuum(session_max_age);
-                tokio::time::sleep(Duration::from_secs(60)).await;
+                http_client_cache.vacuum().await;
+                tokio::time::sleep(HTTP_CLIENT_CACHE_VACUUM_INTERVAL).await;
             }
         });
 

--- a/warpgate-protocol-http/src/proxy.rs
+++ b/warpgate-protocol-http/src/proxy.rs
@@ -30,6 +30,7 @@ use warpgate_common_http::{
 use warpgate_tls::{TlsMode, configure_tls_connector};
 use warpgate_web::lookup_built_file;
 
+use crate::client_cache::HttpClientCache;
 use crate::common::SessionExt;
 use crate::session::SessionStore;
 
@@ -277,42 +278,15 @@ pub async fn proxy_normal_request(
     req: &Request,
     ctx: &AuthenticatedRequestContext,
     body: Body,
+    target_name: &str,
     options: &TargetHTTPOptions,
+    client_cache: &HttpClientCache,
 ) -> poem::Result<Response> {
     let uri = construct_uri(req, options, false)?;
 
     tracing::debug!("URI: {:?}", uri);
 
-    let mut client = reqwest::Client::builder()
-        .gzip(true)
-        .redirect(reqwest::redirect::Policy::none())
-        .connection_verbose(true);
-
-    if options.tls.mode == TlsMode::Required {
-        client = client.https_only(true);
-    }
-
-    client = client.redirect(reqwest::redirect::Policy::custom({
-        let tls_mode = options.tls.mode;
-        let uri = uri.clone();
-        move |attempt| {
-            if tls_mode == TlsMode::Preferred
-                && uri.scheme() == Some(&Scheme::HTTP)
-                && attempt.url().scheme() == "https"
-            {
-                debug!("Following HTTP->HTTPS redirect");
-                attempt.follow()
-            } else {
-                attempt.stop()
-            }
-        }
-    }));
-
-    if !options.tls.verify {
-        client = client.danger_accept_invalid_certs(true);
-    }
-
-    let client = client.build().context("Could not build request")?;
+    let client = client_cache.client_for(target_name, options).await?;
 
     let (authorization_header, uri) = extract_basic_auth(uri)?;
 


### PR DESCRIPTION
## Description
For HTTP requests, Warpgate creates a new HTTP client for every request. HTTP clients are however meant to be long-lived, and recreating them on a per-request basis forces both TCP and TLS handshaking on every request, which has a significant impact on CPU and latency, especially on high-latency requests.

This PR adds a client cache that reuses HTTP clients within a 10 minute idle window to reduce the amount of handshaking that Warpgate needs to do.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
