### PR TITLE
[HELM] Add support for loadBalancerSourceRanges in the Service template

### DIFF
--- a/helm/warpgate/templates/service.yaml
+++ b/helm/warpgate/templates/service.yaml
@@ -10,6 +10,10 @@ metadata:
   {{- end}}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
     {{- with .Values.service.ports.ssh }}
     {{- if ne (int .) 0 }}


### PR DESCRIPTION
## Description

This PR adds support for configuring `loadBalancerSourceRanges` for the Warpgate Service.

The field is rendered only when:

- `service.type` is set to `LoadBalancer`
- `service.loadBalancerSourceRanges` is defined and not empty

This allows users to restrict access to the LoadBalancer by specifying allowed source CIDR ranges while avoiding unnecessary configuration for other Service types.

Example:

```yaml
service:
  type: LoadBalancer
  loadBalancerSourceRanges:
    - 123.123.123.0/24
    - 10.0.0.0/8
```

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [x] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)
