### PR TITLE
Revert "Terminate HTTP target WebSockets on logout (#2111)"

### DIFF
--- a/tests/test_http_websocket.py
+++ b/tests/test_http_websocket.py
@@ -1,12 +1,6 @@
 import ssl
-import time
-
 import requests
-from websocket import (
-    WebSocketConnectionClosedException,
-    WebSocketTimeoutException,
-    create_connection,
-)
+from websocket import create_connection
 from uuid import uuid4
 
 from .api_client import admin_client, sdk
@@ -64,72 +58,4 @@ class TestHTTPWebsocket:
         ws.send_binary(b"test")
         assert ws.recv() == b"test"
         ws.ping()
-        ws.close()
-
-    def test_logout_closes_connection(
-        self,
-        echo_server_port,
-        shared_wg: WarpgateProcess,
-    ):
-        url = f"https://localhost:{shared_wg.http_port}"
-        with admin_client(url) as api:
-            role = api.create_role(sdk.RoleDataRequest(name=f"role-{uuid4()}"))
-            user = api.create_user(sdk.CreateUserRequest(username=f"user-{uuid4()}"))
-            api.create_password_credential(
-                user.id, sdk.NewPasswordCredential(password="123")
-            )
-            api.add_user_role(user.id, role.id)
-            echo_target = api.create_target(sdk.TargetDataRequest(
-                name=f"echo-{uuid4()}",
-                options=sdk.TargetOptions(sdk.TargetOptionsTargetHTTPOptions(
-                    kind="Http",
-                    url=f"http://localhost:{echo_server_port}",
-                    tls=sdk.Tls(
-                        mode=sdk.TlsMode.DISABLED,
-                        verify=False,
-                    ),
-                )),
-            ))
-            api.add_target_role(echo_target.id, role.id)
-
-        session = requests.Session()
-        session.verify = False
-
-        response = session.post(
-            f"{url}/@warpgate/api/auth/login",
-            json={
-                "username": user.username,
-                "password": "123",
-            },
-        )
-        assert response.status_code // 100 == 2
-
-        cookies = session.cookies.get_dict()
-        cookie = "; ".join([f"{k}={v}" for k, v in cookies.items()])
-        ws = create_connection(
-            f"wss://localhost:{shared_wg.http_port}/socket?warpgate-target={echo_target.name}",
-            cookie=cookie,
-            sslopt={"cert_reqs": ssl.CERT_NONE},
-        )
-        ws.send("test")
-        assert ws.recv() == "test"
-
-        response = session.post(f"{url}/@warpgate/api/auth/logout")
-        assert response.status_code // 100 == 2
-
-        ws.settimeout(0.25)
-        deadline = time.monotonic() + 5
-        closed = False
-        while time.monotonic() < deadline:
-            try:
-                if ws.recv() == "":
-                    closed = True
-                    break
-            except WebSocketConnectionClosedException:
-                closed = True
-                break
-            except WebSocketTimeoutException:
-                continue
-
-        assert closed
         ws.close()

--- a/warpgate-protocol-http/src/proxy.rs
+++ b/warpgate-protocol-http/src/proxy.rs
@@ -11,10 +11,8 @@ use http::header::HeaderName;
 use http::uri::{Authority, PathAndQuery, Scheme};
 use http::{HeaderValue, StatusCode, Uri};
 use poem::session::Session;
-use poem::web::Data;
 use poem::web::websocket::WebSocket;
 use poem::{Body, FromRequest, IntoResponse, Request, Response};
-use tokio::sync::Mutex;
 use tokio_tungstenite::{Connector, connect_async_tls_with_config, tungstenite};
 use tracing::{debug, error, warn};
 use url::{Url, form_urlencoded};
@@ -24,15 +22,12 @@ use warpgate_common::http_headers::{
 };
 use warpgate_common::{TargetHTTPOptions, WarpgateError, try_block};
 use warpgate_common_http::logging::{get_client_ip, log_request_result};
