### PR TITLE
fix trusted client IP in HTTP authentication

### DIFF
--- a/warpgate-protocol-http/src/api/auth.rs
+++ b/warpgate-protocol-http/src/api/auth.rs
@@ -420,7 +420,6 @@ async fn serve_login(
     ctx: &UnauthenticatedRequestContext,
     body: &LoginRequest,
 ) -> poem::Result<LoginResponse> {
-    let remote_ip = req.remote_addr().as_socket_addr().map(|a| a.ip());
     let services = ctx.services();
     let client_ip: Option<IpAddr> = get_client_ip(req, services)
         .await
@@ -475,7 +474,7 @@ async fn serve_login(
             let session_id = session_id_for_request(req, ctx).await?;
             emit_unknown_authentication_failed_event(
                 session_id,
-                remote_ip,
+                client_ip,
                 &body.username,
                 "password",
                 "unknown user",
@@ -488,7 +487,7 @@ async fn serve_login(
             let session_id = session_id_for_request(req, ctx).await?;
             emit_unknown_authentication_failed_event(
                 session_id,
-                remote_ip,
+                client_ip,
                 &body.username,
                 "password",
                 "IP address not allowed",

--- a/warpgate-protocol-http/src/api/sso_provider_list.rs
+++ b/warpgate-protocol-http/src/api/sso_provider_list.rs
@@ -1,3 +1,4 @@
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use poem::Request;
@@ -13,6 +14,7 @@ use warpgate_common::WarpgateError;
 use warpgate_common::auth::AuthCredential;
 use warpgate_common_http::auth::UnauthenticatedRequestContext;
 use warpgate_common_http::ext::construct_external_url;
+use warpgate_common_http::logging::get_client_ip;
 use warpgate_core::ConfigProvider;
 use warpgate_core::auth::submit_credential;
 use warpgate_sso::{SsoClient, SsoInternalProviderConfig};
@@ -237,6 +239,9 @@ impl Api {
     ) -> Result<Result<String, String>, WarpgateError> {
         // pull services locally for convenience
         let services = ctx.services();
+        let client_ip: Option<IpAddr> = get_client_ip(req, services)
+            .await
+            .and_then(|ip| ip.parse().ok());
         let Some(context) = session.get::<SsoContext>(SSO_CONTEXT_SESSION_KEY) else {
             return Ok(Err("Not in an active SSO process".to_string()));
         };
@@ -312,7 +317,7 @@ impl Api {
             let session_id = session_id_for_request(req, &ctx).await?;
             emit_unknown_authentication_failed_event(
                 session_id,
-                req.remote_addr().as_socket_addr().map(|a| a.ip()),
+                client_ip,
                 email,
                 &cred.safe_description(),
                 "unknown user",
@@ -320,7 +325,6 @@ impl Api {
             return Ok(Err(format!("No user matching {email}")));
         };
 
-        let remote_ip = req.remote_addr().as_socket_addr().map(|a| a.ip());
         let state_arc = match get_or_create_auth_state_for_request(req, &username, &ctx, None).await
         {
             Ok(state) => state,
@@ -329,7 +333,7 @@ impl Api {
                     let session_id = session_id_for_request(req, &ctx).await?;
                     emit_unknown_authentication_failed_event(
                         session_id,
-                        remote_ip,
+                        client_ip,
                         &username,
                         &cred.safe_description(),
                         "IP address not allowed",

--- a/warpgate-protocol-http/src/common.rs
+++ b/warpgate-protocol-http/src/common.rs
@@ -18,6 +18,7 @@ use warpgate_common::helpers::username::username_eq_ci;
 use warpgate_common::{Protocol, SessionId, WarpgateError};
 use warpgate_common_http::auth::UnauthenticatedRequestContext;
 use warpgate_common_http::ext::construct_external_url;
+use warpgate_common_http::logging::get_client_ip;
 use warpgate_common_http::{
     AuthenticatedRequestContext, RequestAuthorization, SessionAuthorization,
     X_WARPGATE_CLUSTER_IDENTITY, is_cluster_peer_request,
@@ -166,7 +167,9 @@ pub async fn get_or_create_auth_state_for_request(
     ctx: &UnauthenticatedRequestContext,
     rate_limit_credential_type: Option<&str>,
 ) -> Result<Arc<Mutex<AuthState>>, WarpgateError> {
-    let remote_ip = req.remote_addr().as_socket_addr().map(|a| a.ip());
+    let client_ip = get_client_ip(req, ctx.services())
+        .await
+        .and_then(|ip| ip.parse().ok());
 
     if let Some(state) = get_auth_state_for_request(req, ctx).await? {
         let reusable = {
@@ -198,7 +201,7 @@ pub async fn get_or_create_auth_state_for_request(
                 CredentialKind::Sso,
                 CredentialKind::Totp,
             ],
-            remote_ip,
+            client_ip,
             rate_limit_credential_type,
         )
         .await?;


### PR DESCRIPTION
## Description

Fixes #2327.

HTTP request logging and login protection already resolve the client address through `get_client_ip()`, which honors trusted `X-Forwarded-For` headers and cluster forwarding. HTTP auth-state creation still passed `req.remote_addr()` directly, so per-user allowed IP ranges were evaluated against the reverse proxy address even while the network status page showed the forwarded client address.

This change:

- resolves the trusted client IP before creating an HTTP auth state
- uses the same resolved IP in password and SSO authentication-failure audit events
- keeps the existing safe fallback: when forwarded headers are not trusted, `get_client_ip()` returns the socket peer address

The existing `warpgate-common-http::request` tests cover both trusted forwarded headers and the untrusted fallback.

### Validation

- `cargo check -p warpgate-protocol-http --tests`
- `cargo test -p warpgate-common-http request::tests`
- `cargo test -p warpgate-protocol-http --lib`
- `cargo clippy -p warpgate-protocol-http --tests -- -D warnings`
- `rustfmt` check for all changed files

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
