### PR TITLE
Fix SSH target page overflow after host key check

### DIFF
--- a/warpgate-web/src/common/CopyableTextArea.svelte
+++ b/warpgate-web/src/common/CopyableTextArea.svelte
@@ -25,6 +25,7 @@
         white-space: pre-wrap;
         overflow: hidden;
         word-wrap: break-word;
+        overflow-wrap: anywhere;
         height: auto;
 
         padding-top: 35px !important; // clear the copy button


### PR DESCRIPTION
## Description

Long unbroken values rendered by `CopyableTextArea` can set a large min-content width even with `word-wrap: break-word`. On the SSH target page, checking an untrusted ECDSA or RSA host key then expands the target form far beyond the viewport.

Use `overflow-wrap: anywhere` so unbroken values contribute soft wrap opportunities during min-content sizing. This keeps the host-key status row within the available width while retaining the existing `break-word` fallback for older browsers.

## Reproduction

1. Open an SSH target with no trusted host key.
2. Click **Check host key**.
3. Observe that the returned public key expands the configuration page horizontally.

Reproduced on Warpgate v0.27.3.

## Validation

- Confirmed the change against the current upstream `main` branch.
- Confirmed the PR contains one CSS declaration in `CopyableTextArea.svelte`.
- `git diff --check`

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*