-use warpgate_common_http::{
-    AuthenticatedRequestContext, RequestAuthorization, SessionAuthorization,
-};
+use warpgate_common_http::{AuthenticatedRequestContext, SessionAuthorization};
 use warpgate_tls::{TlsMode, configure_tls_connector};
 use warpgate_web::lookup_built_file;
 
 use crate::client_cache::HttpClientCache;
 use crate::common::SessionExt;
-use crate::session::SessionStore;
 
 static X_WARPGATE_USERNAME: HeaderName = HeaderName::from_static("x-warpgate-username");
 static X_WARPGATE_AUTHENTICATION_TYPE: HeaderName =
@@ -448,20 +443,6 @@ async fn proxy_ws_inner(
     ctx: &AuthenticatedRequestContext,
     options: &TargetHTTPOptions,
 ) -> poem::Result<impl IntoResponse> {
-    let session_middleware = Data::<&Arc<Mutex<SessionStore>>>::from_request_without_body(req)
-        .await?
-        .clone();
-    let session = <&Session>::from_request_without_body(req).await?;
-    let mut close_rx = session_middleware.lock().await.close_receiver_for(session);
-    if close_rx.is_none()
-        && matches!(
-            &ctx.auth,
-            RequestAuthorization::Session(SessionAuthorization::User { .. })
-        )
-    {
-        return Err(poem::Error::from_status(StatusCode::UNAUTHORIZED));
-    }
-
     let (authorization_header, uri) = extract_basic_auth(uri)?;
     let mut client_request = http::request::Builder::new()
         .uri(uri.clone())
@@ -514,7 +495,7 @@ async fn proxy_ws_inner(
             let (server_sink, server_source) = socket.split();
 
             if let Err(error) = {
-                let mut server_to_client =
+                let server_to_client =
                     tokio::spawn(pump_websocket(server_source, client_sink, |msg| {
                         Box::pin(async {
                             tracing::debug!("Server: {:?}", msg);
@@ -522,7 +503,7 @@ async fn proxy_ws_inner(
                         })
                     }));
 
-                let mut client_to_server =
+                let client_to_server =
                     tokio::spawn(pump_websocket(client_source, server_sink, |msg| {
                         Box::pin(async {
                             tracing::debug!("Client: {:?}", msg);
@@ -530,47 +511,8 @@ async fn proxy_ws_inner(
                         })
                     }));
 
-                let (server_finished, pump_result): (
-                    bool,
-                    Option<Result<anyhow::Result<()>, tokio::task::JoinError>>,
-                ) = tokio::select! {
-                    result = &mut server_to_client => {
-                        (true, Some(result))
-                    }
-                    result = &mut client_to_server => {
-                        (false, Some(result))
-                    }
-                    () = async {
-                        match close_rx.as_mut() {
-                            Some(close_rx) => {
-                                let _ = close_rx.recv().await;
-                            }
-                            None => std::future::pending::<()>().await,
-                        }
-                    } => {
-                        (false, None)
-                    }
-                };
-
-                match pump_result {
-                    Some(result) if server_finished => {
-                        client_to_server.abort();
-                        let _ = client_to_server.await;
-                        result.context("server-to-client WebSocket pump task failed")??;
-                    }
-                    Some(result) => {
-                        server_to_client.abort();
-                        let _ = server_to_client.await;
-                        result.context("client-to-server WebSocket pump task failed")??;
-                    }
-                    None => {
-                        debug!("Closing WebSocket stream after HTTP session ended");
-                        server_to_client.abort();
-                        client_to_server.abort();
-                        let _ = server_to_client.await;
-                        let _ = client_to_server.await;
-                    }
-                }
+                server_to_client.await??;
+                client_to_server.await??;
                 debug!("Closing Websocket stream");
 
                 Ok::<_, anyhow::Error>(())

--- a/warpgate-protocol-http/src/session.rs
+++ b/warpgate-protocol-http/src/session.rs
@@ -6,7 +6,7 @@ use poem::session::{MemoryStorage, Session, SessionStorage};
 use poem::web::{Data, RemoteAddr};
 use poem::{FromRequest, Request};
 use serde_json::Value;
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::Mutex;
 use tracing::info;
 use warpgate_common::SessionId;
 use warpgate_common_http::auth::UnauthenticatedRequestContext;
@@ -58,7 +58,6 @@ impl SessionStorage for SharedSessionStorage {
 
 pub struct SessionStore {
     session_handles: HashMap<SessionId, Arc<Mutex<WarpgateServerHandle>>>,
-    session_close_senders: HashMap<SessionId, broadcast::Sender<()>>,
     session_timestamps: HashMap<SessionId, Instant>,
     this: Weak<Mutex<Self>>,
 }
@@ -71,7 +70,6 @@ impl SessionStore {
         Arc::new_cyclic(|me| {
             Mutex::new(Self {
                 session_handles: HashMap::new(),
-                session_close_senders: HashMap::new(),
                 session_timestamps: HashMap::new(),
                 this: me.clone(),
             })
@@ -121,9 +119,7 @@ impl SessionStore {
         .await?;
 
         let id = server_handle.lock().await.id();
-        let (session_close_sender, _) = broadcast::channel(1);
         self.session_handles.insert(id, server_handle.clone());
-        self.session_close_senders.insert(id, session_close_sender);
 
         session.set(SESSION_ID_SESSION_KEY, id);
 
@@ -142,7 +138,8 @@ impl SessionStore {
                             }
                             info!(%id, "Removed HTTP session");
                             let mut that = this.lock().await;
-                            that.remove_session_by_id(id);
+                            that.session_handles.remove(&id);
+                            that.session_timestamps.remove(&id);
                         }
                     }
                 }
@@ -161,19 +158,10 @@ impl SessionStore {
             .and_then(|id| self.session_handles.get(&id).cloned())
     }
 
-    pub fn close_receiver_for(&self, session: &Session) -> Option<broadcast::Receiver<()>> {
-        session
-            .get::<SessionId>(SESSION_ID_SESSION_KEY)
-            .and_then(|id| {
-                self.session_close_senders
-                    .get(&id)
-                    .map(|sender| sender.subscribe())
-            })
-    }
-
     pub fn remove_session(&mut self, session: &Session) {
         if let Some(id) = session.get::<SessionId>(SESSION_ID_SESSION_KEY) {
-            self.remove_session_by_id(id);
+            self.session_handles.remove(&id);
+            self.session_timestamps.remove(&id);
         }
     }
 
@@ -186,15 +174,8 @@ impl SessionStore {
             }
         }
         for id in to_remove {
-            self.remove_session_by_id(id);
+            self.session_handles.remove(&id);
+            self.session_timestamps.remove(&id);
         }
-    }
-
-    fn remove_session_by_id(&mut self, id: SessionId) {
-        if let Some(sender) = self.session_close_senders.remove(&id) {
-            let _ = sender.send(());
-        }
-        self.session_handles.remove(&id);
-        self.session_timestamps.remove(&id);
     }
 }


### PR DESCRIPTION
This reverts commit d8f898ab02c086b228bc46a342ea706c442b9cef.

## Description
I created an issue sometime ago in Warpgate about it not closing websockets on logout, which meant you could continue sending websocket traffic after you logged out. As a response to this, a contribution was opened that closed websockets when an HTTP session terminated, which got released on 0.26.

We use a lot of code-server (web-based vscode) through warpgate HTTP, and we started noticing vscode throwing WebSocket failures in the new version: `The workbench failed to connect to the server (Error: WebSocket close with status code 1006)`. This always happened after Warpgate terminated an HTTP session, and could only be fixed by clearing your browser cookies. Until you cleared your browser cookies, vscode would no longer be usable.

One thing I noticed is that Warpgate was closing the websockets forcefully, without sending a graceful close signal. This would have been a very logical reason for the vscode issue, especially because vscode reported a forceful websocket close. However, I tried to add graceful closure, but then during testing I would still get the issue in vscode, even when trying to gracefully close.

Furthermore, session handling in Warpgate is a bit weird where it doesn't always seem to be starting new sessions properly after a previous session has been expired, so doing websocket closure is in general a bit scary on http session termination with the current setup.

I would personally argue that the websocket issues that we are now getting are a lot more important than not properly closing websockets on logout, so I would suggest to revert this change now, so it can make the next release, and then we can more long term look into a more stable, deeply tested version of this that does not cause serious websocket issues.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [x] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
