### PR TITLE
fixed #2328 - channel confirmation race

### DIFF
--- a/tests/test_ssh_proto.py
+++ b/tests/test_ssh_proto.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 import os
 import requests
+import socket
 import subprocess
 import tempfile
 import time
@@ -182,6 +183,74 @@ class Test:
         response = s.get(f"https://localhost:{local_port}", timeout=timeout, verify=False)
         assert response.status_code == 200
         ssh_client.kill()
+
+    # https://github.com/warp-tech/warpgate/issues/2328
+    def test_direct_tcpip_server_speaks_first(
+        self,
+        processes: ProcessManager,
+        wg_c_ed25519_pubkey,
+        shared_wg: WarpgateProcess,
+        timeout,
+    ):
+        # The first direct-tcpip channel to a given host:port must deliver bytes
+        # the target sends on its own, before the client writes anything (#2328).
+        # The target's own sshd (localhost:22 inside the container) greets with an
+        # SSH-2.0 banner immediately, so it is a convenient server-first peer.
+        #
+        # On the buggy code the channel-open confirmation races the target's first
+        # bytes and can lose, so the client never sees the banner. The race is
+        # timing-sensitive: a single connection is flaky, but the first channel to
+        # a host:port in a *fresh* session reliably loses often enough that a
+        # handful of fresh sessions makes the regression deterministic. Recording
+        # is left at its default (on) — that is the exact scenario reported.
+        user, ssh_target = setup_user_and_target(
+            processes, shared_wg, wg_c_ed25519_pubkey
+        )
+
+        for attempt in range(8):
+            local_port = alloc_port()
+            ssh_client = processes.start_ssh_client(
+                f"{user.username}:{ssh_target.name}@localhost",
+                "-p",
+                str(shared_wg.ssh_port),
+                *common_args,
+                "-L",
+                f"{local_port}:localhost:22",
+                "-N",
+                password="123",
+            )
+            try:
+                # Do not probe the port first: every accepted connection opens a
+                # fresh channel. A refused connection (listener not up yet) opens
+                # nothing, so retrying the connect is safe — the first one that
+                # succeeds is channel #1.
+                deadline = time.time() + timeout
+                conn = None
+                while time.time() < deadline:
+                    try:
+                        conn = socket.create_connection(
+                            ("localhost", local_port), timeout=5
+                        )
+                        break
+                    except socket.error:
+                        assert ssh_client.poll() is None, "ssh client exited early"
+                        time.sleep(0.1)
+                assert conn is not None, f"attempt {attempt}: forwarded port never came up"
+
+                conn.settimeout(8)
+                try:
+                    banner = conn.recv(100)
+                except socket.timeout:
+                    banner = b""
+                finally:
+                    conn.close()
+
+                assert banner.startswith(b"SSH-2.0"), (
+                    f"attempt {attempt}: first-channel banner never arrived "
+                    f"(got {banner!r}) — server-first bytes were dropped"
+                )
+            finally:
+                ssh_client.kill()
 
     def test_agent_forwarding_parallel(
         self,

--- a/warpgate-protocol-ssh/src/server/russh_handler.rs
+++ b/warpgate-protocol-ssh/src/server/russh_handler.rs
@@ -20,6 +20,17 @@ impl Debug for HandleWrapper {
     }
 }
 
