### PR TITLE
fix: don't send Transfer-Encoding: chunked on bodyless proxy requests

### DIFF
--- a/warpgate-protocol-http/src/proxy.rs
+++ b/warpgate-protocol-http/src/proxy.rs
@@ -322,8 +322,13 @@ pub async fn proxy_normal_request(
         client_request = client_request.header(http::header::AUTHORIZATION, authorization_header);
     }
 
-    client_request = client_request.body(reqwest::Body::wrap_stream(body.into_bytes_stream()));
-
+    if req.headers().contains_key(http::header::CONTENT_LENGTH)
+        || req.headers().contains_key(http::header::TRANSFER_ENCODING)
+    {
+        client_request =
+        client_request.body(reqwest::Body::wrap_stream(body.into_bytes_stream()));
+    }
+    
     let client_request = client_request.build().context("Could not build request")?;
     let client_response = client
         .execute(client_request)


### PR DESCRIPTION
When proxying requests without a body (e.g. DELETE, GET), the proxy unconditionally wraps an empty stream with reqwest::Body::wrap_stream. This causes reqwest to add a Transfer-Encoding: chunked header to the outgoing request. Some upstream servers (notably Fastify) do not handle an empty chunked body gracefully and respond with 500 ISE.

## Description

...

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [X] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
