### PR TITLE
make sure "close all sessions" closes sessions on all nodes

### DIFF
--- a/tests/test_cluster_failover.py
+++ b/tests/test_cluster_failover.py
@@ -130,6 +130,35 @@ class Test:
             node_b.config_path, session_id
         ), "dead node's session was not marked ended"
 
+    def test_close_all_sessions_fans_out(
+        self,
+        processes: ProcessManager,
+        timeout,
+        wg_c_ed25519_pubkey,
+    ):
+        # A session lives only on the node that owns it, so close-all issued on
+        # B must reach A's session too.
+        node_a = processes.start_wg()
+        wait_port(node_a.http_port, recv=False)
+        node_b = processes.start_wg(share_with=node_a)
+        wait_port(node_b.http_port, recv=False)
+
+        session_id, _ = _open_session_on_a(
+            processes, node_a, wg_c_ed25519_pubkey, timeout
+        )
+
+        with admin_client(f"https://localhost:{node_b.http_port}") as api:
+            api.close_all_sessions()
+
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline and not _session_ended(
+            node_a.config_path, session_id
+        ):
+            time.sleep(0.5)
+        assert _session_ended(
+            node_a.config_path, session_id
+        ), "close-all on node B did not close node A's session"
+
     def test_proxy_fails_cleanly_when_owner_dies(
         self,
         processes: ProcessManager,

--- a/warpgate-admin/src/api/admin_scheme.rs
+++ b/warpgate-admin/src/api/admin_scheme.rs
@@ -135,12 +135,27 @@ pub(crate) struct ClusterOrAdminTokenAuth(AdminAccess);
 )]
 pub(crate) struct ClusterOrAdminCookieAuth(AdminAccess);
 
