### PR TITLE
Fix embedded session menu clicks misclassified as drags

### DIFF
--- a/warpgate-web/src/embed/EmbeddedUI.svelte
+++ b/warpgate-web/src/embed/EmbeddedUI.svelte
@@ -6,9 +6,10 @@
     let ready = false
     let menuVisible = false
     let dragging = false
+    const DRAG_THRESHOLD = 5
     let savedPosition = { x: 0.1, y: 0.8 }
     let position = { x: 0.1, y: 0.8 }
-    let dragStartCoords = { x: 0, y: 0 }
+    let dragStartCoords: { x: number; y: number } | undefined
     let externalHost: string | undefined
 
     if (localStorage.warpgateMenuLocation) {
@@ -23,13 +24,17 @@
     })
 
     function drag(e: MouseEvent) {
-        if (!dragging) {
+        if (!dragStartCoords || !e.buttons) {
             return
         }
         const { x, y } = dragStartCoords
         const { clientX, clientY } = e
         const dx = clientX - x
         const dy = clientY - y
+        if (!dragging && Math.hypot(dx, dy) < DRAG_THRESHOLD) {
+            return
+        }
+        dragging = true
         position = {
             x: Math.max(
                 0,
@@ -44,11 +49,12 @@
 
     function startDragging(e: MouseEvent) {
         dragStartCoords = { x: e.clientX, y: e.clientY }
-        dragging = true
+        dragging = false
     }
 
     function stopDragging() {
         dragging = false
+        dragStartCoords = undefined
         savedPosition = position
         localStorage.warpgateMenuLocation = JSON.stringify(position)
     }
@@ -88,16 +94,10 @@
         on:mouseup|stopPropagation|preventDefault={() => {
             if (!dragging) {
                 menuVisible = !menuVisible
-            } else {
-                stopDragging()
             }
+            stopDragging()
         }}
-        on:mousedown|preventDefault
-        on:mousemove|preventDefault={e => {
-            if (e.buttons && !dragging) {
-                startDragging(e)
-            }
-        }}
+        on:mousedown|preventDefault={startDragging}
     >
 
     {#if menuVisible}

--- a/warpgate-web/src/embed/EmbeddedUI.svelte
+++ b/warpgate-web/src/embed/EmbeddedUI.svelte
@@ -3,10 +3,12 @@
     import { onMount } from 'svelte'
     import logo from '../../public/assets/favicon.svg'
 
+    // Movement in pixels before a press turns into a drag rather than a menu toggle.
+    const DRAG_THRESHOLD = 5
+
     let ready = false
     let menuVisible = false
     let dragging = false
-    const DRAG_THRESHOLD = 5
     let savedPosition = { x: 0.1, y: 0.8 }
     let position = { x: 0.1, y: 0.8 }
     let dragStartCoords: { x: number; y: number } | undefined
@@ -23,14 +25,20 @@
         externalHost = `${info.externalHosts?.http ?? info.externalHost}:${info.ports.http ?? 443}`
     })
 
-    function drag(e: MouseEvent) {
-        if (!dragStartCoords || !e.buttons) {
+    function startDragging(e: PointerEvent) {
+        dragStartCoords = { x: e.clientX, y: e.clientY }
+        dragging = false
+        // Capture guarantees the matching pointerup/pointermove reach the icon even
+        // if the pointer leaves the window, so a release outside can't strand `dragging`.
+        ;(e.currentTarget as Element).setPointerCapture(e.pointerId)
+    }
+
+    function drag(e: PointerEvent) {
+        if (!dragStartCoords) {
             return
         }
-        const { x, y } = dragStartCoords
-        const { clientX, clientY } = e
-        const dx = clientX - x
-        const dy = clientY - y
+        const dx = e.clientX - dragStartCoords.x
+        const dy = e.clientY - dragStartCoords.y
         if (!dragging && Math.hypot(dx, dy) < DRAG_THRESHOLD) {
             return
         }
@@ -47,16 +55,12 @@
         }
     }
 
-    function startDragging(e: MouseEvent) {
-        dragStartCoords = { x: e.clientX, y: e.clientY }
-        dragging = false
-    }
-
-    function stopDragging() {
-        dragging = false
+    function endDragging() {
+        if (dragging) {
+            savedPosition = position
+            localStorage.warpgateMenuLocation = JSON.stringify(position)
+        }
         dragStartCoords = undefined
-        savedPosition = position
-        localStorage.warpgateMenuLocation = JSON.stringify(position)
     }
 
     function goHome() {
@@ -73,13 +77,7 @@
     }
 </script>
 
-<svelte:window
-    on:mousemove|passive={drag}
-    on:mouseup={() => {
-        menuVisible = false
-        stopDragging()
-    }}
-/>
+<svelte:window on:pointerup={() => (menuVisible = false)} />
 
 <div
     class="embedded-ui"
@@ -91,19 +89,21 @@
         class="menu-toggle"
         src={logo}
         alt="Warpgate"
-        on:mouseup|stopPropagation|preventDefault={() => {
+        on:pointerdown|preventDefault={startDragging}
+        on:pointermove={drag}
+        on:pointerup|stopPropagation|preventDefault={() => {
             if (!dragging) {
                 menuVisible = !menuVisible
             }
-            stopDragging()
+            endDragging()
         }}
-        on:mousedown|preventDefault={startDragging}
+        on:pointercancel={endDragging}
     >
 
     {#if menuVisible}
         <div class="menu">
-            <button type="button" on:mouseup={goHome}>Home</button>
-            <button type="button" on:mouseup={logout}>Log out</button>
+            <button type="button" on:pointerup={goHome}>Home</button>
+            <button type="button" on:pointerup={logout}>Log out</button>
         </div>
     {/if}
 </div>


### PR DESCRIPTION
## Description

Fix the embedded session menu failing to open with normal mouse clicks. The problem is confirmed manually in Brave.

Reason: Chromiym can emit a zero-distance `mousemove` between `mousedown` and `mouseup`. The menu treated any `mousemove` as a drag, causing `mouseup` to skip opening the menu.

This change records the initial cursor position on `mousedown` and requires 5 pixels of movement before entering drag mode. This threshold can be lowered to 1px if needed, it will still prevent the problem which was happening even when the cursor does not move at all between the click and the mousemove event.

The issue and root cause were manually verified in Chrome DevTools:

- Normal clicks produced `mousedown → mousemove → mouseup` with identical coordinates, which prevented the menu from opening.
- Device-emulated taps (via dev tools mobile device emulation) opened the menu.

The production frontend build and Biome checks pass.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [x] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*