### PR TITLE
Avoid unnecessary set_target and set_user_info hot path work

### DIFF
--- a/warpgate-common/src/config/target.rs
+++ b/warpgate-common/src/config/target.rs
@@ -27,7 +27,7 @@ impl Default for KubernetesTargetCertificateAuth {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Object)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Object)]
 pub struct TargetSSHOptions {
     pub host: String,
     #[serde(default = "_default_ssh_port")]
@@ -71,7 +71,7 @@ impl Default for SSHTargetAuth {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Object)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Object)]
 pub struct TargetHTTPOptions {
     #[serde(default = "_default_empty_string")]
     pub url: String,
@@ -86,7 +86,7 @@ pub struct TargetHTTPOptions {
     pub external_host: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Object)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Object)]
 pub struct Tls {
     #[serde(default)]
     pub mode: TlsMode,
@@ -139,7 +139,7 @@ impl DatabaseTargetAuth {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Object)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Object)]
 pub struct TargetMySqlOptions {
     #[serde(default = "_default_empty_string")]
     pub host: String,
@@ -200,7 +200,7 @@ pub enum PostgresProtocolVersion {
     V3_2,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Object)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Object)]
 pub struct TargetPostgresOptions {
     #[serde(default = "_default_empty_string")]
     pub host: String,
@@ -256,7 +256,7 @@ impl TargetPostgresOptions {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Object)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Object)]
 pub struct TargetVncOptions {
     #[serde(default = "_default_empty_string")]
     pub host: String,
@@ -292,7 +292,7 @@ impl Default for VncTargetAuth {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Object)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Object)]
 pub struct TargetRdpOptions {
     #[serde(default = "_default_empty_string")]
     pub host: String,
@@ -336,7 +336,7 @@ impl Default for RdpTargetAuth {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Object)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Object)]
 pub struct TargetKubernetesOptions {
     #[serde(default = "_default_empty_string")]
     pub cluster_url: String,
@@ -374,7 +374,7 @@ impl Default for KubernetesTargetAuth {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Object)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Object)]
 pub struct Target {
     #[serde(default)]
     pub id: Uuid,
@@ -392,7 +392,7 @@ pub struct Target {
     pub ticket_max_uses: Option<i16>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Union)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Union)]
 #[oai(discriminator_name = "kind", one_of)]
 pub enum TargetOptions {
     #[serde(rename = "ssh")]

--- a/warpgate-core/src/protocols/handle.rs
+++ b/warpgate-core/src/protocols/handle.rs
@@ -54,90 +54,70 @@ impl WarpgateServerHandle {
         use sea_orm::ActiveValue::Set;
 
         {
-            let state = self.session_state.lock().await;
-            // Kubernetes reuses one session handle for many requests. Avoid emitting a
-            // change and writing the same username to the session row for every request.
+            // Kubernetes reuses one session handle for many concurrent requests, so
+            // most calls are no-ops, and the lock must span the no-op check and the
+            // commit to keep the DB and in-memory state consistent.
+            let mut state = self.session_state.lock().await;
             if state.user_info.as_ref() == Some(&user_info) {
                 return Ok(());
             }
+
+            Session::Entity::update_many()
+                .set(Session::ActiveModel {
+                    username: Set(Some(user_info.username.clone())),
+                    ..Default::default()
+                })
+                .filter(Session::Column::Id.eq(self.id))
+                .exec(&self.db)
+                .await?;
+
+            state.user_info = Some(user_info);
+            state.emit_change();
         }
 
-        let db = &self.db;
-
-        Session::Entity::update_many()
-            .set(Session::ActiveModel {
-                username: Set(Some(user_info.username.clone())),
-                ..Default::default()
-            })
-            .filter(Session::Column::Id.eq(self.id))
-            .exec(db)
-            .await?;
-
-        let previous_user_info = {
-            let mut state = self.session_state.lock().await;
-            state.user_info.replace(user_info)
-        };
-
-        if let Err(error) = self.update_rate_limiters().await {
-            self.session_state.lock().await.user_info = previous_user_info;
-            return Err(error);
-        }
-        self.session_state.lock().await.emit_change();
-
-        Ok(())
+        self.update_rate_limiters().await
     }
 
     pub async fn set_target(&self, target: &Target) -> Result<(), WarpgateError> {
         use sea_orm::ActiveValue::Set;
 
-        let user_info = {
-            let state = self.session_state.lock().await;
-            // Do not emit a change if the target is the same as the previous one.
+        {
+            let mut state = self.session_state.lock().await;
             if state.target.as_ref() == Some(target) {
                 return Ok(());
             }
 
-            state.user_info.clone().ok_or_else(|| {
+            let user_info = state.user_info.clone().ok_or_else(|| {
                 WarpgateError::InconsistentState("set_target called before set_user_info".into())
-            })?
-        };
+            })?;
 
-        let db = &self.db;
+            Session::Entity::update_many()
+                .set(Session::ActiveModel {
+                    target_snapshot: Set(Some(
+                        serde_json::to_string(&target).map_err(WarpgateError::other)?,
+                    )),
+                    ..Default::default()
+                })
+                .filter(Session::Column::Id.eq(self.id))
+                .exec(&self.db)
+                .await?;
 
-        Session::Entity::update_many()
-            .set(Session::ActiveModel {
-                target_snapshot: Set(Some(
-                    serde_json::to_string(&target).map_err(WarpgateError::other)?,
-                )),
-                ..Default::default()
-            })
-            .filter(Session::Column::Id.eq(self.id))
-            .exec(db)
-            .await?;
+            let previous_target = state.target.replace(target.clone());
+            state.emit_change();
 
-        let previous_target = {
-            let mut state = self.session_state.lock().await;
-            state.target.replace(target.clone())
-        };
-
-        if let Err(error) = self.update_rate_limiters().await {
-            self.session_state.lock().await.target = previous_target;
-            return Err(error);
-        }
-        self.session_state.lock().await.emit_change();
-
-        if previous_target.as_ref().map(|x| x.id) != Some(target.id) {
-            AuditEvent::TargetSessionStarted {
-                session_id: self.id,
-                target_id: target.id,
-                target_name: target.name.clone(),
-                user_id: user_info.id,
-                username: user_info.username.clone(),
+            if previous_target.map(|x| x.id) != Some(target.id) {
+                AuditEvent::TargetSessionStarted {
+                    session_id: self.id,
+                    target_id: target.id,
+                    target_name: target.name.clone(),
+                    user_id: user_info.id,
+                    username: user_info.username,
+                }
+                .emit();
             }
-            .emit();
         }
 
-        Ok(())
+        self.update_rate_limiters().await
     }
 
     pub async fn wrap_stream<S>(

--- a/warpgate-core/src/protocols/handle.rs
+++ b/warpgate-core/src/protocols/handle.rs
@@ -54,41 +54,52 @@ impl WarpgateServerHandle {
         use sea_orm::ActiveValue::Set;
 
         {
-            let mut state = self.session_state.lock().await;
-            state.user_info = Some(user_info.clone());
-            state.emit_change();
+            let state = self.session_state.lock().await;
+            // Kubernetes reuses one session handle for many requests. Avoid emitting a
+            // change and writing the same username to the session row for every request.
+            if state.user_info.as_ref() == Some(&user_info) {
+                return Ok(());
+            }
         }
 
         let db = &self.db;
 
         Session::Entity::update_many()
             .set(Session::ActiveModel {
-                username: Set(Some(user_info.username)),
+                username: Set(Some(user_info.username.clone())),
                 ..Default::default()
             })
             .filter(Session::Column::Id.eq(self.id))
             .exec(db)
             .await?;
 
+        let previous_user_info = {
+            let mut state = self.session_state.lock().await;
+            state.user_info.replace(user_info)
+        };
 
-        self.update_rate_limiters().await?;
+        if let Err(error) = self.update_rate_limiters().await {
+            self.session_state.lock().await.user_info = previous_user_info;
+            return Err(error);
+        }
+        self.session_state.lock().await.emit_change();
 
         Ok(())
     }
 
     pub async fn set_target(&self, target: &Target) -> Result<(), WarpgateError> {
         use sea_orm::ActiveValue::Set;
-        let previous_target = {
-            let mut state = self.session_state.lock().await;
-            let previous_target = state.target.replace(target.clone());
-            state.emit_change();
-            previous_target
-        };
 
-        let Some(user_info) = self.session_state.lock().await.user_info.clone() else {
-            return Err(WarpgateError::InconsistentState(
-                "set_target called before set_user_info".into(),
-            ));
+        let user_info = {
+            let state = self.session_state.lock().await;
+            // Do not emit a change if the target is the same as the previous one.
+            if state.target.as_ref() == Some(target) {
+                return Ok(());
+            }
+
+            state.user_info.clone().ok_or_else(|| {
+                WarpgateError::InconsistentState("set_target called before set_user_info".into())
+            })?
         };
 
         let db = &self.db;
@@ -104,8 +115,18 @@ impl WarpgateServerHandle {
             .exec(db)
             .await?;
 
+        let previous_target = {
+            let mut state = self.session_state.lock().await;
+            state.target.replace(target.clone())
+        };
 
-        if previous_target.map(|x| x.id) != Some(target.id) {
+        if let Err(error) = self.update_rate_limiters().await {
+            self.session_state.lock().await.target = previous_target;
+            return Err(error);
+        }
+        self.session_state.lock().await.emit_change();
+
+        if previous_target.as_ref().map(|x| x.id) != Some(target.id) {
             AuditEvent::TargetSessionStarted {
                 session_id: self.id,
                 target_id: target.id,
@@ -115,8 +136,6 @@ impl WarpgateServerHandle {
             }
             .emit();
         }
-
-        self.update_rate_limiters().await?;
 
         Ok(())
     }


### PR DESCRIPTION
## Description
Kubernetes and HTTP targets make use of set_target and set_user_info. These functions run once per request, and are quite expensive (JSON serialization and DB call). In 99% of cases they are however simply an expensive no-op as the DB state is already equal to the request state.

This PR guards this such that set_Target and set_user_info only run when they will actually change the state, as we have access to both the session state and the request state in the context already. 

Furthermore, the order of operations of the code was a bit scary, as the memory state was committed before the DB state, meaning that a DB update failure would lead to a desync between DB state and memory state. This was somewhat fine in the previous implementation, as it would fix itself on the next request if it got desynced. But in the new approach, we are running less DB updates, so it won't fix itself as easily. So reorder the operations to first execute a succesful DB commit before committing the memory change.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