+/// Peer-to-peer cluster token.
+// A forwarded request carries no admin token or cookie - the cluster token header is its only
+// credential, so it has to be a key this scheme accepts. The value here is not trusted:
+// `cluster_or_admin_access` goes by the authorization the middleware already validated.
+#[derive(SecurityScheme)]
+#[oai(
+    rename = "ClusterTokenSecurityScheme",
+    ty = "api_key",
+    key_name = "X-Warpgate-Cluster-Token",
+    key_in = "header",
+    checker = "cluster_or_admin_access"
+)]
+pub(crate) struct ClusterTokenAuth(AdminAccess);
+
 /// Like [`AdminContext`], but also accepts a cluster token (peer-forwarded admin requests).
 /// Use only on endpoints that are legitimately cross-node forwardable.
 #[derive(SecurityScheme)]
 pub(crate) enum ClusterOrAdminContext {
     Token(ClusterOrAdminTokenAuth),
     Cookie(ClusterOrAdminCookieAuth),
+    ClusterToken(ClusterTokenAuth),
 }
 
 impl ClusterOrAdminContext {
@@ -148,6 +163,7 @@ impl ClusterOrAdminContext {
         match self {
             Self::Token(t) => &t.0,
             Self::Cookie(c) => &c.0,
+            Self::ClusterToken(t) => &t.0,
         }
     }
 

--- a/warpgate-admin/src/api/cluster_proxy.rs
+++ b/warpgate-admin/src/api/cluster_proxy.rs
@@ -43,16 +43,22 @@ pub enum Owner {
     Remote(RemoteNode),
 }
 
+impl From<Node::Model> for RemoteNode {
+    fn from(node: Node::Model) -> Self {
+        Self {
+            address: node.address,
+            tls_spki_sha256: node.tls_spki_sha256,
+        }
+    }
+}
+
 impl Owner {
     pub fn local() -> Self {
         Self::Local
     }
 
     pub fn remote(node: Node::Model) -> Self {
-        Self::Remote(RemoteNode {
-            address: node.address,
-            tls_spki_sha256: node.tls_spki_sha256,
-        })
+        Self::Remote(node.into())
     }
 }
 
@@ -174,11 +180,22 @@ pub(crate) async fn forward_http(
     owner: RemoteNode,
     token: &Secret<String>,
 ) -> poem::Result<Response> {
+    forward_http_to(ctx, req, &path_and_query(req), owner, token).await
+}
+
+/// [`forward_http`], but to `path` on the peer rather than the request's own
+/// path - for when the peer's copy of the request needs different parameters.
+pub(crate) async fn forward_http_to(
+    ctx: &AuthenticatedRequestContext,
+    req: &Request,
+    path: &str,
+    owner: RemoteNode,
+    token: &Secret<String>,
+) -> poem::Result<Response> {
     let (tls, addrs) = peer_connection(ctx, &owner).await?;
     let url = format!(
-        "https://{CLUSTER_TLS_SNI_NAME}:{}{}",
+        "https://{CLUSTER_TLS_SNI_NAME}:{}{path}",
         peer_port(&addrs)?,
-        path_and_query(req)
     );
 
     let mut headers = poem::http::HeaderMap::new();

--- a/warpgate-admin/src/api/sessions_list.rs
+++ b/warpgate-admin/src/api/sessions_list.rs
@@ -1,4 +1,5 @@
 use futures::{SinkExt, StreamExt};
+use poem::http::StatusCode;
 use poem::session::Session;
 use poem::web::Data;
 use poem::web::websocket::{Message, WebSocket};
@@ -9,12 +10,15 @@ use poem_openapi::{ApiResponse, OpenApi};
 use sea_orm::prelude::Expr;
 use sea_orm::sea_query::Func;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+use tracing::warn;
 use warpgate_common::{AdminPermission, WarpgateError};
 use warpgate_common_http::AuthenticatedRequestContext;
 use warpgate_core::SessionSnapshot;
+use warpgate_db_entities::Node;
 
-use super::AdminContext;
 use super::pagination::{PaginatedResponse, PaginationParams};
+use super::{AdminContext, ClusterOrAdminContext};
+use crate::api::cluster_proxy::forward_http_to;
 use crate::api::common::require_admin_permission;
 
 pub struct Api;
@@ -86,21 +90,73 @@ impl Api {
     )]
     async fn api_close_all_sessions(
         &self,
-        admin: AdminContext,
+        admin: ClusterOrAdminContext,
         session: &Session,
+        req: &poem::Request,
+        /// Close only this node's own sessions instead of the whole cluster's.
+        /// Set on cluster-forwarded copies of the request.
+        local_only: Query<Option<bool>>,
     ) -> poem::Result<CloseAllSessionsResponse> {
         admin.require(AdminPermission::SessionsTerminate)?;
 
-        let state = admin.services().state.lock().await;
-
-        for s in state.sessions.values() {
-            let mut session = s.lock().await;
-            session.handle.close();
+        {
+            let state = admin.services().state.lock().await;
+            for s in state.sessions.values() {
+                s.lock().await.handle.close();
+            }
         }
 
         session.purge();
 
+        // A session's handle lives only on the node owning its connection, so
+        // the request goes out to every other node too.
+        if !local_only.unwrap_or(false) {
+            close_on_peers(&admin, req).await?;
+        }
+
         Ok(CloseAllSessionsResponse::Ok)
+    }
+}
+
+/// Forward the close-all request to every other registered cluster node.
+async fn close_on_peers(
+    ctx: &AuthenticatedRequestContext,
+    req: &poem::Request,
+) -> poem::Result<()> {
+    let services = ctx.services();
+    let peers = Node::Entity::find()
+        .filter(Node::Column::Id.ne(services.cluster.node_id))
+        .all(&services.db)
+        .await
+        .map_err(WarpgateError::from)?;
+
+    // `local_only` stops the peers from fanning out again
+    let path = format!("{}?local_only=true", req.original_uri().path());
+
+    let mut failed = vec![];
+    for peer in peers {
+        let hostname = peer.hostname.clone();
+        match forward_http_to(ctx, req, &path, peer.into(), &services.cluster_token).await {
+            Ok(response) if response.status() == StatusCode::CREATED => {}
+            Ok(response) => {
+                let status = response.status();
+                warn!(node = %hostname, %status, "Failed to close sessions on a cluster node");
+                failed.push(hostname);
+            }
+            Err(error) => {
+                warn!(node = %hostname, %error, "Failed to close sessions on a cluster node");
+                failed.push(hostname);
+            }
+        }
+    }
+
+    if failed.is_empty() {
+        Ok(())
+    } else {
+        Err(poem::Error::from_string(
+            format!("Failed to close sessions on: {}", failed.join(", ")),
+            StatusCode::BAD_GATEWAY,
+        ))
     }
 }
 

--- a/warpgate-admin/src/api/sessions_list.rs
+++ b/warpgate-admin/src/api/sessions_list.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use futures::{SinkExt, StreamExt};
 use poem::http::StatusCode;
 use poem::session::Session;
@@ -10,6 +12,7 @@ use poem_openapi::{ApiResponse, OpenApi};
 use sea_orm::prelude::Expr;
 use sea_orm::sea_query::Func;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+use tokio::time::timeout;
 use tracing::warn;
 use warpgate_common::{AdminPermission, WarpgateError};
 use warpgate_common_http::AuthenticatedRequestContext;
@@ -111,52 +114,55 @@ impl Api {
         // A session's handle lives only on the node owning its connection, so
         // the request goes out to every other node too.
         if !local_only.unwrap_or(false) {
-            close_on_peers(&admin, req).await?;
+            close_on_peers(&admin, req).await;
         }
 
         Ok(CloseAllSessionsResponse::Ok)
     }
 }
 
