### PR TITLE
link straight to a prefilled ticket request

### DIFF
--- a/warpgate-web/src/common/helpers.ts
+++ b/warpgate-web/src/common/helpers.ts
@@ -1,4 +1,14 @@
 import type { BootstrapThemeColor } from 'gateway/lib/api'
+import { router } from 'svelte-spa-router'
+
+/**
+ * Query parameters of the current hash route, e.g. `#/foo?a=b`.
+ * Read once at component init - svelte-spa-router keeps the component
+ * mounted when only the querystring changes.
+ */
+export function routeQueryParams(): URLSearchParams {
+    return new URLSearchParams(router.querystring ?? '')
+}
 
 export function getCSSColorFromThemeColor(color?: BootstrapThemeColor): string {
     // Handle capitalized color names from API (e.g., "Primary" -> "primary")

--- a/warpgate-web/src/gateway/ApiTokenManager.svelte
+++ b/warpgate-web/src/gateway/ApiTokenManager.svelte
@@ -5,10 +5,10 @@
     import { parseHumantimeDuration } from 'common/duration'
     import EmptyState from 'common/EmptyState.svelte'
     import { stringifyError } from 'common/errors'
+    import { routeQueryParams } from 'common/helpers'
     import Loadable from 'common/Loadable.svelte'
     import { api, type ExistingApiToken } from 'gateway/lib/api'
     import Fa from 'svelte-fa'
-    import { router } from 'svelte-spa-router'
     import CreateApiTokenModal from './CreateApiTokenModal.svelte'
 
     let tokens: ExistingApiToken[] = $state([])
@@ -17,7 +17,7 @@
     let error: string | undefined = $state()
     const now = Date.now()
 
-    const urlParams = new URLSearchParams(router.querystring ?? '')
+    const urlParams = routeQueryParams()
     const autoCreate = urlParams.get('create') === 'true'
     const paramLabel = urlParams.get('label') ?? ''
     const paramExpiry = urlParams.get('expiry')

--- a/warpgate-web/src/gateway/Login.svelte
+++ b/warpgate-web/src/gateway/Login.svelte
@@ -7,6 +7,7 @@
     import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
     import { Alert, Button, FormGroup } from '@sveltestrap/sveltestrap'
     import { stringifyError } from 'common/errors'
+    import { routeQueryParams } from 'common/helpers'
     import Loadable from 'common/Loadable.svelte'
 
     import {
@@ -20,7 +21,7 @@
     } from 'gateway/lib/api'
     import { reloadServerInfo, serverInfo } from 'gateway/lib/store'
     import Fa from 'svelte-fa'
-    import { replace, router } from 'svelte-spa-router'
+    import { replace } from 'svelte-spa-router'
 
     let error: string | null = $state(null)
     let username = $state('')
@@ -43,10 +44,9 @@
         passwordLoginMode === PasswordLoginMode.Minimized,
     )
 
-    const nextURL =
-        new URLSearchParams(router.querystring ?? '').get('next') ?? undefined
-    const reauthRequired =
-        new URLSearchParams(router.querystring ?? '').get('reauth') === '1'
+    const urlParams = routeQueryParams()
+    const nextURL = urlParams.get('next') ?? undefined
+    const reauthRequired = urlParams.get('reauth') === '1'
     const serverErrorMessage = new URLSearchParams(location.search).get(
         'login_error',
     )

--- a/warpgate-web/src/gateway/TicketRequests.svelte
+++ b/warpgate-web/src/gateway/TicketRequests.svelte
@@ -31,6 +31,16 @@
     } from 'gateway/lib/api'
     import { serverInfo } from 'gateway/lib/store'
     import Fa from 'svelte-fa'
+    import { router } from 'svelte-spa-router'
+
+    // Matches the server-side limit in warpgate-core/src/ticket_requests.rs
+    const DESCRIPTION_MAX_LENGTH = 2000
+
+    // Prefill from #/ticket-requests?target=x&description=y&duration=8h
+    const urlParams = new URLSearchParams(router.querystring ?? '')
+    const paramTarget = urlParams.get('target')
+    const paramDescription = urlParams.get('description')
+    const paramDuration = urlParams.get('duration')
 
     let error: string | undefined = $state()
     let success: string | undefined = $state()
@@ -40,7 +50,7 @@
     let tickets: MyTicketModel[] | undefined = $state()
     let ticketRequestTargets: TicketRequestTarget[] | undefined = $state()
     let targets: TargetSnapshot[] | undefined = $state()
