### PR TITLE
feat(http): forward the SSO access token to HTTP targets on request

### DIFF
--- a/warpgate-protocol-http/src/api/sso_provider_list.rs
+++ b/warpgate-protocol-http/src/api/sso_provider_list.rs
@@ -361,6 +361,7 @@ impl Api {
             session.set_sso_login_state(SsoLoginState {
                 provider: context.provider,
                 token: response.id_token.clone(),
+                access_token: response.access_token.clone(),
                 supports_single_logout: context.supports_single_logout,
             });
         }

--- a/warpgate-protocol-http/src/common.rs
+++ b/warpgate-protocol-http/src/common.rs
@@ -48,6 +48,9 @@ pub fn host_is_subdomain_of_or_equal(host: &str, base_domain: &str) -> bool {
 #[derive(Serialize, Deserialize)]
 pub struct SsoLoginState {
     pub token: WarpgateIdToken,
+    /// The OAuth access token from the same authorization, when the provider
+    /// issued one. Absent for flows without a code exchange.
+    pub access_token: Option<String>,
     pub provider: String,
     pub supports_single_logout: bool,
 }

--- a/warpgate-protocol-http/src/proxy.rs
+++ b/warpgate-protocol-http/src/proxy.rs
@@ -165,13 +165,53 @@ fn copy_client_response<R: SomeResponse>(
     server_response.set_status(client_response.status());
 }
 
-fn rewrite_request<B: SomeRequestBuilder>(mut req: B, options: &TargetHTTPOptions) -> Result<B> {
+/// Placeholder for the user's OAuth **access token**.
+///
+/// This is the credential intended for calling downstream APIs, and is what a
+/// target should normally request. It carries the audience and scopes the
+/// authorization server issued it with, so the upstream can make a real
+/// authorization decision rather than inferring one.
+///
+/// Example header value: `Bearer ${WARPGATE_SSO_ACCESS_TOKEN}`
+pub const SSO_ACCESS_TOKEN_PLACEHOLDER: &str = "${WARPGATE_SSO_ACCESS_TOKEN}";
+
+fn rewrite_request<B: SomeRequestBuilder>(
+    mut req: B,
+    options: &TargetHTTPOptions,
+    access_token: Option<&str>,
+) -> Result<B> {
     if let Some(ref headers) = options.headers {
         for (k, v) in headers {
-            req = req.header(HeaderName::try_from(k)?, v);
+            if !v.contains(SSO_ACCESS_TOKEN_PLACEHOLDER) {
+                req = req.header(HeaderName::try_from(k)?, v);
+                continue;
+            }
+            // Drop the header entirely when the session has no access token
+            // (password or ticket auth, or a provider that issued none) rather
+            // than forwarding the literal placeholder, which the upstream would
+            // read as a malformed credential.
+            let Some(token) = access_token else {
+                debug!(
+                    header = %k,
+                    "Skipping header: it requests an SSO access token this session does not have"
+                );
+                continue;
+            };
+            req = req.header(
+                HeaderName::try_from(k)?,
+                v.replace(SSO_ACCESS_TOKEN_PLACEHOLDER, token),
+            );
         }
     }
     Ok(req)
+}
+
+/// The SSO tokens for this browser session, if the user authenticated via SSO.
+/// Kept out of logs deliberately.
+/// The access token from this session's SSO login, if it has one.
+async fn sso_access_token_for(req: &Request) -> Option<String> {
+    let session = <&Session>::from_request_without_body(req).await.ok()?;
+    session.get_sso_login_state()?.access_token
 }
 
 fn rewrite_response(
@@ -296,7 +336,8 @@ pub async fn proxy_normal_request(
     client_request = copy_server_request(req, client_request);
     client_request = inject_forwarding_headers(req, ctx, client_request);
     client_request = inject_own_headers(req, client_request).await?;
-    client_request = rewrite_request(client_request, options)?;
+    let access_token = sso_access_token_for(req).await;
+    client_request = rewrite_request(client_request, options, access_token.as_deref())?;
     if let Some(authorization_header) = authorization_header {
         client_request = client_request.header(http::header::AUTHORIZATION, authorization_header);
     }
@@ -484,7 +525,8 @@ async fn proxy_ws_inner(
     client_request = copy_server_request(req, client_request);
     client_request = inject_forwarding_headers(req, ctx, client_request);
     client_request = inject_own_headers(req, client_request).await?;
-    client_request = rewrite_request(client_request, options)?;
+    let access_token = sso_access_token_for(req).await;
+    client_request = rewrite_request(client_request, options, access_token.as_deref())?;
 
     let tls_config = configure_tls_connector(!options.tls.verify, false, None)
         .await
@@ -588,6 +630,69 @@ async fn proxy_ws_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Minimal builder that records the headers `rewrite_request` sets, so the
+    /// substitution can be asserted without a live upstream.
+    #[derive(Default)]
+    struct RecordingBuilder {
+        headers: Vec<(String, String)>,
+    }
+
+    impl SomeRequestBuilder for RecordingBuilder {
+        fn header<K: Into<HeaderName>, V>(mut self, k: K, v: V) -> Self
+        where
+            HeaderValue: TryFrom<V>,
+            <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
+        {
+            let name: HeaderName = k.into();
+            if let Ok(value) = HeaderValue::try_from(v) {
+                self.headers.push((
+                    name.as_str().to_owned(),
+                    value.to_str().unwrap_or_default().to_owned(),
+                ));
+            }
+            self
+        }
+    }
+
+    fn options_with_header(value: &str) -> TargetHTTPOptions {
+        let mut o = make_options("https://upstream.invalid");
+        o.headers = Some([("Authorization".to_string(), value.to_string())].into());
+        o
+    }
+
+    fn sent(value: &str, access_token: Option<&str>) -> Vec<(String, String)> {
+        rewrite_request(
+            RecordingBuilder::default(),
+            &options_with_header(value),
+            access_token,
+        )
+        .unwrap()
+        .headers
+    }
+
+    #[test]
+    fn substitutes_the_access_token() {
+        let got = sent("Bearer ${WARPGATE_SSO_ACCESS_TOKEN}", Some("at-abc"));
+        assert_eq!(got, vec![("authorization".into(), "Bearer at-abc".into())]);
+    }
+
+    /// A session may have no access token — password or ticket auth, or a
+    /// provider that issued none. The header must be dropped, never sent with
+    /// the literal placeholder, which the upstream would read as a malformed
+    /// credential.
+    #[test]
+    fn drops_the_header_when_the_session_has_no_access_token() {
+        assert!(sent("Bearer ${WARPGATE_SSO_ACCESS_TOKEN}", None).is_empty());
+    }
+
+    /// Headers without a placeholder must pass through untouched, and must not
+    /// be affected by the absence of a token.
+    #[test]
+    fn leaves_static_headers_alone() {
+        let got = sent("Basic c3RhdGlj", None);
+        assert_eq!(got, vec![("authorization".into(), "Basic c3RhdGlj".into())]);
+    }
 
     fn make_options(url: &str) -> TargetHTTPOptions {
         TargetHTTPOptions {

--- a/warpgate-sso/src/request.rs
+++ b/warpgate-sso/src/request.rs
@@ -108,6 +108,7 @@ pub async fn map_sso_result(
         access_roles: access_groups,
         admin_roles: admin_groups,
         id_token: result.token.clone(),
+        access_token: result.access_token.clone(),
     }
 }
 

--- a/warpgate-sso/src/response.rs
+++ b/warpgate-sso/src/response.rs
@@ -8,5 +8,9 @@ pub struct SsoLoginResponse {
     pub access_roles: Option<Vec<String>>,
     pub admin_roles: Option<Vec<String>>,
     pub id_token: WarpgateIdToken,
+    /// The OAuth access token, when the provider issued one. Absent for flows
+    /// that verify a bare ID token (e.g. the kubectl bearer-token path), where
+    /// no code exchange happens and therefore no access token exists.
+    pub access_token: Option<String>,
     pub preferred_username: Option<String>,
 }

--- a/warpgate-sso/src/sso.rs
+++ b/warpgate-sso/src/sso.rs
@@ -122,6 +122,10 @@ type WarpgateClient = Client<
 
 pub struct SsoResult {
     pub token: WarpgateIdToken,
+    /// The OAuth access token from the same authorization, when the provider
+    /// issued one. This is the credential intended for calling downstream APIs;
+    /// the ID token is not (see RFC 9068 and OpenID Connect Core §2).
+    pub access_token: Option<String>,
     pub claims: WarpgateIdTokenClaims,
     pub userinfo_claims: Option<UserInfoClaims<WarpgateClaims, CoreGenderClaim>>,
 }
@@ -303,6 +307,7 @@ impl SsoClient {
 
         Ok(SsoResult {
             token: id_token.clone(),
+            access_token: Some(token_response.access_token().secret().to_owned()),
             userinfo_claims,
             claims: claims.clone(),
         })
@@ -362,6 +367,10 @@ impl SsoClient {
 
         Ok(SsoResult {
             token: id_token,
+            // This path verifies a bare ID token with no code exchange, so no
+            // access token exists. A target requesting one has the header
+            // dropped rather than receiving a bogus value.
+            access_token: None,
             claims,
             userinfo_claims: None,
         })


### PR DESCRIPTION
Replaces #2300, which I withdrew. @FWest98 was right that forwarding the **ID token** was the wrong mechanism, and this is the corrected version: it forwards the **access token** and does not offer the ID token at all.

## What it does

A target can opt in per header:

```yaml
headers:
  Authorization: "Bearer ${WARPGATE_SSO_ACCESS_TOKEN}"
```

`rewrite_request` substitutes the access token from the user's SSO session. If the session has no access token — password auth, ticket auth, or a provider that issued none — the **header is dropped entirely** rather than sent with the literal placeholder, which an upstream would read as a malformed credential.

## Why no ID-token placeholder

#2300 offered one. This deliberately does not, and I'd argue against adding it back:

- An ID token is issued *for the client that authenticated the user*. Its `aud` is Warpgate. Sending it to a third party asks that party to accept a token not addressed to it.
- OWASP ASVS 5.0 V10 is normative: ID tokens **shall** only be consumed by the client that triggered the authorization flow. Auth0, AWS and Duende all document forwarding as an anti-pattern.
- ID tokens carry no `scope`, so a resource server can't narrow what the token authorises.
- There's no back-compat argument — this is a new feature, so nothing depends on it.

Dropping it also let the implementation collapse: the earlier version needed an `SsoTokens` struct, a selector type and a placeholder table to hold two entries. With one token it's `Option<&str>` and a direct substitution — about 60 fewer lines.

## Scope

- `warpgate-sso` carries the access token through `SsoResult` → `SsoLoginResponse` (the code-exchange path; the bare-ID-token verification path has none and returns `None`)
- stored in `SsoLoginState`, so it's DB-backed alongside the existing ID token
- 3 tests; both mutations (forward the literal placeholder instead of dropping, never substitute) are caught

## What this does NOT fix — please read before merging

I measured this in a deployment behind a TLS-terminating middlebox, and I don't want the PR to imply more than it delivers.

**PII is unchanged.** Part of the case against ID tokens is that they carry unencrypted PII. My IdP puts the user's email in `sub`, so the **access token carries exactly the same PII** — on 988 of 1001 observed crossings. Changing the token type did not fix this. It needs a pairwise/pseudonymous subject identifier at the IdP, which is outside Warpgate's control.

**Identity also crosses outside the token.** A full header census found `x-warpgate-username` on every request, carrying the same identity in clear. That's `inject_own_headers` doing its job and predates this PR — but it means "the access token exposes identity" is only half the picture, and worth knowing if you're reasoning about what a target can see.

So the honest claim for this PR is narrow: it sends the **correct token type**, one that is audience-bound and scope-narrowed, so a resource server can validate it properly and a capture is worth less. It does not reduce identity exposure.

## Operational note

`SsoLoginState` is written once, at login. Sessions authenticated before the upgrade keep `access_token: null` forever — the placeholder resolves to nothing, the header is dropped, and the target 403s while the user still appears logged in. Rolling this out wants a forced re-authentication. Cost me a while to diagnose; worth a line in the docs if you take this.