+/// How long a single peer gets to close its sessions. A node that is registered
+/// but unreachable must not hold up the rest of the fan-out.
+const PEER_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Forward the close-all request to every other registered cluster node.
-async fn close_on_peers(
-    ctx: &AuthenticatedRequestContext,
-    req: &poem::Request,
-) -> poem::Result<()> {
+///
+/// Best effort: a node can be registered but already gone (a crashed node stays
+/// in the registry until the reaper drops it), and its sessions get marked ended
+/// there anyway - so an unreachable peer is logged, not raised.
+async fn close_on_peers(ctx: &AuthenticatedRequestContext, req: &poem::Request) {
     let services = ctx.services();
     let peers = Node::Entity::find()
         .filter(Node::Column::Id.ne(services.cluster.node_id))
         .all(&services.db)
-        .await
-        .map_err(WarpgateError::from)?;
+        .await;
+    let peers = match peers {
+        Ok(peers) => peers,
+        Err(error) => {
+            warn!(%error, "Failed to list cluster nodes");
+            return;
+        }
+    };
 
     // `local_only` stops the peers from fanning out again
     let path = format!("{}?local_only=true", req.original_uri().path());
 
-    let mut failed = vec![];
     for peer in peers {
         let hostname = peer.hostname.clone();
-        match forward_http_to(ctx, req, &path, peer.into(), &services.cluster_token).await {
-            Ok(response) if response.status() == StatusCode::CREATED => {}
-            Ok(response) => {
+        let forward = forward_http_to(ctx, req, &path, peer.into(), &services.cluster_token);
+        match timeout(PEER_TIMEOUT, forward).await {
+            Ok(Ok(response)) if response.status() == StatusCode::CREATED => {}
+            Ok(Ok(response)) => {
                 let status = response.status();
                 warn!(node = %hostname, %status, "Failed to close sessions on a cluster node");
-                failed.push(hostname);
             }
-            Err(error) => {
+            Ok(Err(error)) => {
                 warn!(node = %hostname, %error, "Failed to close sessions on a cluster node");
-                failed.push(hostname);
+            }
+            Err(_) => {
+                warn!(node = %hostname, "Timed out closing sessions on a cluster node");
             }
         }
-    }
-
-    if failed.is_empty() {
-        Ok(())
-    } else {
-        Err(poem::Error::from_string(
-            format!("Failed to close sessions on: {}", failed.join(", ")),
-            StatusCode::BAD_GATEWAY,
-        ))
     }
 }
 

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -90,6 +90,19 @@
         "operationId": "get_sessions"
       },
       "delete": {
+        "parameters": [
+          {
+            "name": "local_only",
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "description": "Close only this node's own sessions instead of the whole cluster's.\nSet on cluster-forwarded copies of the request.",
+            "required": false,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
         "responses": {
           "201": {
             "description": ""
@@ -101,6 +114,9 @@
           },
           {
             "CookieSecurityScheme": []
+          },
+          {
+            "ClusterTokenSecurityScheme": []
           }
         ],
         "operationId": "close_all_sessions"
@@ -217,6 +233,9 @@
           },
           {
             "CookieSecurityScheme": []
+          },
+          {
+            "ClusterTokenSecurityScheme": []
           }
         ],
         "operationId": "close_session"
@@ -258,6 +277,9 @@
           },
           {
             "CookieSecurityScheme": []
+          },
+          {
+            "ClusterTokenSecurityScheme": []
           }
         ],
         "operationId": "get_recording"
@@ -7728,6 +7750,12 @@
       }
     },
     "securitySchemes": {
+      "ClusterTokenSecurityScheme": {
+        "type": "apiKey",
+        "description": "Peer-to-peer cluster token.",
+        "name": "X-Warpgate-Cluster-Token",
+        "in": "header"
+      },
       "CookieSecurityScheme": {
         "type": "apiKey",
         "name": "warpgate-http-session",


### PR DESCRIPTION
## Description

...

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