+/// Carries a channel-open reply handle into the session event loop so the
+/// confirmation is sent from the same task that writes channel data, keeping
+/// `CHANNEL_OPEN_CONFIRMATION` ahead of the target's first bytes (#2328).
+pub struct ChannelOpenHandleWrapper(pub ChannelOpenHandle);
+
+impl Debug for ChannelOpenHandleWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ChannelOpenHandleWrapper")
+    }
+}
+
 #[derive(Debug)]
 pub enum ServerHandlerEvent {
     Authenticated(HandleWrapper),
@@ -38,8 +49,8 @@ pub enum ServerHandlerEvent {
     WindowChangeRequest(ServerChannelId, PtyRequest, oneshot::Sender<()>),
     Signal(ServerChannelId, Sig, oneshot::Sender<()>),
     ExecRequest(ServerChannelId, Bytes, oneshot::Sender<bool>),
-    ChannelOpenDirectTcpIp(ServerChannelId, DirectTCPIPParams, oneshot::Sender<bool>),
-    ChannelOpenDirectStreamlocal(ServerChannelId, String, oneshot::Sender<bool>),
+    ChannelOpenDirectTcpIp(ServerChannelId, DirectTCPIPParams, ChannelOpenHandleWrapper),
+    ChannelOpenDirectStreamlocal(ServerChannelId, String, ChannelOpenHandleWrapper),
     EnvRequest(ServerChannelId, String, String, oneshot::Sender<()>),
     X11Request(ServerChannelId, X11Request, oneshot::Sender<()>),
     TcpIpForward(String, u32, oneshot::Sender<bool>),
@@ -449,7 +460,6 @@ impl russh::server::Handler for ServerHandler {
     ) -> Result<(), Self::Error> {
         let host_to_connect = host_to_connect.to_string();
         let originator_address = originator_address.to_string();
-        let (tx, rx) = oneshot::channel();
         self.send_event(ServerHandlerEvent::ChannelOpenDirectTcpIp(
             ServerChannelId(channel.id()),
             DirectTCPIPParams {
@@ -458,9 +468,8 @@ impl russh::server::Handler for ServerHandler {
                 originator_address,
                 originator_port,
             },
-            tx,
+            ChannelOpenHandleWrapper(reply),
         ))?;
-        reply_channel_open(reply, rx.await.unwrap_or(false)).await;
         Ok(())
     }
 
@@ -472,13 +481,11 @@ impl russh::server::Handler for ServerHandler {
         _session: &mut Session,
     ) -> Result<(), Self::Error> {
         let socket_path = socket_path.to_string();
-        let (tx, rx) = oneshot::channel();
         self.send_event(ServerHandlerEvent::ChannelOpenDirectStreamlocal(
             ServerChannelId(channel.id()),
             socket_path,
-            tx,
+            ChannelOpenHandleWrapper(reply),
         ))?;
-        reply_channel_open(reply, rx.await.unwrap_or(false)).await;
         Ok(())
     }
 

--- a/warpgate-protocol-ssh/src/server/session.rs
+++ b/warpgate-protocol-ssh/src/server/session.rs
@@ -11,7 +11,8 @@ use bimap::BiMap;
 use bytes::Bytes;
 use futures::{Future, FutureExt};
 use russh::keys::{PublicKey, PublicKeyBase64};
-use russh::{MethodKind, MethodSet, Sig};
+use russh::server::ChannelOpenHandle;
+use russh::{ChannelOpenFailure, MethodKind, MethodSet, Sig};
 use termcolor::Color;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::{Mutex, broadcast, oneshot};
@@ -149,7 +150,12 @@ pub struct ServerSession {
     /// *attempted* (events may need mapping while the open is in flight),
     /// unlike [`ServerSession::channels`] entries which appear on demand.
     channel_map: BiMap<ServerChannelId, Uuid>,
-    pending_server_channel_opens: HashSet<Uuid>,
+    /// Channels whose open has not yet been confirmed to the client. Their
+    /// target-side events are deferred until the open resolves, so no data is
+    /// written before `CHANNEL_OPEN_CONFIRMATION` — covers both server-initiated
+    /// opens ([`ServerSession::open_server_channel_in_background`]) and
+    /// client-initiated direct-tcpip/streamlocal opens (#2328).
+    pending_channel_opens: HashSet<Uuid>,
     deferred_events: Vec<Event>,
     rc_tx: UnboundedSender<(RCCommand, Option<RCCommandReply>)>,
     rc_abort_tx: UnboundedSender<()>,
@@ -225,7 +231,7 @@ impl ServerSession {
             session_handle: None,
             channels: HashMap::new(),
             channel_map: BiMap::new(),
-            pending_server_channel_opens: HashSet::new(),
+            pending_channel_opens: HashSet::new(),
             deferred_events: vec![],
             rc_tx: rc_handles.command_tx.clone(),
             rc_abort_tx: rc_handles.abort_tx,
@@ -466,7 +472,7 @@ impl ServerSession {
         + Send
         + 'static,
     ) {
-        self.pending_server_channel_opens.insert(id);
+        self.pending_channel_opens.insert(id);
         let sender = self.event_sender.clone();
         tokio::spawn(async move {
             let result = open.await.map(|channel| ServerChannelId(channel.id()));
@@ -476,17 +482,18 @@ impl ServerSession {
         });
     }
 
-    /// Events for a channel whose server-side open is still in flight arrive
-    /// before the channel mapping is known and must be held back; they are
-    /// replayed once the open resolves.
+    /// Events for a channel whose open is still in flight must be held back and
+    /// replayed once the open resolves — for server-initiated channels because
+    /// the mapping isn't known yet, and for client-initiated direct-tcpip opens
+    /// so no target data is written before CHANNEL_OPEN_CONFIRMATION (#2328).
     fn should_defer_event(&self, event: &Event) -> bool {
-        if self.pending_server_channel_opens.is_empty() {
+        if self.pending_channel_opens.is_empty() {
             return false;
         }
         match event {
             Event::Client(e) => e
                 .channel()
-                .is_some_and(|ch| self.pending_server_channel_opens.contains(&ch)),
+                .is_some_and(|ch| self.pending_channel_opens.contains(&ch)),
             // A server event for an unmapped channel can only refer to a
             // pending open: the client learns of such channels no earlier
             // than from the confirmation that resolves the open.
@@ -724,7 +731,7 @@ impl ServerSession {
                     }
                 }
                 Event::ServerChannelOpenResult(id, result) => {
-                    self.pending_server_channel_opens.remove(&id);
+                    self.pending_channel_opens.remove(&id);
                     match result {
                         Ok(server_channel_id) => {
                             self.channel_map.insert(server_channel_id, id);
@@ -739,16 +746,24 @@ impl ServerSession {
                                 self.send_command(RCCommand::Channel(id, ChannelOperation::Close));
                         }
                     }
-                    let deferred = std::mem::take(&mut self.deferred_events);
-                    for event in deferred {
-                        self.handle_event(event).await?;
-                    }
+                    self.replay_deferred_events().await?;
                 }
                 Event::MenuRedraw(_, _) | Event::ConsoleInput(_) => (),
             }
             Ok(())
         }
         .boxed()
+    }
+
+    /// Re-dispatch events held back while a channel open was in flight. Events
+    /// whose channel is still pending are deferred again by [`Self::handle_event`],
+    /// so this is safe to call whenever any one pending open resolves.
+    async fn replay_deferred_events(&mut self) -> Result<(), WarpgateError> {
+        let deferred = std::mem::take(&mut self.deferred_events);
+        for event in deferred {
+            self.handle_event(event).await?;
+        }
+        Ok(())
     }
 
     async fn start_target_selection_menu(&self, channel_id: Uuid) -> Result<()> {
@@ -1000,11 +1015,13 @@ impl ServerSession {
             }
 
             ServerHandlerEvent::ChannelOpenDirectTcpIp(channel, params, reply) => {
-                let _ = reply.send(self._channel_open_direct_tcpip(channel, params).await?);
+                self._channel_open_direct_tcpip(channel, params, reply.0)
+                    .await?;
             }
 
             ServerHandlerEvent::ChannelOpenDirectStreamlocal(channel, path, reply) => {
-                let _ = reply.send(self._channel_open_direct_streamlocal(channel, path).await?);
+                self._channel_open_direct_streamlocal(channel, path, reply.0)
+                    .await?;
             }
 
             ServerHandlerEvent::EnvRequest(channel, name, value, reply) => {
@@ -1454,23 +1471,29 @@ impl ServerSession {
         &mut self,
         channel: ServerChannelId,
         params: DirectTCPIPParams,
-    ) -> Result<bool> {
+        open_handle: ChannelOpenHandle,
+    ) -> Result<()> {
         let uuid = Uuid::new_v4();
         self.channel_map.insert(channel, uuid);
+        // Hold back target output until the open is confirmed to the client, so
+        // server-speaks-first bytes never precede CHANNEL_OPEN_CONFIRMATION (#2328).
+        self.pending_channel_opens.insert(uuid);
 
         info!(%channel, "Opening direct TCP/IP channel from {}:{} to {}:{}", params.originator_address, params.originator_port, params.host_to_connect, params.port_to_connect);
 
         let _ = self.maybe_connect_remote().await;
 
-        match self
+        let result = self
             .send_command_and_wait(RCCommand::Channel(
                 uuid,
                 ChannelOperation::OpenDirectTCPIP(params.clone()),
             ))
-            .await
-        {
+            .await;
+
+        let outcome = match result {
             Ok(()) => {
                 self.channel_entry(uuid).mark_open();
+                open_handle.accept().await;
 
                 let recorder = self
                     .traffic_recorder_for(
@@ -1500,37 +1523,53 @@ impl ServerSession {
                     }
                 }
 
-                Ok(true)
+                Ok(())
             }
             Err(SshClientError::Russh(russh::Error::ChannelOpenFailure(_))) => {
+                open_handle.reject(ChannelOpenFailure::ConnectFailed).await;
                 self.close_channel(uuid);
-                Ok(false)
+                Ok(())
             }
-            Err(x) => Err(x.into()),
-        }
+            // Dropping `open_handle` auto-rejects the open, so the client always
+            // gets a reply even on unexpected errors.
+            Err(x) => {
+                self.close_channel(uuid);
+                Err(x.into())
+            }
+        };
+
+        self.pending_channel_opens.remove(&uuid);
+        self.replay_deferred_events().await?;
+        outcome
     }
 
     async fn _channel_open_direct_streamlocal(
         &mut self,
         channel: ServerChannelId,
         path: String,
-    ) -> Result<bool> {
+        open_handle: ChannelOpenHandle,
+    ) -> Result<()> {
         let uuid = Uuid::new_v4();
         self.channel_map.insert(channel, uuid);
+        // Hold back target output until the open is confirmed to the client, so
+        // server-speaks-first bytes never precede CHANNEL_OPEN_CONFIRMATION (#2328).
+        self.pending_channel_opens.insert(uuid);
 
         info!(%channel, "Opening direct streamlocal channel to {}", path);
 
         let _ = self.maybe_connect_remote().await;
 
-        match self
+        let result = self
             .send_command_and_wait(RCCommand::Channel(
                 uuid,
                 ChannelOperation::OpenDirectStreamlocal(path.clone()),
             ))
-            .await
-        {
+            .await;
+
+        let outcome = match result {
             Ok(()) => {
                 self.channel_entry(uuid).mark_open();
+                open_handle.accept().await;
 
                 let recorder = self
                     .traffic_recorder_for(
@@ -1550,14 +1589,24 @@ impl ServerSession {
                     }
                 }
 
-                Ok(true)
+                Ok(())
             }
             Err(SshClientError::Russh(russh::Error::ChannelOpenFailure(_))) => {
+                open_handle.reject(ChannelOpenFailure::ConnectFailed).await;
                 self.close_channel(uuid);
-                Ok(false)
+                Ok(())
             }
-            Err(x) => Err(x.into()),
-        }
+            // Dropping `open_handle` auto-rejects the open, so the client always
+            // gets a reply even on unexpected errors.
+            Err(x) => {
+                self.close_channel(uuid);
+                Err(x.into())
+            }
+        };
+
+        self.pending_channel_opens.remove(&uuid);
+        self.replay_deferred_events().await?;
+        outcome
     }
 
     async fn _window_change_request(


### PR DESCRIPTION
## Description

...

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
