### PR TITLE
fix(web): namespace the theme localStorage key

### DIFF
--- a/warpgate-web/src/theme/index.ts
+++ b/warpgate-web/src/theme/index.ts
@@ -6,7 +6,15 @@ import { get, writable } from 'svelte/store'
 type ThemeFileName = 'dark' | 'light'
 type ThemeName = ThemeFileName | 'auto'
 
-const savedTheme = (localStorage.getItem('theme') ?? 'auto') as ThemeName
+// Namespaced, like every other key we store (warpgateMenuLocation,
+// warpgateWebSSHFontSize, the `warpgate:` prefix in common/autosave.ts).
+// HTTP targets are proxied at the portal root, so the portal shares one
+// localStorage with every app it proxies, and a bare `theme` collides. Argo CD
+// keeps its own `theme` JSON-encoded and JSON.parses it at module scope, so our
+// raw 'auto' made JSON.parse throw and its whole bundle died before mounting:
+// the proxied UI rendered blank.
+const THEME_KEY = 'warpgateTheme'
+const savedTheme = (localStorage.getItem(THEME_KEY) ?? 'auto') as ThemeName
 export const currentTheme = writable(savedTheme)
 export const currentThemeFile = writable<ThemeFileName>('dark')
 
@@ -35,7 +43,7 @@ window
     })
 
 export function setCurrentTheme(theme: ThemeName): void {
-    localStorage.setItem('theme', theme)
+    localStorage.setItem(THEME_KEY, theme)
     currentTheme.set(theme)
     if (theme === 'auto') {
         if (window.matchMedia?.('(prefers-color-scheme: dark)').matches) {


### PR DESCRIPTION
## Description

`warpgate-web` stores its theme preference under a bare `theme` key in `localStorage`. Every other key it stores is namespaced (`warpgateMenuLocation`, `warpgateWebSSHFontSize`, and the `warpgate:` prefix applied in `common/autosave.ts`), so this looks like an oversight rather than intent.

It matters more than a naming nit because **HTTP targets are proxied at the portal root**. The portal therefore shares an origin, and so a single `localStorage`, with every app it proxies. A bare `theme` collides with any proxied app that uses the same name.

Argo CD does exactly that, and stores it JSON-encoded while Warpgate stores a raw string. Argo CD reads it at module top level:

```js
const t = JSON.parse(window.localStorage.getItem('theme')) || 'light'
```

so Warpgate's raw `auto` makes `JSON.parse` throw, Argo CD's bundle dies before it mounts, and the proxied UI renders a blank page with only a favicon:

```
Uncaught SyntaxError: Unexpected token 'a', "auto" is not valid JSON
    at JSON.parse (<anonymous>)
    at main.<hash>.js
```

A private window does not help. `setCurrentTheme(savedTheme)` runs on every load, and you must pass through the portal to select a target, so every fresh profile writes the key before the target is ever reached. This is deterministic, not a race.

### The change

Rename the key to `warpgateTheme`. Two lines.

Deliberately **no migration**: losing a theme preference once is cheaper than the code to carry it, and this is pre-1.0.

Deliberately **no `localStorage.removeItem('theme')`** cleanup either. It is tempting, since it would un-break browsers that already hold the poisoned value, but after this rename that key belongs to whichever app is being proxied. Argo CD keeps a legitimate JSON value there, so deleting it on every portal load would destroy the user's Argo CD preference instead. Not our key to touch.

Existing browsers therefore keep a stale `theme` until the proxied app overwrites it with its own value, or the user clears it once. Worth noting in case you'd rather handle that differently.

### Testing

Verified against a live 0.25.4 deployment: with the key renamed, the raw `auto` value is no longer written to the shared key, which is what was killing the proxied Argo CD bundle. I confirmed the mechanism end to end on the deployed instance before changing anything, including that every asset and API call was served correctly and that the crash was purely the `JSON.parse` at module scope.

I could not run `npm run check` locally: `postinstall` needs `cargo` and `openapi-generator-cli` to regenerate the API clients, which I didn't want to do on a stale checkout. The diff is two identifier substitutions with no type surface change, so I'd rather flag that honestly than imply I'd run the suite.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*

For transparency, since the intent of that section is to speed up review: the diagnosis and patch were AI-produced, then reviewed by a human who rejected two of the proposals along the way. A value-migration path was cut as unnecessary pre-1.0, and a `removeItem('theme')` cleanup was cut because it would clobber the proxied app's own key. Both of those judgements are the human reviewer's, and the reasoning is recorded in the commit message.