-    let showForm = $state(false)
+    let showForm = $state(!!(paramTarget || paramDescription || paramDuration))
     let showAllRequests = $state(false)
 
     const REQUEST_PAGE_SIZE = 25
@@ -54,12 +64,23 @@
         return requests.slice(0, REQUEST_PAGE_SIZE)
     })
 
-    let selectedTarget = $state('')
-    let description = $state('')
+    let selectedTarget = $state(paramTarget ?? '')
+    let description = $state(
+        [...(paramDescription ?? '')].slice(0, DESCRIPTION_MAX_LENGTH).join(''),
+    )
     let descriptionTouched = $state(false)
-    let durationText = $state('8h')
+    let durationText = $state(paramDuration || '8h')
 
     let maxDurationSeconds = $derived($serverInfo?.ticketMaxDurationSeconds)
+
+    let unavailableTarget = $derived.by(() => {
+        if (!selectedTarget || !ticketRequestTargets) {
+            return undefined
+        }
+        return ticketRequestTargets.some(t => t.name === selectedTarget)
+            ? undefined
+            : selectedTarget
+    })
 
     let durationSeconds = $derived(parseHumantimeDuration(durationText))
 
@@ -83,7 +104,9 @@
         descriptionRequired && !description.trim(),
     )
 
-    let formInvalid = $derived(!!durationError || descriptionMissing)
+    let formInvalid = $derived(
+        !!durationError || descriptionMissing || !!unavailableTarget,
+    )
 
     async function load() {
         const [r, t, trt, tgts] = await Promise.all([
@@ -96,6 +119,7 @@
         tickets = t
         ticketRequestTargets = trt
         targets = tgts
+        // Seeded from the URL above, so a linked target isn't replaced here
         if (ticketRequestTargets[0] && !selectedTarget) {
             selectedTarget = ticketRequestTargets[0].name
         }
@@ -225,6 +249,13 @@
     <Modal isOpen={showForm} toggle={() => showForm = false}>
         <ModalBody>
             <h4 class="mb-3">Request a ticket</h4>
+
+            {#if unavailableTarget}
+                <Alert color="warning" fade={false}>
+                    <strong>{unavailableTarget}</strong>
+                    is not available for ticket requests. Select a target below.
+                </Alert>
+            {/if}
 
             {#if ticketRequestTargets?.length}
                 <form onsubmit={e => e.preventDefault()}>

--- a/warpgate-web/src/gateway/TicketRequests.svelte
+++ b/warpgate-web/src/gateway/TicketRequests.svelte
@@ -17,6 +17,7 @@
     } from 'common/duration'
     import EmptyState from 'common/EmptyState.svelte'
     import { stringifyError } from 'common/errors'
+    import { routeQueryParams } from 'common/helpers'
     import InfoBox from 'common/InfoBox.svelte'
     import Loadable from 'common/Loadable.svelte'
     import { statusColor, statusIcon } from 'common/ticketRequestStatus'
@@ -31,16 +32,18 @@
     } from 'gateway/lib/api'
     import { serverInfo } from 'gateway/lib/store'
     import Fa from 'svelte-fa'
-    import { router } from 'svelte-spa-router'
 
     // Matches the server-side limit in warpgate-core/src/ticket_requests.rs
     const DESCRIPTION_MAX_LENGTH = 2000
 
     // Prefill from #/ticket-requests?target=x&description=y&duration=8h
-    const urlParams = new URLSearchParams(router.querystring ?? '')
+    // `target` is what makes such a link meaningful; the other params are only
+    // honoured alongside it, so a link can't open a plausible-looking prefilled
+    // request against whichever target happens to be first in the dropdown.
+    const urlParams = routeQueryParams()
     const paramTarget = urlParams.get('target')
-    const paramDescription = urlParams.get('description')
-    const paramDuration = urlParams.get('duration')
+    const paramDescription = paramTarget ? urlParams.get('description') : null
+    const paramDuration = paramTarget ? urlParams.get('duration') : null
 
     let error: string | undefined = $state()
     let success: string | undefined = $state()
@@ -50,7 +53,7 @@
     let tickets: MyTicketModel[] | undefined = $state()
     let ticketRequestTargets: TicketRequestTarget[] | undefined = $state()
     let targets: TargetSnapshot[] | undefined = $state()
-    let showForm = $state(!!(paramTarget || paramDescription || paramDuration))
+    let showForm = $state(!!paramTarget)
     let showAllRequests = $state(false)
 
     const REQUEST_PAGE_SIZE = 25
@@ -119,7 +122,7 @@
         tickets = t
         ticketRequestTargets = trt
         targets = tgts
-        // Seeded from the URL above, so a linked target isn't replaced here
+        // Never override an explicit selection
         if (ticketRequestTargets[0] && !selectedTarget) {
             selectedTarget = ticketRequestTargets[0].name
         }
@@ -250,14 +253,15 @@
         <ModalBody>
             <h4 class="mb-3">Request a ticket</h4>
 
-            {#if unavailableTarget}
-                <Alert color="warning" fade={false}>
-                    <strong>{unavailableTarget}</strong>
-                    is not available for ticket requests. Select a target below.
-                </Alert>
-            {/if}
-
             {#if ticketRequestTargets?.length}
+                {#if unavailableTarget}
+                    <Alert color="warning" fade={false}>
+                        <strong>{unavailableTarget}</strong>
+                        is not available for ticket requests. Select a target
+                        below.
+                    </Alert>
+                {/if}
+
                 <form onsubmit={e => e.preventDefault()}>
                     <FormGroup floating label="Target">
                         <select
@@ -316,7 +320,10 @@
                     </FormGroup>
                 </form>
             {:else if ticketRequestTargets}
-                <EmptyState title="No targets available" />
+                <EmptyState
+                    title="No targets available"
+                    hint={unavailableTarget ? `${unavailableTarget} is not available for ticket requests.` : ''}
+                />
             {/if}
         </ModalBody>
         <ModalFooter>


### PR DESCRIPTION
## Description

Lets any tool that already knows which target a user needs hand them a link that opens the ticket request form with that target selected:

```
https://<warpgate>/@warpgate#/ticket-requests?target=prod-db-1&description=Investigating+ticket+4821&duration=4h
```

`description` and `duration` are optional. Any of the three opens the form; with none of them the page behaves exactly as it does today.

### The problem

The self-service request form (added in #1818) asks the user to pick a target from a dropdown. But in practice the user isn't choosing anything — something else already decided which machine they need, and they're copying a name across from another screen. The dropdown defaults to whatever target happens to be first in their list.

A ticket carries its own target, so picking the wrong one isn't caught anywhere. The ticket authenticates perfectly and drops the user on a different machine. Same bastion address, same host key, a valid credential, no error. The usual outcome is that the user assumes the tool that sent them there is broken, and the real cause — a mis-selected dropdown entry — is close to invisible.

That's a class of mistake worth designing out rather than detecting.

### Our use case

We run support software that helps our engineers work customer issues. When an engineer needs temporary access to a specific customer server, our tooling already knows exactly which host that is — it's the one attached to the support case.

Today it can only print instructions: *open Warpgate, go to ticket requests, find `vessel-gw-07` in the dropdown, request 4 hours.* Every step of that is a chance to land on the wrong machine, and the failure is silent when it happens.

With this change the tool hands over a link instead. The engineer clicks it, sees a form already describing the access they're about to request, and presses **Request ticket**. If the target requires admin approval, it still requires admin approval.

The same shape works for anything else that knows the answer in advance — access brokers, runbooks, chat bots, an internal wiki page with a per-server link.

### What it deliberately does not do

**The URL fills the form in. It never submits it.**

This is the rule the whole change is built around. A link is a piece of text that can arrive from anywhere — mail, chat, a page written by someone else — so it must be able to *propose* a request and never to *cause* one. With **Auto-approve when user already has role-based access** enabled, a link that submitted on load would mint a live credential from a click. The user still reads what's on screen and presses the button, exactly as before.

**No existing gate can be bypassed by a URL.** Allow users to request tickets, per-target disable, always-require-admin-approval, the duration cap, the use cap — all unchanged, all still enforced. This moves a value into a form field and nothing more.

**A target the user isn't allowed to request is named, not quietly swapped.** If the link points at something that doesn't exist, has ticket requests disabled, or simply isn't visible to that user, the form opens with nothing selected, a warning naming the target that was asked for, and the submit button disabled until they pick one themselves. Silently falling back to the first entry in the list would make a typo indistinguishable from success — which is the original problem again.

**A duration over the cap isn't silently clamped.** It prefills, the existing validator rejects it, and the submit button stays disabled so the user can see why. The server enforces the cap regardless.

**A description arriving from a URL is length-bounded**, to the same limit the API already enforces. An admin reads that text when deciding whether to approve, and it came from a link.

Unknown query parameters are ignored.

### Scope

Frontend only — one file, `warpgate-web/src/gateway/TicketRequests.svelte`. No API, schema, database or Rust changes, and no admin UI changes. Deep links already survive the login redirect, so a link sent to someone who isn't signed in yet still works after they log in.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [x] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

Designed from a written spec and reviewed by a human before submission.

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
