### PR TITLE
Do not check show_session_menu when it's not necessary

### DIFF
--- a/warpgate-protocol-http/src/proxy.rs
+++ b/warpgate-protocol-http/src/proxy.rs
@@ -313,13 +313,16 @@ pub async fn proxy_normal_request(
 
     copy_client_response(&client_response, &mut response);
 
-    let embed_session_menu = {
-        let db = &ctx.services().db;
-        warpgate_db_entities::Parameters::Entity::get(&db)
+    // The session can be embedded if embedding is enabled and the response is a usable HTML page.
+    // We for example don't want to embed a 404 page or a JS file.
+    let embed_session_menu = response.status() == StatusCode::OK
+        && response
+            .content_type()
+            .is_some_and(|content_type| content_type.starts_with("text/html"))
+        && warpgate_db_entities::Parameters::Entity::get(&ctx.services().db)
             .await
             .map(|p| p.show_session_menu)
-            .unwrap_or(true)
-    };
+            .unwrap_or(true);
     copy_client_body(client_response, &mut response, embed_session_menu).await?;
 
     log_request_result(
@@ -338,12 +341,7 @@ async fn copy_client_body(
     response: &mut Response,
     embed_session_menu: bool,
 ) -> Result<()> {
-    if embed_session_menu
-        && response
-            .content_type()
-            .is_some_and(|c| c.starts_with("text/html"))
-        && response.status() == 200
-    {
+    if embed_session_menu {
         copy_client_body_and_embed(client_response, response).await?;
         return Ok(());
     }


### PR DESCRIPTION
## Description
Currently show_session_menu is queried from the db on every HTTP request. However, we only need to know this parameter if the request is actually embeddable (e.g. we don't need this for a JS file, since we won't embed it anyways). So optimise this such that it's only queried when necessary.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [x] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
