### PR TITLE
feat: Add WebAuthn/FIDO2/U2F passkey support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,11 +194,27 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.6.0",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -206,6 +222,18 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.20",
  "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -1024,6 +1052,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "base64urlsafedata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08e33815c87d8cadcddb1e74ac307368a3751fbe40c961538afa21a1899f21c"
+dependencies = [
+ "base64 0.21.7",
+ "pastey",
+ "serde",
+]
+
+[[package]]
 name = "bcder"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.6"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1342,9 +1381,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.6"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -1615,7 +1654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin 0.10.1",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -1702,6 +1741,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1964,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "delegate"
@@ -2011,11 +2056,25 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
  "displaydoc",
  "nom",
  "num-bigint 0.4.8",
@@ -2566,7 +2625,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.9",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2935,6 +2994,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3052,7 +3122,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version",
- "spin 0.9.9",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -3792,7 +3862,7 @@ dependencies = [
  "bit_field",
  "bitflags 2.13.1",
  "byteorder",
- "der-parser",
+ "der-parser 10.0.0",
  "ironrdp-core",
  "ironrdp-error",
  "md-5 0.10.6",
@@ -4111,7 +4181,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.9",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -4146,7 +4216,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "url",
- "x509-parser",
+ "x509-parser 0.18.1",
 ]
 
 [[package]]
@@ -4258,9 +4328,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -4473,7 +4543,7 @@ dependencies = [
  "httparse",
  "memchr",
  "mime",
- "spin 0.9.9",
+ "spin 0.9.8",
  "tokio",
  "version_check",
 ]
@@ -4740,11 +4810,20 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
 ]
 
 [[package]]
@@ -5071,6 +5150,12 @@ checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
  "phc",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pathdiff"
@@ -6052,7 +6137,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.18.2",
+ "lru 0.18.0",
  "palette",
  "serde",
  "strum 0.28.0",
@@ -6190,7 +6275,7 @@ dependencies = [
  "pem",
  "rustls-pki-types",
  "time",
- "x509-parser",
+ "x509-parser 0.18.1",
  "yasna",
  "zeroize",
 ]
@@ -7134,6 +7219,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor_2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aec2709de9078e077090abd848e967abab63c9fb3fdb5d4799ad359d8d482c"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7504,18 +7599,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.9"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spinning_top"
@@ -9044,7 +9139,7 @@ dependencies = [
  "tracing",
  "uuid",
  "x509-cert",
- "x509-parser",
+ "x509-parser 0.18.1",
 ]
 
 [[package]]
@@ -9101,7 +9196,7 @@ dependencies = [
  "warpgate-sso",
  "warpgate-tls",
  "webpki",
- "x509-parser",
+ "x509-parser 0.18.1",
 ]
 
 [[package]]
@@ -9310,6 +9405,8 @@ dependencies = [
  "warpgate-web-clients-common",
  "warpgate-web-desktop",
  "warpgate-web-ssh",
+ "webauthn-rs",
+ "webauthn-rs-proto",
 ]
 
 [[package]]
@@ -9543,7 +9640,7 @@ dependencies = [
  "tracing",
  "warpgate-ca",
  "webpki",
- "x509-parser",
+ "x509-parser 0.18.1",
 ]
 
 [[package]]
@@ -9815,6 +9912,74 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webauthn-attestation-ca"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6475c0bbd1a3f04afaa3e98880408c5be61680c5e6bd3c6f8c250990d5d3e18e"
+dependencies = [
+ "base64urlsafedata",
+ "openssl",
+ "openssl-sys",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "webauthn-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c548915e0e92ee946bbf2aecf01ea21bef53d974b0793cc6732ba81a03fc422"
+dependencies = [
+ "base64urlsafedata",
+ "serde",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-rs-core",
+]
+
+[[package]]
+name = "webauthn-rs-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "296d2d501feb715d80b8e186fb88bab1073bca17f460303a1013d17b673bea6a"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "der-parser 9.0.0",
+ "hex",
+ "nom",
+ "openssl",
+ "openssl-sys",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "serde",
+ "serde_cbor_2",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-attestation-ca",
+ "webauthn-rs-proto",
+ "x509-parser 0.16.0",
+]
+
+[[package]]
+name = "webauthn-rs-proto"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c37393beac9c1ed1ca6dbb30b1e01783fb316ab3a45d90ecd48c99052dd7ef1e"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -10443,17 +10608,34 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "data-encoding",
+ "der-parser 9.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.7.1",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
  "aws-lc-rs",
  "data-encoding",
- "der-parser",
+ "der-parser 10.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.8.1",
  "rusticata-macros",
  "thiserror 2.0.20",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,11 +194,27 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.6.0",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -206,6 +222,18 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.19",
  "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -1024,6 +1052,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "base64urlsafedata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08e33815c87d8cadcddb1e74ac307368a3751fbe40c961538afa21a1899f21c"
+dependencies = [
+ "base64 0.21.7",
+ "pastey",
+ "serde",
+]
+
+[[package]]
 name = "bcder"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,6 +1779,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,11 +2092,25 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
  "displaydoc",
  "nom",
  "num-bigint 0.4.8",
@@ -2948,6 +3007,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3804,7 +3874,7 @@ dependencies = [
  "bit_field",
  "bitflags 2.13.1",
  "byteorder",
- "der-parser",
+ "der-parser 10.0.0",
  "ironrdp-core",
  "ironrdp-error",
  "md-5 0.10.6",
@@ -4167,7 +4237,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "url",
- "x509-parser",
+ "x509-parser 0.18.1",
 ]
 
 [[package]]
@@ -4770,11 +4840,20 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
 ]
 
 [[package]]
@@ -5107,6 +5186,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pathdiff"
@@ -6224,7 +6309,7 @@ dependencies = [
  "pem",
  "rustls-pki-types",
  "time",
- "x509-parser",
+ "x509-parser 0.18.1",
  "yasna",
  "zeroize",
 ]
@@ -7178,6 +7263,16 @@ checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_cbor_2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aec2709de9078e077090abd848e967abab63c9fb3fdb5d4799ad359d8d482c"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -9120,7 +9215,7 @@ dependencies = [
  "tracing",
  "uuid",
  "x509-cert",
- "x509-parser",
+ "x509-parser 0.18.1",
 ]
 
 [[package]]
@@ -9176,7 +9271,7 @@ dependencies = [
  "warpgate-sso",
  "warpgate-tls",
  "webpki",
- "x509-parser",
+ "x509-parser 0.18.1",
 ]
 
 [[package]]
@@ -9381,6 +9476,8 @@ dependencies = [
  "warpgate-web",
  "warpgate-web-desktop",
  "warpgate-web-ssh",
+ "webauthn-rs",
+ "webauthn-rs-proto",
 ]
 
 [[package]]
@@ -9613,7 +9710,7 @@ dependencies = [
  "tracing",
  "warpgate-ca",
  "webpki",
- "x509-parser",
+ "x509-parser 0.18.1",
 ]
 
 [[package]]
@@ -9884,6 +9981,74 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webauthn-attestation-ca"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6475c0bbd1a3f04afaa3e98880408c5be61680c5e6bd3c6f8c250990d5d3e18e"
+dependencies = [
+ "base64urlsafedata",
+ "openssl",
+ "openssl-sys",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "webauthn-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c548915e0e92ee946bbf2aecf01ea21bef53d974b0793cc6732ba81a03fc422"
+dependencies = [
+ "base64urlsafedata",
+ "serde",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-rs-core",
+]
+
+[[package]]
+name = "webauthn-rs-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "296d2d501feb715d80b8e186fb88bab1073bca17f460303a1013d17b673bea6a"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "der-parser 9.0.0",
+ "hex",
+ "nom",
+ "openssl",
+ "openssl-sys",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "serde",
+ "serde_cbor_2",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-attestation-ca",
+ "webauthn-rs-proto",
+ "x509-parser 0.16.0",
+]
+
+[[package]]
+name = "webauthn-rs-proto"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c37393beac9c1ed1ca6dbb30b1e01783fb316ab3a45d90ecd48c99052dd7ef1e"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -10521,17 +10686,34 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "data-encoding",
+ "der-parser 9.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.7.1",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
  "aws-lc-rs",
  "data-encoding",
- "der-parser",
+ "der-parser 10.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.8.1",
  "rusticata-macros",
  "thiserror 2.0.19",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,8 @@ tokio-tungstenite = { version = "0.30", features = [
 reqwest-websocket = { version = "0.6.0", default-features = false }
 time = { version = "0.3", default-features = false }
 url = { version = "2.4", default-features = false }
+webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation", "danger-user-presence-only-security-keys"] }
+webauthn-rs-proto = "0.5"
 zune-jpeg = "0.5"
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,8 @@ tokio-tungstenite = { version = "0.30", features = [
 reqwest-websocket = { version = "0.6.0", default-features = false }
 time = { version = "0.3", default-features = false }
 url = { version = "2.4", default-features = false }
+webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation", "danger-user-presence-only-security-keys"] }
+webauthn-rs-proto = "0.5"
 zune-jpeg = "0.5"
 
 [profile.dev]

--- a/deny.toml
+++ b/deny.toml
@@ -116,7 +116,7 @@ allow = [
 ]
 # List of crates to deny
 deny = [
-    { crate = "openssl-sys", wrappers = ["openssl", "tokio-openssl"], reason = "RDP legacy TLS compatibility uses vendored OpenSSL for older Windows Schannel targets" }
+    { crate = "openssl-sys", wrappers = ["openssl", "tokio-openssl", "webauthn-rs-core", "webauthn-attestation-ca"], reason = "RDP legacy TLS compatibility uses vendored OpenSSL for older Windows Schannel targets; webauthn-rs-core uses OpenSSL for attestation certificate verification" }
     #"ansi_term@0.11.0",
     #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
     # Wrapper crates can optionally be specified to allow the crate when it

--- a/deny.toml
+++ b/deny.toml
@@ -115,7 +115,7 @@ allow = [
 ]
 # List of crates to deny
 deny = [
-    { crate = "openssl-sys", wrappers = ["openssl", "tokio-openssl"], reason = "RDP legacy TLS compatibility uses vendored OpenSSL for older Windows Schannel targets" }
+    { crate = "openssl-sys", wrappers = ["openssl", "tokio-openssl", "webauthn-rs-core", "webauthn-attestation-ca"], reason = "RDP legacy TLS compatibility uses vendored OpenSSL for older Windows Schannel targets; webauthn-rs-core uses OpenSSL for attestation certificate verification" }
     #"ansi_term@0.11.0",
     #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
     # Wrapper crates can optionally be specified to allow the crate when it

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -600,6 +600,20 @@ ADMIN_API_TEST_CASES: list[AdminApiTestCase] = [
         expected_statuses={204},
     ),
     AdminApiTestCase(
+        id="get_webauthn_credentials",
+        permission="users_edit",
+        call=lambda api, r: api.get_webauthn_credentials_with_http_info(r["user_id"]),
+        expected_statuses={200},
+    ),
+    AdminApiTestCase(
+        id="delete_webauthn_credential",
+        permission="users_edit",
+        call=lambda api, r: api.delete_webauthn_credential_with_http_info(
+            r["user_id"], r["otp_id"]
+        ),
+        expected_statuses={204, 404},
+    ),
+    AdminApiTestCase(
         id="get_ldap_servers",
         permission="config_edit",
         call=lambda api, r: api.get_ldap_servers_with_http_info(),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -605,6 +605,20 @@ ADMIN_API_TEST_CASES: list[AdminApiTestCase] = [
         expected_statuses={204},
     ),
     AdminApiTestCase(
+        id="get_webauthn_credentials",
+        permission="users_edit",
+        call=lambda api, r: api.get_webauthn_credentials_with_http_info(r["user_id"]),
+        expected_statuses={200},
+    ),
+    AdminApiTestCase(
+        id="delete_webauthn_credential",
+        permission="users_edit",
+        call=lambda api, r: api.delete_webauthn_credential_with_http_info(
+            r["user_id"], r["otp_id"]
+        ),
+        expected_statuses={204, 404},
+    ),
+    AdminApiTestCase(
         id="get_ldap_servers",
         permission="config_edit",
         call=lambda api, r: api.get_ldap_servers_with_http_info(),

--- a/tests/test_http_user_auth_webauthn.py
+++ b/tests/test_http_user_auth_webauthn.py
@@ -1,0 +1,261 @@
+"""
+Integration tests for WebAuthn/passkey authentication.
+
+These tests verify:
+- The WebAuthn registration and authentication API endpoints exist and respond correctly
+- The credential policy enforces WebAuthn when configured
+- The admin API can list and delete WebAuthn credentials
+
+Note: Full end-to-end WebAuthn ceremony testing requires a browser environment
+(navigator.credentials API). These tests verify the server-side API contract
+and policy enforcement. The actual cryptographic ceremony is tested via the
+Rust unit tests and manual browser testing.
+"""
+import requests
+from uuid import uuid4
+
+from .api_client import admin_client, sdk
+from .conftest import WarpgateProcess
+from .test_http_common import *  # noqa
+
+
+class TestHTTPUserAuthWebAuthn:
+    def test_webauthn_registration_requires_auth(
+        self,
+        echo_server_port,
+        shared_wg: WarpgateProcess,
+    ):
+        """Registration endpoints require an authenticated session."""
+        url = f"https://localhost:{shared_wg.http_port}"
+        session = requests.Session()
+        session.verify = False
+
+        # Unauthenticated request should fail
+        response = session.post(
+            f"{url}/@warpgate/api/auth/webauthn/registration/start",
+        )
+        assert response.status_code in (401, 403, 404)
+
+    def test_webauthn_authentication_requires_login_state(
+        self,
+        echo_server_port,
+        shared_wg: WarpgateProcess,
+    ):
+        """Authentication start requires a pending login (auth state)."""
+        url = f"https://localhost:{shared_wg.http_port}"
+        session = requests.Session()
+        session.verify = False
+
+        # No pending login → NotFound
+        response = session.post(
+            f"{url}/@warpgate/api/auth/webauthn/authentication/start",
+        )
+        assert response.status_code == 404
+
+    def test_webauthn_policy_blocks_without_credential(
+        self,
+        echo_server_port,
+        shared_wg: WarpgateProcess,
+    ):
+        """When policy requires WebAuthn but user has none registered,
+        login with password alone should not grant access."""
+        url = f"https://localhost:{shared_wg.http_port}"
+        with admin_client(url) as api:
+            role = api.create_role(sdk.RoleDataRequest(name=f"role-{uuid4()}"))
+            user = api.create_user(sdk.CreateUserRequest(username=f"user-{uuid4()}"))
+            api.create_password_credential(
+                user.id, sdk.NewPasswordCredential(password="pass123")
+            )
+            # Set policy requiring Password + WebAuthn
+            api.update_user(
+                user.id,
+                sdk.UserDataRequest(
+                    username=user.username,
+                    credential_policy=sdk.UserRequireCredentialsPolicy(
+                        http=["Password", "WebAuthn"]
+                    ),
+                ),
+            )
+            api.add_user_role(user.id, role.id)
+            echo_target = api.create_target(
+                sdk.TargetDataRequest(
+                    name=f"echo-{uuid4()}",
+                    options=sdk.TargetOptions(
+                        sdk.TargetOptionsTargetHTTPOptions(
+                            kind="Http",
+                            url=f"http://localhost:{echo_server_port}",
+                            tls=sdk.Tls(
+                                mode=sdk.TlsMode.DISABLED,
+                                verify=False,
+                            ),
+                        )
+                    ),
+                )
+            )
+            api.add_target_role(echo_target.id, role.id)
+
+        session = requests.Session()
+        session.verify = False
+
+        # Login with password
+        response = session.post(
+            f"{url}/@warpgate/api/auth/login",
+            json={
+                "username": user.username,
+                "password": "pass123",
+            },
+        )
+        # Should not be fully authenticated (needs WebAuthn too)
+        assert response.status_code == 401
+
+        # Check auth state shows WebAuthnNeeded
+        response = session.get(f"{url}/@warpgate/api/auth/state")
+        if response.status_code == 200:
+            state = response.json()
+            assert state["state"] == "WebAuthnNeeded"
+
+        # Trying to access a target should fail
+        response = session.get(
+            f"{url}/some/path?warpgate-target={echo_target.name}",
+            allow_redirects=False,
+        )
+        assert response.status_code // 100 != 2
+
+    def test_webauthn_admin_crud(
+        self,
+        shared_wg: WarpgateProcess,
+    ):
+        """Admin API can list and delete WebAuthn credentials."""
+        url = f"https://localhost:{shared_wg.http_port}"
+        with admin_client(url) as api:
+            user = api.create_user(sdk.CreateUserRequest(username=f"user-{uuid4()}"))
+
+            # Initially no credentials
+            creds = api.get_webauthn_credentials(user.id)
+            assert len(creds) == 0
+
+            # Note: We can't create a credential via admin API (requires browser ceremony)
+            # but we can verify the endpoint exists and returns empty list
+
+    def test_webauthn_complete_without_start_fails(
+        self,
+        echo_server_port,
+        shared_wg: WarpgateProcess,
+    ):
+        """Completing authentication without starting returns BadRequest."""
+        url = f"https://localhost:{shared_wg.http_port}"
+        with admin_client(url) as api:
+            role = api.create_role(sdk.RoleDataRequest(name=f"role-{uuid4()}"))
+            user = api.create_user(sdk.CreateUserRequest(username=f"user-{uuid4()}"))
+            api.create_password_credential(
+                user.id, sdk.NewPasswordCredential(password="pass123")
+            )
+            api.update_user(
+                user.id,
+                sdk.UserDataRequest(
+                    username=user.username,
+                    credential_policy=sdk.UserRequireCredentialsPolicy(
+                        http=["Password", "WebAuthn"]
+                    ),
+                ),
+            )
+            api.add_user_role(user.id, role.id)
+            echo_target = api.create_target(
+                sdk.TargetDataRequest(
+                    name=f"echo-{uuid4()}",
+                    options=sdk.TargetOptions(
+                        sdk.TargetOptionsTargetHTTPOptions(
+                            kind="Http",
+                            url=f"http://localhost:{echo_server_port}",
+                            tls=sdk.Tls(
+                                mode=sdk.TlsMode.DISABLED,
+                                verify=False,
+                            ),
+                        )
+                    ),
+                )
+            )
+            api.add_target_role(echo_target.id, role.id)
+
+        session = requests.Session()
+        session.verify = False
+
+        # Login with password first to establish auth state
+        session.post(
+            f"{url}/@warpgate/api/auth/login",
+            json={
+                "username": user.username,
+                "password": "pass123",
+            },
+        )
+
+        # Try to complete WebAuthn without starting → should fail
+        response = session.post(
+            f"{url}/@warpgate/api/auth/webauthn/authentication/complete",
+            json={
+                "credential_json": "{}",
+            },
+        )
+        assert response.status_code in (400, 401, 404)
+
+    def test_password_only_policy_ignores_webauthn(
+        self,
+        echo_server_port,
+        shared_wg: WarpgateProcess,
+    ):
+        """When policy only requires password, WebAuthn is not needed
+        and login succeeds with just password (regression test)."""
+        url = f"https://localhost:{shared_wg.http_port}"
+        with admin_client(url) as api:
+            role = api.create_role(sdk.RoleDataRequest(name=f"role-{uuid4()}"))
+            user = api.create_user(sdk.CreateUserRequest(username=f"user-{uuid4()}"))
+            api.create_password_credential(
+                user.id, sdk.NewPasswordCredential(password="pass123")
+            )
+            # Only require password
+            api.update_user(
+                user.id,
+                sdk.UserDataRequest(
+                    username=user.username,
+                    credential_policy=sdk.UserRequireCredentialsPolicy(
+                        http=["Password"]
+                    ),
+                ),
+            )
+            api.add_user_role(user.id, role.id)
+            echo_target = api.create_target(
+                sdk.TargetDataRequest(
+                    name=f"echo-{uuid4()}",
+                    options=sdk.TargetOptions(
+                        sdk.TargetOptionsTargetHTTPOptions(
+                            kind="Http",
+                            url=f"http://localhost:{echo_server_port}",
+                            tls=sdk.Tls(
+                                mode=sdk.TlsMode.DISABLED,
+                                verify=False,
+                            ),
+                        )
+                    ),
+                )
+            )
+            api.add_target_role(echo_target.id, role.id)
+
+        session = requests.Session()
+        session.verify = False
+
+        # Login with just password should succeed
+        response = session.post(
+            f"{url}/@warpgate/api/auth/login",
+            json={
+                "username": user.username,
+                "password": "pass123",
+            },
+        )
+        assert response.status_code == 201
+
+        # Should be able to access the target
+        response = session.get(
+            f"{url}/some/path?warpgate-target={echo_target.name}",
+            allow_redirects=False,
+        )
+        assert response.status_code // 100 == 2

--- a/warpgate-admin/src/api/mod.rs
+++ b/warpgate-admin/src/api/mod.rs
@@ -36,6 +36,7 @@ mod ticket_requests_list;
 mod tickets_detail;
 mod tickets_list;
 pub mod users;
+mod webauthn_credentials;
 
 pub use warpgate_common::api::AnySecurityScheme;
 
@@ -85,6 +86,10 @@ pub fn get() -> impl OpenApi {
         (
             certificate_credentials::ListApi,
             certificate_credentials::DetailApi,
+        ),
+        (
+            webauthn_credentials::ListApi,
+            webauthn_credentials::DetailApi,
         ),
     )
 }

--- a/warpgate-admin/src/api/webauthn_credentials.rs
+++ b/warpgate-admin/src/api/webauthn_credentials.rs
@@ -1,0 +1,121 @@
+use poem_openapi::param::Path;
+use poem_openapi::payload::Json;
+use poem_openapi::{ApiResponse, Object, OpenApi};
+use sea_orm::{ColumnTrait, EntityTrait, ModelTrait, QueryFilter};
+use time::OffsetDateTime;
+use uuid::Uuid;
+use warpgate_common::{AdminPermission, WarpgateError};
+use warpgate_core::logging::{AuditEvent, CredentialChangedVia};
+use warpgate_db_entities::{User, WebauthnCredential};
+
+use super::AdminContext;
+
+#[derive(Object)]
+struct ExistingWebauthnCredential {
+    id: Uuid,
+    label: String,
+    date_added: Option<OffsetDateTime>,
+    last_used: Option<OffsetDateTime>,
+}
+
+impl From<WebauthnCredential::Model> for ExistingWebauthnCredential {
+    fn from(credential: WebauthnCredential::Model) -> Self {
+        Self {
+            id: credential.id,
+            label: credential.label,
+            date_added: credential.date_added,
+            last_used: credential.last_used,
+        }
+    }
+}
+
+#[derive(ApiResponse)]
+enum GetWebauthnCredentialsResponse {
+    #[oai(status = 200)]
+    Ok(Json<Vec<ExistingWebauthnCredential>>),
+}
+
+pub struct ListApi;
+
+#[OpenApi]
+impl ListApi {
+    #[oai(
+        path = "/users/:user_id/credentials/webauthn",
+        method = "get",
+        operation_id = "get_webauthn_credentials"
+    )]
+    async fn api_get_all(
+        &self,
+        admin: AdminContext,
+        user_id: Path<Uuid>,
+    ) -> Result<GetWebauthnCredentialsResponse, WarpgateError> {
+        admin.require(AdminPermission::UsersEdit)?;
+
+        let db = &admin.services().db;
+
+        let objects = WebauthnCredential::Entity::find()
+            .filter(WebauthnCredential::Column::UserId.eq(*user_id))
+            .all(db)
+            .await?;
+
+        Ok(GetWebauthnCredentialsResponse::Ok(Json(
+            objects.into_iter().map(Into::into).collect(),
+        )))
+    }
+}
+
+#[derive(ApiResponse)]
+enum DeleteCredentialResponse {
+    #[oai(status = 204)]
+    Deleted,
+    #[oai(status = 404)]
+    NotFound,
+}
+
+pub struct DetailApi;
+
+#[OpenApi]
+impl DetailApi {
+    #[oai(
+        path = "/users/:user_id/credentials/webauthn/:id",
+        method = "delete",
+        operation_id = "delete_webauthn_credential"
+    )]
+    async fn api_delete(
+        &self,
+        admin: AdminContext,
+        user_id: Path<Uuid>,
+        id: Path<Uuid>,
+    ) -> Result<DeleteCredentialResponse, WarpgateError> {
+        admin.require(AdminPermission::UsersEdit)?;
+
+        let db = &admin.services().db;
+
+        let Some(credential) = WebauthnCredential::Entity::find_by_id(id.0)
+            .filter(WebauthnCredential::Column::UserId.eq(*user_id))
+            .one(db)
+            .await?
+        else {
+            return Ok(DeleteCredentialResponse::NotFound);
+        };
+
+        let label = credential.label.clone();
+        credential.delete(db).await?;
+
+        let Some(user) = User::Entity::find_by_id(*user_id).one(db).await? else {
+            return Ok(DeleteCredentialResponse::NotFound);
+        };
+
+        AuditEvent::CredentialDeleted {
+            credential_type: "webauthn".to_string(),
+            credential_name: Some(label),
+            via: CredentialChangedVia::Admin,
+            user_id: *user_id,
+            username: user.username,
+            actor_user_id: admin.auth.user_id(),
+        }
+        .emit();
+
+        Ok(DeleteCredentialResponse::Deleted)
+    }
+}

--- a/warpgate-common/src/auth/cred.rs
+++ b/warpgate-common/src/auth/cred.rs
@@ -22,6 +22,8 @@ pub enum CredentialKind {
     Sso,
     #[serde(rename = "web")]
     WebUserApproval,
+    #[serde(rename = "webauthn")]
+    WebAuthn,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,6 +42,7 @@ pub enum AuthCredential {
         email: String,
     },
     WebUserApproval,
+    WebAuthn,
 }
 
 impl AuthCredential {
@@ -51,6 +54,7 @@ impl AuthCredential {
             Self::Otp { .. } => CredentialKind::Totp,
             Self::Sso { .. } => CredentialKind::Sso,
             Self::WebUserApproval => CredentialKind::WebUserApproval,
+            Self::WebAuthn => CredentialKind::WebAuthn,
         }
     }
 
@@ -62,6 +66,7 @@ impl AuthCredential {
             Self::Otp { .. } => "one-time password".to_string(),
             Self::Sso { provider, .. } => format!("SSO ({provider})"),
             Self::WebUserApproval => "in-browser auth".to_string(),
+            Self::WebAuthn => "passkey".to_string(),
         }
     }
 }
@@ -77,6 +82,7 @@ pub enum AuthCredentialFingerprint {
     Certificate { hash: [u8; 32] },
     Sso { provider: String, email: String },
     WebUserApproval,
+    WebAuthn,
 }
 
 fn sha256(bytes: &[u8]) -> [u8; 32] {
@@ -105,6 +111,7 @@ impl From<&AuthCredential> for AuthCredentialFingerprint {
                 email: email.clone(),
             },
             AuthCredential::WebUserApproval => Self::WebUserApproval,
+            AuthCredential::WebAuthn => Self::WebAuthn,
         }
     }
 }

--- a/warpgate-common/src/auth/state.rs
+++ b/warpgate-common/src/auth/state.rs
@@ -534,4 +534,62 @@ mod tests {
             AuthResult::Accepted { .. }
         ));
     }
+
+    #[tokio::test]
+    async fn webauthn_credential_satisfies_policy() {
+        let mut state = make_state(&[CredentialKind::WebAuthn]);
+        // Initially needs WebAuthn
+        assert!(matches!(
+            state.verify(),
+            AuthResult::Need(kinds) if kinds.contains(&CredentialKind::WebAuthn)
+        ));
+        // After submitting WebAuthn, accepted
+        let outcome = state
+            .submit_credential(AuthCredential::WebAuthn, |_, _| async { Ok(true) })
+            .await
+            .unwrap();
+        assert!(outcome.is_valid());
+        assert!(matches!(outcome.result(), AuthResult::Accepted { .. }));
+    }
+
+    #[tokio::test]
+    async fn password_plus_webauthn_requires_both() {
+        let mut state = make_state(&[CredentialKind::Password, CredentialKind::WebAuthn]);
+        // Needs both
+        assert!(matches!(state.verify(), AuthResult::Need(_)));
+
+        // Submit password
+        let outcome = state
+            .submit_credential(password(), |_, _| async { Ok(true) })
+            .await
+            .unwrap();
+        assert!(outcome.is_valid());
+        // Still needs WebAuthn
+        assert!(matches!(
+            outcome.result(),
+            AuthResult::Need(kinds) if kinds.contains(&CredentialKind::WebAuthn)
+        ));
+
+        // Submit WebAuthn
+        let outcome = state
+            .submit_credential(AuthCredential::WebAuthn, |_, _| async { Ok(true) })
+            .await
+            .unwrap();
+        assert!(outcome.is_valid());
+        assert!(matches!(outcome.result(), AuthResult::Accepted { .. }));
+    }
+
+    #[tokio::test]
+    async fn webauthn_rejection_leaves_state_unchanged() {
+        let mut state = make_state(&[CredentialKind::WebAuthn]);
+        let outcome = state
+            .submit_credential(AuthCredential::WebAuthn, |_, _| async { Ok(false) })
+            .await
+            .unwrap();
+        assert!(!outcome.is_valid());
+        assert!(matches!(
+            state.verify(),
+            AuthResult::Need(kinds) if kinds.contains(&CredentialKind::WebAuthn)
+        ));
+    }
 }

--- a/warpgate-common/src/auth/state.rs
+++ b/warpgate-common/src/auth/state.rs
@@ -530,4 +530,62 @@ mod tests {
             AuthResult::Accepted { .. }
         ));
     }
+
+    #[tokio::test]
+    async fn webauthn_credential_satisfies_policy() {
+        let mut state = make_state(&[CredentialKind::WebAuthn]);
+        // Initially needs WebAuthn
+        assert!(matches!(
+            state.verify(),
+            AuthResult::Need(kinds) if kinds.contains(&CredentialKind::WebAuthn)
+        ));
+        // After submitting WebAuthn, accepted
+        let outcome = state
+            .submit_credential(AuthCredential::WebAuthn, |_, _| async { Ok(true) })
+            .await
+            .unwrap();
+        assert!(outcome.is_valid());
+        assert!(matches!(outcome.result(), AuthResult::Accepted { .. }));
+    }
+
+    #[tokio::test]
+    async fn password_plus_webauthn_requires_both() {
+        let mut state = make_state(&[CredentialKind::Password, CredentialKind::WebAuthn]);
+        // Needs both
+        assert!(matches!(state.verify(), AuthResult::Need(_)));
+
+        // Submit password
+        let outcome = state
+            .submit_credential(password(), |_, _| async { Ok(true) })
+            .await
+            .unwrap();
+        assert!(outcome.is_valid());
+        // Still needs WebAuthn
+        assert!(matches!(
+            outcome.result(),
+            AuthResult::Need(kinds) if kinds.contains(&CredentialKind::WebAuthn)
+        ));
+
+        // Submit WebAuthn
+        let outcome = state
+            .submit_credential(AuthCredential::WebAuthn, |_, _| async { Ok(true) })
+            .await
+            .unwrap();
+        assert!(outcome.is_valid());
+        assert!(matches!(outcome.result(), AuthResult::Accepted { .. }));
+    }
+
+    #[tokio::test]
+    async fn webauthn_rejection_leaves_state_unchanged() {
+        let mut state = make_state(&[CredentialKind::WebAuthn]);
+        let outcome = state
+            .submit_credential(AuthCredential::WebAuthn, |_, _| async { Ok(false) })
+            .await
+            .unwrap();
+        assert!(!outcome.is_valid());
+        assert!(matches!(
+            state.verify(),
+            AuthResult::Need(kinds) if kinds.contains(&CredentialKind::WebAuthn)
+        ));
+    }
 }

--- a/warpgate-common/src/config/mod.rs
+++ b/warpgate-common/src/config/mod.rs
@@ -38,6 +38,7 @@ pub enum UserAuthCredential {
     Certificate(UserCertificateCredential),
     Totp(UserTotpCredential),
     Sso(UserSsoCredential),
+    WebAuthn(UserWebAuthnCredential),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Object)]
@@ -73,6 +74,13 @@ pub struct UserSsoCredential {
     pub email: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Object)]
+pub struct UserWebAuthnCredential {
+    pub credential_id: String,
+    pub credential_json: String,
+    pub label: String,
+}
+
 impl UserAuthCredential {
     pub const fn kind(&self) -> CredentialKind {
         match self {
@@ -81,6 +89,7 @@ impl UserAuthCredential {
             Self::Certificate(_) => CredentialKind::Certificate,
             Self::Totp(_) => CredentialKind::Totp,
             Self::Sso(_) => CredentialKind::Sso,
+            Self::WebAuthn(_) => CredentialKind::WebAuthn,
         }
     }
 }
@@ -137,6 +146,54 @@ impl UserRequireCredentialsPolicy {
             }
             if !kinds.is_empty() {
                 kinds.push(CredentialKind::Totp);
+                copy.ssh = Some(kinds);
+            }
+        }
+        copy
+    }
+
+    #[must_use]
+    pub fn upgrade_to_webauthn(&self, with_existing_credentials: &[UserAuthCredential]) -> Self {
+        let mut copy = self.clone();
+
+        if let Some(policy) = &mut copy.http {
+            if !policy.contains(&CredentialKind::WebAuthn) {
+                policy.push(CredentialKind::WebAuthn);
+            }
+        } else {
+            let mut kinds = vec![];
+            if with_existing_credentials
+                .iter()
+                .any(|c| c.kind() == CredentialKind::Password)
+            {
+                kinds.push(CredentialKind::Password);
+            }
+            if !kinds.is_empty() {
+                kinds.push(CredentialKind::WebAuthn);
+                copy.http = Some(kinds);
+            }
+        }
+
+        if let Some(policy) = &mut copy.ssh {
+            if !policy.contains(&CredentialKind::WebAuthn) {
+                policy.push(CredentialKind::WebAuthn);
+            }
+        } else {
+            // Mirrors `upgrade_to_otp` exactly for consistency: when no explicit
+            // ssh policy exists, seed one from an existing password/public-key.
+            // Note we push `Password` (not `PublicKey`) even when only a public
+            // key is present — this matches the pre-existing OTP behavior. A
+            // public-key-only user would therefore need to also set a password
+            // to satisfy an auto-generated ssh policy. Left as-is to avoid
+            // diverging from the sibling method / changing pre-existing behavior.
+            let mut kinds = vec![];
+            if with_existing_credentials.iter().any(|c| {
+                c.kind() == CredentialKind::Password || c.kind() == CredentialKind::PublicKey
+            }) {
+                kinds.push(CredentialKind::Password);
+            }
+            if !kinds.is_empty() {
+                kinds.push(CredentialKind::WebAuthn);
                 copy.ssh = Some(kinds);
             }
         }
@@ -950,7 +1007,11 @@ impl WarpgateConfig {
 mod tests {
     use std::time::Duration;
 
-    use super::{SshConfig, WarpgateConfigStore};
+    use super::{
+        CredentialKind, SshConfig, UserAuthCredential, UserPasswordCredential,
+        UserRequireCredentialsPolicy, UserTotpCredential, WarpgateConfigStore,
+    };
+    use crate::Secret;
 
     #[test]
     fn keepalive_interval_is_a_humantime_string() {
@@ -969,5 +1030,75 @@ mod tests {
         let config = config.as_object().unwrap();
 
         assert!(!config.contains_key("recordings"));
+    }
+
+    #[test]
+    fn upgrade_to_webauthn_adds_when_password_exists() {
+        let policy = UserRequireCredentialsPolicy::default();
+        let creds = vec![UserAuthCredential::Password(UserPasswordCredential {
+            hash: Secret::new("hash".into()),
+        })];
+        let upgraded = policy.upgrade_to_webauthn(&creds);
+        assert_eq!(
+            upgraded.http,
+            Some(vec![CredentialKind::Password, CredentialKind::WebAuthn])
+        );
+        assert_eq!(
+            upgraded.ssh,
+            Some(vec![CredentialKind::Password, CredentialKind::WebAuthn])
+        );
+    }
+
+    #[test]
+    fn upgrade_to_webauthn_does_not_duplicate() {
+        let policy = UserRequireCredentialsPolicy {
+            http: Some(vec![CredentialKind::Password, CredentialKind::WebAuthn]),
+            ..Default::default()
+        };
+        let creds = vec![UserAuthCredential::Password(UserPasswordCredential {
+            hash: Secret::new("hash".into()),
+        })];
+        let upgraded = policy.upgrade_to_webauthn(&creds);
+        let webauthn_count = upgraded
+            .http
+            .unwrap()
+            .iter()
+            .filter(|k| **k == CredentialKind::WebAuthn)
+            .count();
+        assert_eq!(webauthn_count, 1);
+    }
+
+    #[test]
+    fn upgrade_to_webauthn_stacks_with_otp() {
+        let policy = UserRequireCredentialsPolicy {
+            http: Some(vec![CredentialKind::Password, CredentialKind::Totp]),
+            ..Default::default()
+        };
+        let creds = vec![
+            UserAuthCredential::Password(UserPasswordCredential {
+                hash: Secret::new("hash".into()),
+            }),
+            UserAuthCredential::Totp(UserTotpCredential {
+                key: vec![0u8; 32].into(),
+            }),
+        ];
+        let upgraded = policy.upgrade_to_webauthn(&creds);
+        assert_eq!(
+            upgraded.http,
+            Some(vec![
+                CredentialKind::Password,
+                CredentialKind::Totp,
+                CredentialKind::WebAuthn,
+            ])
+        );
+    }
+
+    #[test]
+    fn upgrade_to_webauthn_noop_without_password() {
+        let policy = UserRequireCredentialsPolicy::default();
+        let creds = vec![];
+        let upgraded = policy.upgrade_to_webauthn(&creds);
+        assert_eq!(upgraded.http, None);
+        assert_eq!(upgraded.ssh, None);
     }
 }

--- a/warpgate-common/src/config/mod.rs
+++ b/warpgate-common/src/config/mod.rs
@@ -36,6 +36,7 @@ pub enum UserAuthCredential {
     Certificate(UserCertificateCredential),
     Totp(UserTotpCredential),
     Sso(UserSsoCredential),
+    WebAuthn(UserWebAuthnCredential),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Object)]
@@ -71,6 +72,13 @@ pub struct UserSsoCredential {
     pub email: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Object)]
+pub struct UserWebAuthnCredential {
+    pub credential_id: String,
+    pub credential_json: String,
+    pub label: String,
+}
+
 impl UserAuthCredential {
     pub const fn kind(&self) -> CredentialKind {
         match self {
@@ -79,6 +87,7 @@ impl UserAuthCredential {
             Self::Certificate(_) => CredentialKind::Certificate,
             Self::Totp(_) => CredentialKind::Totp,
             Self::Sso(_) => CredentialKind::Sso,
+            Self::WebAuthn(_) => CredentialKind::WebAuthn,
         }
     }
 }
@@ -135,6 +144,47 @@ impl UserRequireCredentialsPolicy {
             }
             if !kinds.is_empty() {
                 kinds.push(CredentialKind::Totp);
+                copy.ssh = Some(kinds);
+            }
+        }
+        copy
+    }
+
+    #[must_use]
+    pub fn upgrade_to_webauthn(&self, with_existing_credentials: &[UserAuthCredential]) -> Self {
+        let mut copy = self.clone();
+
+        if let Some(policy) = &mut copy.http {
+            if !policy.contains(&CredentialKind::WebAuthn) {
+                policy.push(CredentialKind::WebAuthn);
+            }
+        } else {
+            let mut kinds = vec![];
+            if with_existing_credentials
+                .iter()
+                .any(|c| c.kind() == CredentialKind::Password)
+            {
+                kinds.push(CredentialKind::Password);
+            }
+            if !kinds.is_empty() {
+                kinds.push(CredentialKind::WebAuthn);
+                copy.http = Some(kinds);
+            }
+        }
+
+        if let Some(policy) = &mut copy.ssh {
+            if !policy.contains(&CredentialKind::WebAuthn) {
+                policy.push(CredentialKind::WebAuthn);
+            }
+        } else {
+            let mut kinds = vec![];
+            if with_existing_credentials.iter().any(|c| {
+                c.kind() == CredentialKind::Password || c.kind() == CredentialKind::PublicKey
+            }) {
+                kinds.push(CredentialKind::Password);
+            }
+            if !kinds.is_empty() {
+                kinds.push(CredentialKind::WebAuthn);
                 copy.ssh = Some(kinds);
             }
         }
@@ -949,6 +999,11 @@ mod tests {
     use std::time::Duration;
 
     use super::{SshConfig, WarpgateConfigStore};
+    use super::{
+        CredentialKind, UserAuthCredential, UserPasswordCredential, UserRequireCredentialsPolicy,
+        UserTotpCredential,
+    };
+    use crate::Secret;
 
     #[test]
     fn keepalive_interval_is_a_humantime_string() {
@@ -967,5 +1022,75 @@ mod tests {
         let config = config.as_object().unwrap();
 
         assert!(!config.contains_key("recordings"));
+    }
+
+    #[test]
+    fn upgrade_to_webauthn_adds_when_password_exists() {
+        let policy = UserRequireCredentialsPolicy::default();
+        let creds = vec![UserAuthCredential::Password(UserPasswordCredential {
+            hash: Secret::new("hash".into()),
+        })];
+        let upgraded = policy.upgrade_to_webauthn(&creds);
+        assert_eq!(
+            upgraded.http,
+            Some(vec![CredentialKind::Password, CredentialKind::WebAuthn])
+        );
+        assert_eq!(
+            upgraded.ssh,
+            Some(vec![CredentialKind::Password, CredentialKind::WebAuthn])
+        );
+    }
+
+    #[test]
+    fn upgrade_to_webauthn_does_not_duplicate() {
+        let policy = UserRequireCredentialsPolicy {
+            http: Some(vec![CredentialKind::Password, CredentialKind::WebAuthn]),
+            ..Default::default()
+        };
+        let creds = vec![UserAuthCredential::Password(UserPasswordCredential {
+            hash: Secret::new("hash".into()),
+        })];
+        let upgraded = policy.upgrade_to_webauthn(&creds);
+        let webauthn_count = upgraded
+            .http
+            .unwrap()
+            .iter()
+            .filter(|k| **k == CredentialKind::WebAuthn)
+            .count();
+        assert_eq!(webauthn_count, 1);
+    }
+
+    #[test]
+    fn upgrade_to_webauthn_stacks_with_otp() {
+        let policy = UserRequireCredentialsPolicy {
+            http: Some(vec![CredentialKind::Password, CredentialKind::Totp]),
+            ..Default::default()
+        };
+        let creds = vec![
+            UserAuthCredential::Password(UserPasswordCredential {
+                hash: Secret::new("hash".into()),
+            }),
+            UserAuthCredential::Totp(UserTotpCredential {
+                key: vec![0u8; 32].into(),
+            }),
+        ];
+        let upgraded = policy.upgrade_to_webauthn(&creds);
+        assert_eq!(
+            upgraded.http,
+            Some(vec![
+                CredentialKind::Password,
+                CredentialKind::Totp,
+                CredentialKind::WebAuthn,
+            ])
+        );
+    }
+
+    #[test]
+    fn upgrade_to_webauthn_noop_without_password() {
+        let policy = UserRequireCredentialsPolicy::default();
+        let creds = vec![];
+        let upgraded = policy.upgrade_to_webauthn(&creds);
+        assert_eq!(upgraded.http, None);
+        assert_eq!(upgraded.ssh, None);
     }
 }

--- a/warpgate-core/src/config_providers/db.rs
+++ b/warpgate-core/src/config_providers/db.rs
@@ -627,6 +627,20 @@ impl ConfigProvider for DatabaseConfigProvider {
                 }
                 Ok(false)
             }
+            AuthCredential::WebAuthn => {
+                // Returns Ok(true) because the WebAuthn ceremony in
+                // `serve_webauthn_auth_complete` has already, before this
+                // credential is ever submitted:
+                //   (a) cryptographically verified the assertion signature and
+                //       challenge via `finish_securitykey_authentication`, and
+                //   (b) confirmed the signing credential belongs to this
+                //       login's user (explicit user_id match in
+                //       `verify_webauthn_authentication`).
+                // This arm is only reachable immediately after that ceremony
+                // succeeds; it records the already-verified factor as satisfied,
+                // mirroring how `WebUserApproval` is handled.
+                Ok(true)
+            }
             _ => Err(WarpgateError::InvalidCredentialType),
         }
     }

--- a/warpgate-core/src/config_providers/db.rs
+++ b/warpgate-core/src/config_providers/db.rs
@@ -627,6 +627,11 @@ impl ConfigProvider for DatabaseConfigProvider {
                 }
                 Ok(false)
             }
+            AuthCredential::WebAuthn => {
+                // WebAuthn validation happens in the ceremony endpoint, not here.
+                // If we reach this point, the ceremony already succeeded.
+                Ok(true)
+            }
             _ => Err(WarpgateError::InvalidCredentialType),
         }
     }

--- a/warpgate-db-entities/src/User.rs
+++ b/warpgate-db-entities/src/User.rs
@@ -11,7 +11,7 @@ use warpgate_common::{User, UserDetails, WarpgateError};
 
 use crate::{
     CertificateCredential, OtpCredential, PasswordCredential, PublicKeyCredential, Role,
-    SsoCredential,
+    SsoCredential, WebauthnCredential,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Object)]
@@ -83,6 +83,12 @@ impl Related<super::SsoCredential::Entity> for Entity {
     }
 }
 
+impl Related<super::WebauthnCredential::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::WebauthnCredentials.def()
+    }
+}
+
 impl Related<super::ApiToken::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::ApiTokens.def()
@@ -97,6 +103,7 @@ pub enum Relation {
     PublicKeyCredentials,
     CertificateCredentials,
     SsoCredentials,
+    WebauthnCredentials,
     ApiTokens,
     AdminRoles,
 }
@@ -123,6 +130,10 @@ impl RelationTrait for Relation {
             Self::SsoCredentials => Entity::has_many(super::SsoCredential::Entity)
                 .from(Column::Id)
                 .to(super::SsoCredential::Column::UserId)
+                .into(),
+            Self::WebauthnCredentials => Entity::has_many(super::WebauthnCredential::Entity)
+                .from(Column::Id)
+                .to(super::WebauthnCredential::Column::UserId)
                 .into(),
             Self::ApiTokens => Entity::has_many(super::ApiToken::Entity)
                 .from(Column::Id)
@@ -217,6 +228,13 @@ impl Model {
         );
         credentials.extend(
             self.find_related(CertificateCredential::Entity)
+                .all(db)
+                .await?
+                .into_iter()
+                .map(Into::into),
+        );
+        credentials.extend(
+            self.find_related(WebauthnCredential::Entity)
                 .all(db)
                 .await?
                 .into_iter()

--- a/warpgate-db-entities/src/WebauthnCredential.rs
+++ b/warpgate-db-entities/src/WebauthnCredential.rs
@@ -1,0 +1,58 @@
+use sea_orm::entity::prelude::*;
+use sea_orm::sea_query::ForeignKeyAction;
+use serde::Serialize;
+use time::OffsetDateTime;
+use uuid::Uuid;
+use warpgate_common::UserAuthCredential;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize)]
+#[sea_orm(table_name = "credentials_webauthn")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub label: String,
+    /// The credential ID from webauthn-rs, stored as base64
+    #[sea_orm(column_type = "Text")]
+    pub credential_id: String,
+    /// The full SecurityKey serialized as JSON (public key + metadata; no secret)
+    #[sea_orm(column_type = "Text")]
+    pub credential_json: String,
+    pub date_added: Option<OffsetDateTime>,
+    pub last_used: Option<OffsetDateTime>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter)]
+pub enum Relation {
+    User,
+}
+
+impl RelationTrait for Relation {
+    fn def(&self) -> RelationDef {
+        match self {
+            Self::User => Entity::belongs_to(super::User::Entity)
+                .from(Column::UserId)
+                .to(super::User::Column::Id)
+                .on_delete(ForeignKeyAction::Cascade)
+                .into(),
+        }
+    }
+}
+
+impl Related<super::User::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::User.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+impl From<Model> for UserAuthCredential {
+    fn from(model: Model) -> Self {
+        Self::WebAuthn(warpgate_common::UserWebAuthnCredential {
+            credential_id: model.credential_id,
+            credential_json: model.credential_json,
+            label: model.label,
+        })
+    }
+}

--- a/warpgate-db-entities/src/WebauthnCredential.rs
+++ b/warpgate-db-entities/src/WebauthnCredential.rs
@@ -1,0 +1,58 @@
+use sea_orm::entity::prelude::*;
+use sea_orm::sea_query::ForeignKeyAction;
+use serde::Serialize;
+use time::OffsetDateTime;
+use uuid::Uuid;
+use warpgate_common::UserAuthCredential;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize)]
+#[sea_orm(table_name = "credentials_webauthn")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub label: String,
+    /// The credential ID from webauthn-rs, stored as base64
+    #[sea_orm(column_type = "Text")]
+    pub credential_id: String,
+    /// The full Passkey serialized as JSON
+    #[sea_orm(column_type = "Text")]
+    pub credential_json: String,
+    pub date_added: Option<OffsetDateTime>,
+    pub last_used: Option<OffsetDateTime>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter)]
+pub enum Relation {
+    User,
+}
+
+impl RelationTrait for Relation {
+    fn def(&self) -> RelationDef {
+        match self {
+            Self::User => Entity::belongs_to(super::User::Entity)
+                .from(Column::UserId)
+                .to(super::User::Column::Id)
+                .on_delete(ForeignKeyAction::Cascade)
+                .into(),
+        }
+    }
+}
+
+impl Related<super::User::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::User.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+impl From<Model> for UserAuthCredential {
+    fn from(model: Model) -> Self {
+        Self::WebAuthn(warpgate_common::UserWebAuthnCredential {
+            credential_id: model.credential_id,
+            credential_json: model.credential_json,
+            label: model.label,
+        })
+    }
+}

--- a/warpgate-db-entities/src/lib.rs
+++ b/warpgate-db-entities/src/lib.rs
@@ -36,6 +36,7 @@ macro_rules! with_every_entity {
             UserLockout,
             UserRoleAssignment,
             UserSession,
+            WebauthnCredential,
         ];
     };
 }

--- a/warpgate-db-entities/src/lib.rs
+++ b/warpgate-db-entities/src/lib.rs
@@ -29,3 +29,4 @@ pub mod User;
 pub mod UserAdminRoleAssignment;
 pub mod UserLockout;
 pub mod UserRoleAssignment;
+pub mod WebauthnCredential;

--- a/warpgate-db-migrations/src/lib.rs
+++ b/warpgate-db-migrations/src/lib.rs
@@ -86,6 +86,7 @@ mod m00079_unique_target_and_group_names;
 mod m00080_user_and_target_sessions;
 mod m00081_http_session_user_session_id;
 mod m00082_target_session_columns;
+mod m00083_webauthn_credentials;
 
 pub(crate) mod helpers;
 
@@ -177,6 +178,7 @@ impl MigratorTrait for Migrator {
             Box::new(m00080_user_and_target_sessions::Migration),
             Box::new(m00081_http_session_user_session_id::Migration),
             Box::new(m00082_target_session_columns::Migration),
+            Box::new(m00083_webauthn_credentials::Migration),
         ]
     }
 }

--- a/warpgate-db-migrations/src/lib.rs
+++ b/warpgate-db-migrations/src/lib.rs
@@ -76,6 +76,7 @@ mod m00069_ssh_client_keys;
 mod m00070_http_sessions;
 mod m00071_ssh_host_key_verification;
 mod m00072_session_node_id_not_null;
+mod m00073_webauthn_credentials;
 
 pub(crate) mod helpers;
 
@@ -157,6 +158,7 @@ impl MigratorTrait for Migrator {
             Box::new(m00070_http_sessions::Migration),
             Box::new(m00071_ssh_host_key_verification::Migration),
             Box::new(m00072_session_node_id_not_null::Migration),
+            Box::new(m00073_webauthn_credentials::Migration),
         ]
     }
 }

--- a/warpgate-db-migrations/src/m00073_webauthn_credentials.rs
+++ b/warpgate-db-migrations/src/m00073_webauthn_credentials.rs
@@ -1,0 +1,97 @@
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m00073_webauthn_credentials"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(WebauthnCredential::Table)
+                    .col(
+                        ColumnDef::new(WebauthnCredential::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(WebauthnCredential::UserId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(WebauthnCredential::Label)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(WebauthnCredential::CredentialId)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(WebauthnCredential::CredentialJson)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(WebauthnCredential::DateAdded)
+                            .timestamp_with_time_zone(),
+                    )
+                    .col(
+                        ColumnDef::new(WebauthnCredential::LastUsed)
+                            .timestamp_with_time_zone(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(WebauthnCredential::Table, WebauthnCredential::UserId)
+                            .to(Users::Table, Users::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_credentials_webauthn_user_id")
+                    .table(WebauthnCredential::Table)
+                    .col(WebauthnCredential::UserId)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(WebauthnCredential::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum WebauthnCredential {
+    #[iden = "credentials_webauthn"]
+    Table,
+    Id,
+    UserId,
+    Label,
+    CredentialId,
+    CredentialJson,
+    DateAdded,
+    LastUsed,
+}
+
+#[derive(Iden)]
+enum Users {
+    Table,
+    Id,
+}

--- a/warpgate-db-migrations/src/m00075_hash_ticket_and_api_token_secrets.rs
+++ b/warpgate-db-migrations/src/m00075_hash_ticket_and_api_token_secrets.rs
@@ -102,7 +102,7 @@ mod tests {
     use uuid::Uuid;
     use warpgate_db_entities::Parameters::{ConfigMigrationValues, set_config_migration_values};
 
-    use super::index_name;
+    use super::{Migration, index_name};
     use crate::Migrator;
 
     #[tokio::test]
@@ -112,7 +112,12 @@ mod tests {
         let backend = db.get_database_backend();
 
         // Migrate up to just before this migration, then seed raw-secret rows.
-        let steps = 74;
+        let all_migrations = Migrator::migrations();
+        let this_migration_index = all_migrations
+            .iter()
+            .position(|m| m.name() == Migration.name())
+            .expect("this migration must be registered in Migrator::migrations()");
+        let steps = this_migration_index as u32;
         Migrator::up(&db, Some(steps)).await.unwrap();
 
         db.execute_unprepared("PRAGMA foreign_keys = OFF")

--- a/warpgate-db-migrations/src/m00083_webauthn_credentials.rs
+++ b/warpgate-db-migrations/src/m00083_webauthn_credentials.rs
@@ -1,0 +1,87 @@
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m00083_webauthn_credentials"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(WebauthnCredential::Table)
+                    .col(
+                        ColumnDef::new(WebauthnCredential::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(WebauthnCredential::UserId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(WebauthnCredential::Label)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(WebauthnCredential::CredentialId)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(WebauthnCredential::CredentialJson)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(WebauthnCredential::DateAdded).timestamp_with_time_zone())
+                    .col(ColumnDef::new(WebauthnCredential::LastUsed).timestamp_with_time_zone())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(WebauthnCredential::Table, WebauthnCredential::UserId)
+                            .to(Users::Table, Users::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_credentials_webauthn_user_id")
+                    .table(WebauthnCredential::Table)
+                    .col(WebauthnCredential::UserId)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(WebauthnCredential::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum WebauthnCredential {
+    #[iden = "credentials_webauthn"]
+    Table,
+    Id,
+    UserId,
+    Label,
+    CredentialId,
+    CredentialJson,
+    DateAdded,
+    LastUsed,
+}
+
+#[derive(Iden)]
+enum Users {
+    Table,
+    Id,
+}

--- a/warpgate-protocol-http/Cargo.toml
+++ b/warpgate-protocol-http/Cargo.toml
@@ -42,6 +42,8 @@ warpgate-web = { path = "../warpgate-web", default-features = false }
 warpgate-web-clients-common = { path = "../warpgate-web-clients-common" }
 warpgate-web-desktop = { path = "../warpgate-web-desktop", default-features = false }
 warpgate-web-ssh = { path = "../warpgate-web-ssh", default-features = false }
+webauthn-rs = { workspace = true }
+webauthn-rs-proto = { workspace = true }
 
 [dev-dependencies]
 poem = { workspace = true, features = ["test"] }

--- a/warpgate-protocol-http/Cargo.toml
+++ b/warpgate-protocol-http/Cargo.toml
@@ -41,6 +41,8 @@ warpgate-tls = { path = "../warpgate-tls", default-features = false }
 warpgate-web = { path = "../warpgate-web", default-features = false }
 warpgate-web-desktop = { path = "../warpgate-web-desktop", default-features = false }
 warpgate-web-ssh = { path = "../warpgate-web-ssh", default-features = false }
+webauthn-rs = { workspace = true }
+webauthn-rs-proto = { workspace = true }
 
 [dev-dependencies]
 poem = { workspace = true, features = ["test"] }

--- a/warpgate-protocol-http/src/api/auth.rs
+++ b/warpgate-protocol-http/src/api/auth.rs
@@ -15,7 +15,7 @@ use sea_orm::EntityTrait;
 use serde::Serialize;
 use time::OffsetDateTime;
 use tokio::sync::{Mutex, broadcast};
-use tracing::warn;
+use tracing::{error, warn};
 use uuid::Uuid;
 use warpgate_admin::api::cluster_proxy::{
     Owner, ReparseForwardedResponse, fan_out_to_peers, forwarded_error, node_owner,
@@ -61,6 +61,7 @@ enum ApiAuthState {
     OtpNeeded,
     SsoNeeded,
     WebUserApprovalNeeded,
+    WebAuthnNeeded,
     PublicKeyNeeded,
     Success,
     IpBlocked,
@@ -158,6 +159,7 @@ const PREFERRED_NEED_CRED_ORDER: &[CredentialKind] = &[
     CredentialKind::PublicKey,
     CredentialKind::Password,
     CredentialKind::Totp,
+    CredentialKind::WebAuthn,
     CredentialKind::Sso,
     CredentialKind::WebUserApproval,
 ];
@@ -176,6 +178,7 @@ impl From<AuthResult> for ApiAuthState {
                     Some(CredentialKind::Totp) => Self::OtpNeeded,
                     Some(CredentialKind::Sso) => Self::SsoNeeded,
                     Some(CredentialKind::WebUserApproval) => Self::WebUserApprovalNeeded,
+                    Some(CredentialKind::WebAuthn) => Self::WebAuthnNeeded,
                     Some(CredentialKind::PublicKey) => Self::PublicKeyNeeded,
                     Some(CredentialKind::Certificate) => {
                         // Certificate authentication is not supported for HTTP protocol
@@ -410,6 +413,41 @@ impl Api {
             Ok(AuthStateResponse::Ok(Json(
                 serialize_auth_state_inner(state_arc, ctx.services()).await?,
             )))
+        })
+        .await
+    }
+
+    #[oai(
+        path = "/auth/webauthn/authentication/start",
+        method = "post",
+        operation_id = "start_webauthn_authentication"
+    )]
+    async fn api_webauthn_auth_start(
+        &self,
+        req: &Request,
+        session: &Session,
+        ctx: Data<&UnauthenticatedRequestContext>,
+    ) -> poem::Result<super::webauthn::StartAuthenticationResponse> {
+        on_login_owner(req, session, &ctx, None::<&()>, || {
+            serve_webauthn_auth_start(req, session, &ctx)
+        })
+        .await
+    }
+
+    #[oai(
+        path = "/auth/webauthn/authentication/complete",
+        method = "post",
+        operation_id = "complete_webauthn_authentication"
+    )]
+    async fn api_webauthn_auth_complete(
+        &self,
+        req: &Request,
+        session: &Session,
+        ctx: Data<&UnauthenticatedRequestContext>,
+        body: Json<super::webauthn::AuthenticationCompleteRequest>,
+    ) -> poem::Result<super::webauthn::CompleteAuthenticationResponse> {
+        on_login_owner(req, session, &ctx, Some(&body.to_json()), || {
+            serve_webauthn_auth_complete(req, session, &ctx, &body.credential_json)
         })
         .await
     }
@@ -899,4 +937,190 @@ pub async fn api_get_web_auth_requests_stream(
 
         Ok::<(), anyhow::Error>(())
     }))
+}
+
+async fn serve_webauthn_auth_start(
+    req: &Request,
+    session: &Session,
+    ctx: &UnauthenticatedRequestContext,
+) -> poem::Result<super::webauthn::StartAuthenticationResponse> {
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+    use warpgate_db_entities::WebauthnCredential;
+
+    use super::webauthn::{
+        AuthenticationStartResponse, SESSION_KEY_AUTH_STATE, StartAuthenticationResponse,
+        build_webauthn,
+    };
+
+    let services = ctx.services();
+
+    let Some(state_arc) = get_auth_state_for_request(req, ctx).await? else {
+        return Ok(StartAuthenticationResponse::NotFound);
+    };
+
+    let username = {
+        let state = state_arc.lock().await;
+        state.user_info().username.clone()
+    };
+
+    let webauthn = match build_webauthn(services).await {
+        Ok(w) => w,
+        Err(e) => {
+            error!("Failed to build WebAuthn instance: {e}");
+            return Ok(StartAuthenticationResponse::InternalError);
+        }
+    };
+
+    let db = &services.db;
+    let user_model = warpgate_db_entities::User::Entity::find()
+        .filter(warpgate_db_entities::User::Entity::username_eq_ci(
+            &username,
+        ))
+        .one(db)
+        .await
+        .map_err(poem::error::InternalServerError)?;
+
+    let Some(user_model) = user_model else {
+        return Ok(StartAuthenticationResponse::NotFound);
+    };
+
+    let cred_models = WebauthnCredential::Entity::find()
+        .filter(WebauthnCredential::Column::UserId.eq(user_model.id))
+        .all(db)
+        .await
+        .map_err(poem::error::InternalServerError)?;
+
+    if cred_models.is_empty() {
+        return Ok(StartAuthenticationResponse::NoCredentials);
+    }
+
+    let security_keys: Vec<webauthn_rs::prelude::SecurityKey> = cred_models
+        .iter()
+        .filter_map(|c| {
+            serde_json::from_str(&c.credential_json)
+                .map_err(|e| {
+                    tracing::warn!(
+                        credential_id = %c.id,
+                        "Failed to deserialize WebAuthn credential, skipping: {e}"
+                    );
+                })
+                .ok()
+        })
+        .collect();
+
+    if security_keys.is_empty() {
+        return Ok(StartAuthenticationResponse::NoCredentials);
+    }
+
+    let (rcr, auth_state) = match webauthn.start_securitykey_authentication(&security_keys) {
+        Ok(result) => result,
+        Err(e) => {
+            error!("WebAuthn authentication start ceremony failed: {e}");
+            return Ok(StartAuthenticationResponse::InternalError);
+        }
+    };
+
+    let state_json =
+        serde_json::to_string(&auth_state).map_err(poem::error::InternalServerError)?;
+    session.set(SESSION_KEY_AUTH_STATE, state_json);
+
+    let challenge_json = serde_json::to_string(&rcr).map_err(poem::error::InternalServerError)?;
+
+    Ok(StartAuthenticationResponse::Ok(Json(
+        AuthenticationStartResponse { challenge_json },
+    )))
+}
+
+async fn serve_webauthn_auth_complete(
+    req: &Request,
+    session: &Session,
+    ctx: &UnauthenticatedRequestContext,
+    credential_json: &str,
+) -> poem::Result<super::webauthn::CompleteAuthenticationResponse> {
+    use super::webauthn::CompleteAuthenticationResponse;
+
+    let services = ctx.services();
+
+    // Resolve the in-progress login this ceremony belongs to up front, so we
+    // can bind the verification to that specific user (defense-in-depth) and
+    // reuse the same state handle for both failure accounting and completion.
+    let Some(state_arc) = get_auth_state_for_request(req, ctx).await? else {
+        return Ok(CompleteAuthenticationResponse::NotFound);
+    };
+    let (expected_user_id, username) = {
+        let state = state_arc.lock().await;
+        (state.user_info().id, state.user_info().username.clone())
+    };
+
+    // Verify the WebAuthn response and update counter/last_used
+    if let Err(e) = super::webauthn::verify_webauthn_authentication(
+        services,
+        session,
+        credential_json,
+        expected_user_id,
+    )
+    .await
+    {
+        error!("WebAuthn authentication failed: {e}");
+
+        // Record the failed attempt for brute-force protection
+        let client_ip = get_client_ip_addr(req, services).await;
+        if let Some(ip) = client_ip {
+            let _ = services
+                .login_protection
+                .record_failed_attempt(FailedAttemptInfo {
+                    username,
+                    remote_ip: ip,
+                    protocol: crate::common::PROTOCOL_NAME,
+                    credential_type: "webauthn".to_string(),
+                })
+                .await;
+        }
+
+        return Ok(CompleteAuthenticationResponse::Unauthorized);
+    }
+
+    let mut state = state_arc.lock().await;
+    let outcome = submit_credential(
+        &mut state,
+        AuthCredential::WebAuthn,
+        services.config_provider.as_ref(),
+        &services.login_protection,
+    )
+    .await
+    .map_err(poem::error::InternalServerError)?;
+
+    if let Ok(user_info) = outcome.into_accepted() {
+        authorize_session(req, ctx, user_info)
+            .await
+            .map_err(poem::error::InternalServerError)?;
+        state.emit_authenticated_event_once();
+    }
+
+    Ok(CompleteAuthenticationResponse::Ok)
+}
+
+impl ReparseForwardedResponse for super::webauthn::StartAuthenticationResponse {
+    async fn reparse_forwarded_response(response: poem::Response) -> poem::Result<Self> {
+        match response.status() {
+            http::StatusCode::OK => Ok(Self::Ok(Json(parse_forwarded_body(response).await?))),
+            http::StatusCode::BAD_REQUEST => Ok(Self::NoCredentials),
+            http::StatusCode::NOT_FOUND => Ok(Self::NotFound),
+            http::StatusCode::INTERNAL_SERVER_ERROR => Ok(Self::InternalError),
+            _ => Err(forwarded_error(response).await),
+        }
+    }
+}
+
+impl ReparseForwardedResponse for super::webauthn::CompleteAuthenticationResponse {
+    async fn reparse_forwarded_response(response: poem::Response) -> poem::Result<Self> {
+        match response.status() {
+            http::StatusCode::OK => Ok(Self::Ok),
+            http::StatusCode::BAD_REQUEST => Ok(Self::BadRequest),
+            http::StatusCode::UNAUTHORIZED => Ok(Self::Unauthorized),
+            http::StatusCode::NOT_FOUND => Ok(Self::NotFound),
+            http::StatusCode::INTERNAL_SERVER_ERROR => Ok(Self::InternalError),
+            _ => Err(forwarded_error(response).await),
+        }
+    }
 }

--- a/warpgate-protocol-http/src/api/auth.rs
+++ b/warpgate-protocol-http/src/api/auth.rs
@@ -59,6 +59,7 @@ enum ApiAuthState {
     OtpNeeded,
     SsoNeeded,
     WebUserApprovalNeeded,
+    WebAuthnNeeded,
     PublicKeyNeeded,
     Success,
     IpBlocked,
@@ -156,6 +157,7 @@ const PREFERRED_NEED_CRED_ORDER: &[CredentialKind] = &[
     CredentialKind::PublicKey,
     CredentialKind::Password,
     CredentialKind::Totp,
+    CredentialKind::WebAuthn,
     CredentialKind::Sso,
     CredentialKind::WebUserApproval,
 ];
@@ -174,6 +176,7 @@ impl From<AuthResult> for ApiAuthState {
                     Some(CredentialKind::Totp) => Self::OtpNeeded,
                     Some(CredentialKind::Sso) => Self::SsoNeeded,
                     Some(CredentialKind::WebUserApproval) => Self::WebUserApprovalNeeded,
+                    Some(CredentialKind::WebAuthn) => Self::WebAuthnNeeded,
                     Some(CredentialKind::PublicKey) => Self::PublicKeyNeeded,
                     Some(CredentialKind::Certificate) => {
                         // Certificate authentication is not supported for HTTP protocol
@@ -408,6 +411,41 @@ impl Api {
             Ok(AuthStateResponse::Ok(Json(
                 serialize_auth_state_inner(state_arc, ctx.services()).await?,
             )))
+        })
+        .await
+    }
+
+    #[oai(
+        path = "/auth/webauthn/authentication/start",
+        method = "post",
+        operation_id = "start_webauthn_authentication"
+    )]
+    async fn api_webauthn_auth_start(
+        &self,
+        req: &Request,
+        session: &Session,
+        ctx: Data<&UnauthenticatedRequestContext>,
+    ) -> poem::Result<super::webauthn::StartAuthenticationResponse> {
+        on_login_owner(req, session, &ctx, None::<&()>, || {
+            serve_webauthn_auth_start(req, session, &ctx)
+        })
+        .await
+    }
+
+    #[oai(
+        path = "/auth/webauthn/authentication/complete",
+        method = "post",
+        operation_id = "complete_webauthn_authentication"
+    )]
+    async fn api_webauthn_auth_complete(
+        &self,
+        req: &Request,
+        session: &Session,
+        ctx: Data<&UnauthenticatedRequestContext>,
+        body: Json<super::webauthn::AuthenticationCompleteRequest>,
+    ) -> poem::Result<super::webauthn::CompleteAuthenticationResponse> {
+        on_login_owner(req, session, &ctx, Some(&body.to_json()), || {
+            serve_webauthn_auth_complete(req, session, &ctx, &body.credential_json)
         })
         .await
     }
@@ -898,4 +936,177 @@ pub async fn api_get_web_auth_requests_stream(
 
         Ok::<(), anyhow::Error>(())
     }))
+}
+
+
+
+async fn serve_webauthn_auth_start(
+    req: &Request,
+    session: &Session,
+    ctx: &UnauthenticatedRequestContext,
+) -> poem::Result<super::webauthn::StartAuthenticationResponse> {
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+    use super::webauthn::{
+        build_webauthn, AuthenticationStartResponse, StartAuthenticationResponse,
+        SESSION_KEY_AUTH_STATE,
+    };
+    use warpgate_db_entities::WebauthnCredential;
+
+    let services = ctx.services();
+
+    let Some(state_arc) = get_auth_state_for_request(req, ctx).await? else {
+        return Ok(StartAuthenticationResponse::NotFound);
+    };
+
+    let username = {
+        let state = state_arc.lock().await;
+        state.user_info().username.clone()
+    };
+
+    let webauthn = match build_webauthn(services).await {
+        Ok(w) => w,
+        Err(e) => {
+            error!("Failed to build WebAuthn instance: {e}");
+            return Ok(StartAuthenticationResponse::InternalError);
+        }
+    };
+
+    let db = &services.db;
+    let user_model = warpgate_db_entities::User::Entity::find()
+        .filter(warpgate_db_entities::User::Entity::username_eq_ci(&username))
+        .one(db)
+        .await
+        .map_err(poem::error::InternalServerError)?;
+
+    let Some(user_model) = user_model else {
+        return Ok(StartAuthenticationResponse::NotFound);
+    };
+
+    let cred_models = WebauthnCredential::Entity::find()
+        .filter(WebauthnCredential::Column::UserId.eq(user_model.id))
+        .all(db)
+        .await
+        .map_err(poem::error::InternalServerError)?;
+
+    if cred_models.is_empty() {
+        return Ok(StartAuthenticationResponse::NoCredentials);
+    }
+
+    let security_keys: Vec<webauthn_rs::prelude::SecurityKey> = cred_models
+        .iter()
+        .filter_map(|c| {
+            serde_json::from_str(&c.credential_json).map_err(|e| {
+                tracing::warn!(
+                    credential_id = %c.id,
+                    "Failed to deserialize WebAuthn credential, skipping: {e}"
+                );
+            }).ok()
+        })
+        .collect();
+
+    if security_keys.is_empty() {
+        return Ok(StartAuthenticationResponse::NoCredentials);
+    }
+
+    let (rcr, auth_state) = match webauthn.start_securitykey_authentication(&security_keys) {
+        Ok(result) => result,
+        Err(e) => {
+            error!("WebAuthn authentication start ceremony failed: {e}");
+            return Ok(StartAuthenticationResponse::InternalError);
+        }
+    };
+
+    let state_json = serde_json::to_string(&auth_state)
+        .map_err(poem::error::InternalServerError)?;
+    session.set(SESSION_KEY_AUTH_STATE, state_json);
+
+    let challenge_json = serde_json::to_string(&rcr)
+        .map_err(poem::error::InternalServerError)?;
+
+    Ok(StartAuthenticationResponse::Ok(Json(
+        AuthenticationStartResponse { challenge_json },
+    )))
+}
+
+async fn serve_webauthn_auth_complete(
+    req: &Request,
+    session: &Session,
+    ctx: &UnauthenticatedRequestContext,
+    credential_json: &str,
+) -> poem::Result<super::webauthn::CompleteAuthenticationResponse> {
+    use super::webauthn::CompleteAuthenticationResponse;
+
+    let services = ctx.services();
+
+    // Verify the WebAuthn response and update counter/last_used
+    if let Err(e) = super::webauthn::verify_webauthn_authentication(services, session, credential_json).await {
+        error!("WebAuthn authentication failed: {e}");
+
+        // Record the failed attempt for brute-force protection
+        if let Some(state_arc) = get_auth_state_for_request(req, ctx).await? {
+            let state = state_arc.lock().await;
+            let username = state.user_info().username.clone();
+            let client_ip = get_client_ip_addr(req, services).await;
+            if let Some(ip) = client_ip {
+                let _ = services
+                    .login_protection
+                    .record_failed_attempt(FailedAttemptInfo {
+                        username,
+                        remote_ip: ip,
+                        protocol: crate::common::PROTOCOL_NAME,
+                        credential_type: "webauthn".to_string(),
+                    })
+                    .await;
+            }
+        }
+
+        return Ok(CompleteAuthenticationResponse::Unauthorized);
+    }
+
+    let Some(state_arc) = get_auth_state_for_request(req, ctx).await? else {
+        return Ok(CompleteAuthenticationResponse::NotFound);
+    };
+
+    let mut state = state_arc.lock().await;
+    let outcome = submit_credential(
+        &mut state,
+        AuthCredential::WebAuthn,
+        services.config_provider.as_ref(),
+    )
+    .await
+    .map_err(poem::error::InternalServerError)?;
+
+    if let Ok(user_info) = outcome.into_accepted() {
+        authorize_session(req, ctx, user_info)
+            .await
+            .map_err(poem::error::InternalServerError)?;
+        state.emit_authenticated_event_once();
+    }
+
+    Ok(CompleteAuthenticationResponse::Ok)
+}
+
+impl ReparseForwardedResponse for super::webauthn::StartAuthenticationResponse {
+    async fn reparse_forwarded_response(response: poem::Response) -> poem::Result<Self> {
+        match response.status() {
+            http::StatusCode::OK => Ok(Self::Ok(Json(parse_forwarded_body(response).await?))),
+            http::StatusCode::BAD_REQUEST => Ok(Self::NoCredentials),
+            http::StatusCode::NOT_FOUND => Ok(Self::NotFound),
+            http::StatusCode::INTERNAL_SERVER_ERROR => Ok(Self::InternalError),
+            _ => Err(forwarded_error(response).await),
+        }
+    }
+}
+
+impl ReparseForwardedResponse for super::webauthn::CompleteAuthenticationResponse {
+    async fn reparse_forwarded_response(response: poem::Response) -> poem::Result<Self> {
+        match response.status() {
+            http::StatusCode::OK => Ok(Self::Ok),
+            http::StatusCode::BAD_REQUEST => Ok(Self::BadRequest),
+            http::StatusCode::UNAUTHORIZED => Ok(Self::Unauthorized),
+            http::StatusCode::NOT_FOUND => Ok(Self::NotFound),
+            http::StatusCode::INTERNAL_SERVER_ERROR => Ok(Self::InternalError),
+            _ => Err(forwarded_error(response).await),
+        }
+    }
 }

--- a/warpgate-protocol-http/src/api/credentials.rs
+++ b/warpgate-protocol-http/src/api/credentials.rs
@@ -69,9 +69,29 @@ pub struct CredentialsState {
     public_keys: Vec<ExistingPublicKeyCredential>,
     certificates: Vec<ExistingCertificateCredential>,
     sso: Vec<ExistingSsoCredential>,
+    webauthn: Vec<ExistingWebauthnCredentialSelf>,
     credential_policy: UserRequireCredentialsPolicy,
     ldap_linked: bool,
     password_policy: PasswordPolicy,
+}
+
+#[derive(Object)]
+struct ExistingWebauthnCredentialSelf {
+    id: Uuid,
+    label: String,
+    date_added: Option<OffsetDateTime>,
+    last_used: Option<OffsetDateTime>,
+}
+
+impl From<entities::WebauthnCredential::Model> for ExistingWebauthnCredentialSelf {
+    fn from(credential: entities::WebauthnCredential::Model) -> Self {
+        Self {
+            id: credential.id,
+            label: credential.label,
+            date_added: credential.date_added,
+            last_used: credential.last_used,
+        }
+    }
 }
 
 #[derive(ApiResponse)]
@@ -283,6 +303,11 @@ impl Api {
             .all(db)
             .await?;
 
+        let webauthn_creds = user
+            .find_related(entities::WebauthnCredential::Entity)
+            .all(db)
+            .await?;
+
         let parameters = ctx.parameters().await?;
 
         Ok(CredentialsStateResponse::Ok(Json(CredentialsState {
@@ -295,6 +320,7 @@ impl Api {
             public_keys: pk_creds.into_iter().map(Into::into).collect(),
             certificates: cert_creds.into_iter().map(Into::into).collect(),
             sso: sso_creds.into_iter().map(Into::into).collect(),
+            webauthn: webauthn_creds.into_iter().map(Into::into).collect(),
             credential_policy: user_cfg.credential_policy.unwrap_or_default(),
             ldap_linked: user.ldap_server_id.is_some(),
             password_policy: parameters.password_policy(),
@@ -679,5 +705,51 @@ impl Api {
         .emit();
 
         Ok(DeleteCertificateCredentialResponse::Ok)
+    }
+
+    #[oai(
+        path = "/profile/credentials/webauthn/:id",
+        method = "delete",
+        operation_id = "delete_my_webauthn_credential",
+        transform = "parameters_based_auth"
+    )]
+    async fn api_delete_webauthn(
+        &self,
+        ctx: AuthedSession,
+        id: Path<Uuid>,
+    ) -> Result<DeleteCredentialResponse, WarpgateError> {
+        let auth = &ctx.auth;
+        let db = &ctx.services().db;
+
+        let Some(full) = auth.as_full_user() else {
+            return Ok(DeleteCredentialResponse::Unauthorized);
+        };
+        let Some(user) = get_user(&full, db).await? else {
+            return Ok(DeleteCredentialResponse::Unauthorized);
+        };
+
+        let Some(model) = user
+            .find_related(entities::WebauthnCredential::Entity)
+            .filter(entities::WebauthnCredential::Column::Id.eq(id.0))
+            .one(db)
+            .await?
+        else {
+            return Ok(DeleteCredentialResponse::NotFound);
+        };
+
+        let label = model.label.clone();
+        model.delete(db).await?;
+
+        AuditEvent::CredentialDeleted {
+            credential_type: "webauthn".to_string(),
+            credential_name: Some(label),
+            via: CredentialChangedVia::SelfService,
+            user_id: user.id,
+            username: user.username.clone(),
+            actor_user_id: ctx.auth.user_id(),
+        }
+        .emit();
+
+        Ok(DeleteCredentialResponse::Deleted)
     }
 }

--- a/warpgate-protocol-http/src/api/mod.rs
+++ b/warpgate-protocol-http/src/api/mod.rs
@@ -13,6 +13,7 @@ pub mod ticket_request_targets;
 pub mod ticket_requests;
 mod web_desktop;
 mod web_ssh;
+pub mod webauthn;
 
 pub fn get() -> impl OpenApi {
     (
@@ -27,5 +28,6 @@ pub fn get() -> impl OpenApi {
         ticket_request_targets::Api,
         web_ssh::Api,
         web_desktop::Api,
+        webauthn::Api,
     )
 }

--- a/warpgate-protocol-http/src/api/webauthn.rs
+++ b/warpgate-protocol-http/src/api/webauthn.rs
@@ -1,0 +1,435 @@
+use anyhow::anyhow;
+use poem::session::Session;
+use poem_openapi::payload::Json;
+use poem_openapi::{ApiResponse, Object, OpenApi};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use tracing::error;
+use uuid::Uuid;
+use warpgate_common::WarpgateError;
+use warpgate_core::Services;
+use warpgate_db_entities::WebauthnCredential;
+
+use super::auth_scheme::AuthedSession;
+
+pub struct Api;
+
+/// Maximum number of WebAuthn credentials per user.
+const MAX_CREDENTIALS_PER_USER: usize = 8;
+
+#[derive(Object, Serialize, Deserialize)]
+struct RegistrationStartResponse {
+    /// JSON-serialized CreationChallengeResponse from webauthn-rs
+    challenge_json: String,
+}
+
+#[derive(ApiResponse)]
+enum StartRegistrationResponse {
+    #[oai(status = 200)]
+    Ok(Json<RegistrationStartResponse>),
+    #[oai(status = 401)]
+    Unauthorized,
+    #[oai(status = 409)]
+    TooManyCredentials,
+    #[oai(status = 500)]
+    InternalError,
+}
+
+#[derive(Object, Deserialize)]
+struct RegistrationCompleteRequest {
+    /// JSON-serialized RegisterPublicKeyCredential from the browser
+    credential_json: String,
+    /// Friendly label for this key (e.g. "Office Yubikey", "Backup key")
+    label: String,
+}
+
+#[derive(Object, Serialize)]
+struct RegistrationCompleteResponse {
+    id: Uuid,
+    label: String,
+}
+
+#[derive(ApiResponse)]
+enum CompleteRegistrationResponse {
+    #[oai(status = 201)]
+    Created(Json<RegistrationCompleteResponse>),
+    #[oai(status = 400)]
+    BadRequest,
+    #[oai(status = 500)]
+    InternalError,
+}
+
+#[derive(Object, Serialize, Deserialize)]
+pub(crate) struct AuthenticationStartResponse {
+    /// JSON-serialized RequestChallengeResponse from webauthn-rs
+    pub challenge_json: String,
+}
+
+#[derive(ApiResponse)]
+pub(crate) enum StartAuthenticationResponse {
+    #[oai(status = 200)]
+    Ok(Json<AuthenticationStartResponse>),
+    #[oai(status = 400)]
+    NoCredentials,
+    #[oai(status = 404)]
+    NotFound,
+    #[oai(status = 500)]
+    InternalError,
+}
+
+#[derive(Object, Deserialize)]
+pub(crate) struct AuthenticationCompleteRequest {
+    /// JSON-serialized PublicKeyCredential from the browser
+    pub credential_json: String,
+}
+
+#[derive(ApiResponse)]
+pub(crate) enum CompleteAuthenticationResponse {
+    #[oai(status = 200)]
+    Ok,
+    #[oai(status = 400)]
+    BadRequest,
+    #[oai(status = 401)]
+    Unauthorized,
+    #[oai(status = 404)]
+    NotFound,
+    #[oai(status = 500)]
+    InternalError,
+}
+
+/// Session key for storing the in-progress webauthn registration state
+const SESSION_KEY_REG_STATE: &str = "webauthn_reg_state";
+/// Session key for storing the in-progress webauthn authentication state
+pub(crate) const SESSION_KEY_AUTH_STATE: &str = "webauthn_auth_state";
+
+/// Construct the Webauthn verifier from config.
+/// RP ID comes from `http.external_host` (or top-level `external_host`).
+pub(crate) async fn build_webauthn(
+    services: &Services,
+) -> Result<webauthn_rs::Webauthn, WarpgateError> {
+    let config = services.config.lock().await;
+    let external_host = config
+        .store
+        .http
+        .external_host
+        .clone()
+        .or_else(|| config.store.external_host.clone())
+        .unwrap_or_else(|| "localhost".to_string());
+    drop(config);
+
+    // RP ID must be just the domain (no port)
+    let rp_id = external_host
+        .split(':')
+        .next()
+        .unwrap_or(&external_host)
+        .to_string();
+    // Origin must include the port if non-standard
+    let rp_origin = url::Url::parse(&format!("https://{external_host}"))
+        .map_err(|e| WarpgateError::from(anyhow!("Invalid RP origin: {e}")))?;
+
+    let builder = webauthn_rs::WebauthnBuilder::new(&rp_id, &rp_origin)
+        .map_err(|e| WarpgateError::from(anyhow!("WebAuthn builder error: {e}")))?
+        .rp_name("Warpgate")
+        // Allow subdomains: Warpgate uses DNS binding (e.g. target.wg.example.com)
+        // where the RP ID is the base domain (wg.example.com) but the browser
+        // origin may be a subdomain for a specific target.
+        .allow_subdomains(true)
+        // We only require user presence (touch), not full user verification (PIN).
+        // This disables CredProtect extensions that conflict with non-resident
+        // credentials on many authenticators, and sets UV=Discouraged so a simple
+        // tap on the key suffices — matching the AWS IAM MFA UX.
+        .danger_set_user_presence_only_security_keys(true);
+
+    builder
+        .build()
+        .map_err(|e| WarpgateError::from(anyhow!("WebAuthn build error: {e}")))
+}
+
+#[OpenApi]
+impl Api {
+    #[oai(
+        path = "/auth/webauthn/registration/start",
+        method = "post",
+        operation_id = "start_webauthn_registration"
+    )]
+    async fn api_registration_start(
+        &self,
+        session: &Session,
+        ctx: AuthedSession,
+    ) -> Result<StartRegistrationResponse, WarpgateError> {
+        let services = ctx.services();
+        let Some(username) = ctx.auth.username().cloned() else {
+            return Ok(StartRegistrationResponse::Unauthorized);
+        };
+        let user_id = ctx.auth.user_id();
+
+        let db = &services.db;
+
+        let existing_models = WebauthnCredential::Entity::find()
+            .filter(WebauthnCredential::Column::UserId.eq(user_id))
+            .all(db)
+            .await?;
+
+        if existing_models.len() >= MAX_CREDENTIALS_PER_USER {
+            return Ok(StartRegistrationResponse::TooManyCredentials);
+        }
+
+        let webauthn = match build_webauthn(services).await {
+            Ok(w) => w,
+            Err(e) => {
+                error!("Failed to build WebAuthn instance: {e}");
+                return Ok(StartRegistrationResponse::InternalError);
+            }
+        };
+
+        let existing_cred_ids: Vec<webauthn_rs::prelude::CredentialID> = existing_models
+            .into_iter()
+            .filter_map(|c| {
+                serde_json::from_str::<webauthn_rs::prelude::SecurityKey>(&c.credential_json)
+                    .map_err(|e| {
+                        tracing::warn!(
+                            credential_id = %c.id,
+                            "Failed to deserialize WebAuthn credential, skipping: {e}"
+                        );
+                    })
+                    .ok()
+                    .map(|sk| sk.cred_id().clone())
+            })
+            .collect();
+
+        let (ccr, reg_state) = match webauthn.start_securitykey_registration(
+            user_id,
+            &username,
+            &username,
+            Some(existing_cred_ids),
+            None, // no attestation CA list = attestation "none"
+            None, // no UI hint override
+        ) {
+            Ok(result) => result,
+            Err(e) => {
+                error!("WebAuthn registration start ceremony failed: {e}");
+                return Ok(StartRegistrationResponse::InternalError);
+            }
+        };
+
+        let state_json = serde_json::to_string(&reg_state)
+            .map_err(|e| WarpgateError::from(anyhow!("Serialize reg state: {e}")))?;
+        session.set(SESSION_KEY_REG_STATE, state_json);
+
+        let challenge_json = serde_json::to_string(&ccr)
+            .map_err(|e| WarpgateError::from(anyhow!("Serialize challenge: {e}")))?;
+
+        Ok(StartRegistrationResponse::Ok(Json(
+            RegistrationStartResponse { challenge_json },
+        )))
+    }
+
+    #[oai(
+        path = "/auth/webauthn/registration/complete",
+        method = "post",
+        operation_id = "complete_webauthn_registration"
+    )]
+    async fn api_registration_complete(
+        &self,
+        session: &Session,
+        ctx: AuthedSession,
+        body: Json<RegistrationCompleteRequest>,
+    ) -> Result<CompleteRegistrationResponse, WarpgateError> {
+        let services = ctx.services();
+        let user_id = ctx.auth.user_id();
+
+        if body.label.trim().is_empty() || body.label.len() > 255 {
+            return Ok(CompleteRegistrationResponse::BadRequest);
+        }
+
+        // Prevent duplicate names for the same user
+        let db = &services.db;
+        let existing_with_name = WebauthnCredential::Entity::find()
+            .filter(WebauthnCredential::Column::UserId.eq(user_id))
+            .filter(WebauthnCredential::Column::Label.eq(body.label.trim()))
+            .one(db)
+            .await?;
+        if existing_with_name.is_some() {
+            return Ok(CompleteRegistrationResponse::BadRequest);
+        }
+
+        let webauthn = match build_webauthn(services).await {
+            Ok(w) => w,
+            Err(e) => {
+                error!("Failed to build WebAuthn instance: {e}");
+                return Ok(CompleteRegistrationResponse::InternalError);
+            }
+        };
+
+        let Some(state_json) = session.get::<String>(SESSION_KEY_REG_STATE) else {
+            return Ok(CompleteRegistrationResponse::BadRequest);
+        };
+        session.remove(SESSION_KEY_REG_STATE);
+
+        let reg_state: webauthn_rs::prelude::SecurityKeyRegistration =
+            match serde_json::from_str(&state_json) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!("Invalid registration state in session: {e}");
+                    return Ok(CompleteRegistrationResponse::BadRequest);
+                }
+            };
+
+        let reg_response: webauthn_rs_proto::RegisterPublicKeyCredential =
+            match serde_json::from_str(&body.credential_json) {
+                Ok(r) => r,
+                Err(e) => {
+                    error!("Invalid credential response from client: {e}");
+                    return Ok(CompleteRegistrationResponse::BadRequest);
+                }
+            };
+
+        let security_key = match webauthn.finish_securitykey_registration(&reg_response, &reg_state)
+        {
+            Ok(sk) => sk,
+            Err(e) => {
+                error!("WebAuthn registration verification failed: {e}");
+                return Ok(CompleteRegistrationResponse::BadRequest);
+            }
+        };
+
+        let credential_id = data_encoding::BASE64URL_NOPAD.encode(security_key.cred_id().as_ref());
+        let credential_json = serde_json::to_string(&security_key)
+            .map_err(|e| WarpgateError::from(anyhow!("Serialize security key: {e}")))?;
+
+        let db = &services.db;
+        let current_count = WebauthnCredential::Entity::find()
+            .filter(WebauthnCredential::Column::UserId.eq(user_id))
+            .all(db)
+            .await?
+            .len();
+        if current_count >= MAX_CREDENTIALS_PER_USER {
+            return Ok(CompleteRegistrationResponse::BadRequest);
+        }
+
+        let id = Uuid::new_v4();
+        WebauthnCredential::ActiveModel {
+            id: Set(id),
+            user_id: Set(user_id),
+            label: Set(body.label.clone()),
+            credential_id: Set(credential_id),
+            credential_json: Set(credential_json),
+            date_added: Set(Some(OffsetDateTime::now_utc())),
+            last_used: Set(None),
+        }
+        .insert(db)
+        .await?;
+
+        // Auto-upgrade credential policy (same as OTP self-service registration)
+        if let Some(user_model) = warpgate_db_entities::User::Entity::find_by_id(user_id)
+            .one(db)
+            .await?
+        {
+            let details = user_model.clone().load_details(db).await?;
+            let mut user_cfg: warpgate_common::User = user_model.try_into()?;
+            user_cfg.credential_policy = Some(
+                user_cfg
+                    .credential_policy
+                    .unwrap_or_default()
+                    .upgrade_to_webauthn(details.credentials.as_slice()),
+            );
+            let user_active = warpgate_db_entities::User::ActiveModel::try_from(user_cfg)?;
+            user_active.update(db).await?;
+        }
+
+        warpgate_core::logging::AuditEvent::CredentialCreated {
+            credential_type: "webauthn".to_string(),
+            credential_name: Some(body.label.clone()),
+            via: warpgate_core::logging::CredentialChangedVia::SelfService,
+            user_id,
+            username: ctx.auth.username().cloned().unwrap_or_default(),
+            actor_user_id: ctx.auth.user_id(),
+        }
+        .emit();
+
+        Ok(CompleteRegistrationResponse::Created(Json(
+            RegistrationCompleteResponse {
+                id,
+                label: body.label.clone(),
+            },
+        )))
+    }
+}
+
+/// Verify a WebAuthn authentication response and update the credential's
+/// counter and last_used timestamp. This is the core verification logic
+/// shared between the login flow and any future step-up authentication.
+///
+/// `expected_user_id` is the user whose login this ceremony belongs to. The
+/// verified credential MUST belong to that user; this is enforced explicitly
+/// below as defense-in-depth, in addition to the challenge being scoped to
+/// that user's keys at start time (see `serve_webauthn_auth_start`).
+///
+/// Returns `Ok(())` on success, or an error string on failure.
+pub(crate) async fn verify_webauthn_authentication(
+    services: &Services,
+    session: &poem::session::Session,
+    credential_json: &str,
+    expected_user_id: Uuid,
+) -> Result<(), String> {
+    use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+
+    let webauthn = build_webauthn(services)
+        .await
+        .map_err(|e| format!("Failed to build WebAuthn instance: {e}"))?;
+
+    let state_json = session
+        .get::<String>(SESSION_KEY_AUTH_STATE)
+        .ok_or_else(|| "No pending WebAuthn challenge in session".to_string())?;
+    session.remove(SESSION_KEY_AUTH_STATE);
+
+    let auth_state: webauthn_rs::prelude::SecurityKeyAuthentication =
+        serde_json::from_str(&state_json)
+            .map_err(|e| format!("Invalid authentication state: {e}"))?;
+
+    let auth_response: webauthn_rs_proto::PublicKeyCredential =
+        serde_json::from_str(credential_json)
+            .map_err(|e| format!("Invalid credential response: {e}"))?;
+
+    let auth_result = webauthn
+        .finish_securitykey_authentication(&auth_response, &auth_state)
+        .map_err(|e| format!("Verification failed: {e}"))?;
+
+    // Locate the credential that just signed the assertion.
+    let db = &services.db;
+    let cred_id_b64 = data_encoding::BASE64URL_NOPAD.encode(auth_result.cred_id().as_ref());
+    let cred_model = WebauthnCredential::Entity::find()
+        .filter(WebauthnCredential::Column::CredentialId.eq(&cred_id_b64))
+        .one(db)
+        .await
+        .map_err(|e| format!("Failed to load credential: {e}"))?
+        .ok_or_else(|| "Verified credential is not registered".to_string())?;
+
+    // Defense-in-depth: the verified credential must belong to the user whose
+    // login this ceremony is completing. The challenge was already scoped to
+    // this user's keys at start time, so a mismatch should be impossible, but
+    // we enforce it explicitly rather than trusting that invariant implicitly.
+    if cred_model.user_id != expected_user_id {
+        return Err(format!(
+            "Verified credential belongs to user {} but this login is for user {expected_user_id}",
+            cred_model.user_id
+        ));
+    }
+
+    // Update last_used and counter
+    let mut active: WebauthnCredential::ActiveModel = cred_model.clone().into();
+    active.last_used = Set(Some(time::OffsetDateTime::now_utc()));
+
+    if let Ok(mut security_key) =
+        serde_json::from_str::<webauthn_rs::prelude::SecurityKey>(&cred_model.credential_json)
+        && security_key.update_credential(&auth_result) == Some(true)
+        && let Ok(updated_json) = serde_json::to_string(&security_key)
+    {
+        active.credential_json = Set(updated_json);
+    }
+
+    let _ = active.update(db).await;
+
+    Ok(())
+}

--- a/warpgate-protocol-http/src/api/webauthn.rs
+++ b/warpgate-protocol-http/src/api/webauthn.rs
@@ -1,0 +1,419 @@
+use anyhow::anyhow;
+use poem::session::Session;
+use poem_openapi::payload::Json;
+use poem_openapi::{ApiResponse, Object, OpenApi};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use tracing::error;
+use uuid::Uuid;
+use warpgate_common::WarpgateError;
+use warpgate_core::Services;
+use warpgate_db_entities::WebauthnCredential;
+
+use super::auth_scheme::AuthedSession;
+
+pub struct Api;
+
+/// Maximum number of WebAuthn credentials per user.
+const MAX_CREDENTIALS_PER_USER: usize = 8;
+
+
+
+#[derive(Object, Serialize, Deserialize)]
+struct RegistrationStartResponse {
+    /// JSON-serialized CreationChallengeResponse from webauthn-rs
+    challenge_json: String,
+}
+
+#[derive(ApiResponse)]
+enum StartRegistrationResponse {
+    #[oai(status = 200)]
+    Ok(Json<RegistrationStartResponse>),
+    #[oai(status = 401)]
+    Unauthorized,
+    #[oai(status = 409)]
+    TooManyCredentials,
+    #[oai(status = 500)]
+    InternalError,
+}
+
+#[derive(Object, Deserialize)]
+struct RegistrationCompleteRequest {
+    /// JSON-serialized RegisterPublicKeyCredential from the browser
+    credential_json: String,
+    /// Friendly label for this key (e.g. "Office Yubikey", "Backup key")
+    label: String,
+}
+
+#[derive(Object, Serialize)]
+struct RegistrationCompleteResponse {
+    id: Uuid,
+    label: String,
+}
+
+#[derive(ApiResponse)]
+enum CompleteRegistrationResponse {
+    #[oai(status = 201)]
+    Created(Json<RegistrationCompleteResponse>),
+    #[oai(status = 400)]
+    BadRequest,
+    #[oai(status = 500)]
+    InternalError,
+}
+
+
+
+#[derive(Object, Serialize, Deserialize)]
+pub(crate) struct AuthenticationStartResponse {
+    /// JSON-serialized RequestChallengeResponse from webauthn-rs
+    pub challenge_json: String,
+}
+
+#[derive(ApiResponse)]
+pub(crate) enum StartAuthenticationResponse {
+    #[oai(status = 200)]
+    Ok(Json<AuthenticationStartResponse>),
+    #[oai(status = 400)]
+    NoCredentials,
+    #[oai(status = 404)]
+    NotFound,
+    #[oai(status = 500)]
+    InternalError,
+}
+
+#[derive(Object, Deserialize)]
+pub(crate) struct AuthenticationCompleteRequest {
+    /// JSON-serialized PublicKeyCredential from the browser
+    pub credential_json: String,
+}
+
+#[derive(ApiResponse)]
+pub(crate) enum CompleteAuthenticationResponse {
+    #[oai(status = 200)]
+    Ok,
+    #[oai(status = 400)]
+    BadRequest,
+    #[oai(status = 401)]
+    Unauthorized,
+    #[oai(status = 404)]
+    NotFound,
+    #[oai(status = 500)]
+    InternalError,
+}
+
+/// Session key for storing the in-progress webauthn registration state
+const SESSION_KEY_REG_STATE: &str = "webauthn_reg_state";
+/// Session key for storing the in-progress webauthn authentication state
+pub(crate) const SESSION_KEY_AUTH_STATE: &str = "webauthn_auth_state";
+
+/// Construct the Webauthn verifier from config.
+/// RP ID comes from `http.external_host` (or top-level `external_host`).
+pub(crate) async fn build_webauthn(services: &Services) -> Result<webauthn_rs::Webauthn, WarpgateError> {
+    let config = services.config.lock().await;
+    let external_host = config
+        .store
+        .http
+        .external_host
+        .clone()
+        .or_else(|| config.store.external_host.clone())
+        .unwrap_or_else(|| "localhost".to_string());
+    drop(config);
+
+    // RP ID must be just the domain (no port)
+    let rp_id = external_host
+        .split(':')
+        .next()
+        .unwrap_or(&external_host)
+        .to_string();
+    // Origin must include the port if non-standard
+    let rp_origin = url::Url::parse(&format!("https://{external_host}"))
+        .map_err(|e| WarpgateError::from(anyhow!("Invalid RP origin: {e}")))?;
+
+    let builder = webauthn_rs::WebauthnBuilder::new(&rp_id, &rp_origin)
+        .map_err(|e| WarpgateError::from(anyhow!("WebAuthn builder error: {e}")))?
+        .rp_name("Warpgate")
+        // Allow subdomains: Warpgate uses DNS binding (e.g. target.wg.example.com)
+        // where the RP ID is the base domain (wg.example.com) but the browser
+        // origin may be a subdomain for a specific target.
+        .allow_subdomains(true)
+        // We only require user presence (touch), not full user verification (PIN).
+        // This disables CredProtect extensions that conflict with non-resident
+        // credentials on many authenticators, and sets UV=Discouraged so a simple
+        // tap on the key suffices — matching the AWS IAM MFA UX.
+        .danger_set_user_presence_only_security_keys(true);
+
+    builder
+        .build()
+        .map_err(|e| WarpgateError::from(anyhow!("WebAuthn build error: {e}")))
+}
+
+#[OpenApi]
+impl Api {
+    #[oai(
+        path = "/auth/webauthn/registration/start",
+        method = "post",
+        operation_id = "start_webauthn_registration"
+    )]
+    async fn api_registration_start(
+        &self,
+        session: &Session,
+        ctx: AuthedSession,
+    ) -> Result<StartRegistrationResponse, WarpgateError> {
+        let services = ctx.services();
+        let Some(username) = ctx.auth.username().cloned() else {
+            return Ok(StartRegistrationResponse::Unauthorized);
+        };
+        let user_id = ctx.auth.user_id();
+
+        let db = &services.db;
+
+        let existing_models = WebauthnCredential::Entity::find()
+            .filter(WebauthnCredential::Column::UserId.eq(user_id))
+            .all(db)
+            .await?;
+
+        if existing_models.len() >= MAX_CREDENTIALS_PER_USER {
+            return Ok(StartRegistrationResponse::TooManyCredentials);
+        }
+
+        let webauthn = match build_webauthn(services).await {
+            Ok(w) => w,
+            Err(e) => {
+                error!("Failed to build WebAuthn instance: {e}");
+                return Ok(StartRegistrationResponse::InternalError);
+            }
+        };
+
+        let existing_cred_ids: Vec<webauthn_rs::prelude::CredentialID> = existing_models
+            .into_iter()
+            .filter_map(|c| {
+                serde_json::from_str::<webauthn_rs::prelude::SecurityKey>(&c.credential_json)
+                    .map_err(|e| {
+                        tracing::warn!(
+                            credential_id = %c.id,
+                            "Failed to deserialize WebAuthn credential, skipping: {e}"
+                        );
+                    })
+                    .ok()
+                    .map(|sk| sk.cred_id().clone())
+            })
+            .collect();
+
+        let (ccr, reg_state) = match webauthn.start_securitykey_registration(
+            user_id,
+            &username,
+            &username,
+            Some(existing_cred_ids),
+            None, // no attestation CA list = attestation "none"
+            None, // no UI hint override
+        ) {
+            Ok(result) => result,
+            Err(e) => {
+                error!("WebAuthn registration start ceremony failed: {e}");
+                return Ok(StartRegistrationResponse::InternalError);
+            }
+        };
+
+        let state_json = serde_json::to_string(&reg_state)
+            .map_err(|e| WarpgateError::from(anyhow!("Serialize reg state: {e}")))?;
+        session.set(SESSION_KEY_REG_STATE, state_json);
+
+        let challenge_json = serde_json::to_string(&ccr)
+            .map_err(|e| WarpgateError::from(anyhow!("Serialize challenge: {e}")))?;
+
+        Ok(StartRegistrationResponse::Ok(Json(
+            RegistrationStartResponse { challenge_json },
+        )))
+    }
+
+    #[oai(
+        path = "/auth/webauthn/registration/complete",
+        method = "post",
+        operation_id = "complete_webauthn_registration"
+    )]
+    async fn api_registration_complete(
+        &self,
+        session: &Session,
+        ctx: AuthedSession,
+        body: Json<RegistrationCompleteRequest>,
+    ) -> Result<CompleteRegistrationResponse, WarpgateError> {
+        let services = ctx.services();
+        let user_id = ctx.auth.user_id();
+
+        if body.label.trim().is_empty() || body.label.len() > 255 {
+            return Ok(CompleteRegistrationResponse::BadRequest);
+        }
+
+        // Prevent duplicate names for the same user
+        let db = &services.db;
+        let existing_with_name = WebauthnCredential::Entity::find()
+            .filter(WebauthnCredential::Column::UserId.eq(user_id))
+            .filter(WebauthnCredential::Column::Label.eq(body.label.trim()))
+            .one(db)
+            .await?;
+        if existing_with_name.is_some() {
+            return Ok(CompleteRegistrationResponse::BadRequest);
+        }
+
+        let webauthn = match build_webauthn(services).await {
+            Ok(w) => w,
+            Err(e) => {
+                error!("Failed to build WebAuthn instance: {e}");
+                return Ok(CompleteRegistrationResponse::InternalError);
+            }
+        };
+
+        let Some(state_json) = session.get::<String>(SESSION_KEY_REG_STATE) else {
+            return Ok(CompleteRegistrationResponse::BadRequest);
+        };
+        session.remove(SESSION_KEY_REG_STATE);
+
+        let reg_state: webauthn_rs::prelude::SecurityKeyRegistration =
+            match serde_json::from_str(&state_json) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!("Invalid registration state in session: {e}");
+                    return Ok(CompleteRegistrationResponse::BadRequest);
+                }
+            };
+
+        let reg_response: webauthn_rs_proto::RegisterPublicKeyCredential =
+            match serde_json::from_str(&body.credential_json) {
+                Ok(r) => r,
+                Err(e) => {
+                    error!("Invalid credential response from client: {e}");
+                    return Ok(CompleteRegistrationResponse::BadRequest);
+                }
+            };
+
+        let security_key = match webauthn.finish_securitykey_registration(&reg_response, &reg_state)
+        {
+            Ok(sk) => sk,
+            Err(e) => {
+                error!("WebAuthn registration verification failed: {e}");
+                return Ok(CompleteRegistrationResponse::BadRequest);
+            }
+        };
+
+        let credential_id =
+            data_encoding::BASE64URL_NOPAD.encode(security_key.cred_id().as_ref());
+        let credential_json = serde_json::to_string(&security_key)
+            .map_err(|e| WarpgateError::from(anyhow!("Serialize security key: {e}")))?;
+
+        let db = &services.db;
+        let current_count = WebauthnCredential::Entity::find()
+            .filter(WebauthnCredential::Column::UserId.eq(user_id))
+            .all(db)
+            .await?
+            .len();
+        if current_count >= MAX_CREDENTIALS_PER_USER {
+            return Ok(CompleteRegistrationResponse::BadRequest);
+        }
+
+        let id = Uuid::new_v4();
+        WebauthnCredential::ActiveModel {
+            id: Set(id),
+            user_id: Set(user_id),
+            label: Set(body.label.clone()),
+            credential_id: Set(credential_id),
+            credential_json: Set(credential_json),
+            date_added: Set(Some(OffsetDateTime::now_utc())),
+            last_used: Set(None),
+        }
+        .insert(db)
+        .await?;
+
+        // Auto-upgrade credential policy (same as OTP self-service registration)
+        if let Some(user_model) = warpgate_db_entities::User::Entity::find_by_id(user_id)
+            .one(db)
+            .await?
+        {
+            let details = user_model.clone().load_details(db).await?;
+            let mut user_cfg: warpgate_common::User = user_model.try_into()?;
+            user_cfg.credential_policy = Some(
+                user_cfg
+                    .credential_policy
+                    .unwrap_or_default()
+                    .upgrade_to_webauthn(details.credentials.as_slice()),
+            );
+            let user_active = warpgate_db_entities::User::ActiveModel::try_from(user_cfg)?;
+            user_active.update(db).await?;
+        }
+
+        warpgate_core::logging::AuditEvent::CredentialCreated {
+            credential_type: "webauthn".to_string(),
+            credential_name: Some(body.label.clone()),
+            via: warpgate_core::logging::CredentialChangedVia::SelfService,
+            user_id,
+            username: ctx.auth.username().cloned().unwrap_or_default(),
+            actor_user_id: ctx.auth.user_id(),
+        }
+        .emit();
+
+        Ok(CompleteRegistrationResponse::Created(Json(
+            RegistrationCompleteResponse {
+                id,
+                label: body.label.clone(),
+            },
+        )))
+    }
+}
+
+/// Verify a WebAuthn authentication response and update the credential's
+/// counter and last_used timestamp. This is the core verification logic
+/// shared between the login flow and any future step-up authentication.
+///
+/// Returns `Ok(())` on success, or an error string on failure.
+pub(crate) async fn verify_webauthn_authentication(
+    services: &Services,
+    session: &poem::session::Session,
+    credential_json: &str,
+) -> Result<(), String> {
+    use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+
+    let webauthn = build_webauthn(services)
+        .await
+        .map_err(|e| format!("Failed to build WebAuthn instance: {e}"))?;
+
+    let state_json = session
+        .get::<String>(SESSION_KEY_AUTH_STATE)
+        .ok_or_else(|| "No pending WebAuthn challenge in session".to_string())?;
+    session.remove(SESSION_KEY_AUTH_STATE);
+
+    let auth_state: webauthn_rs::prelude::SecurityKeyAuthentication =
+        serde_json::from_str(&state_json)
+            .map_err(|e| format!("Invalid authentication state: {e}"))?;
+
+    let auth_response: webauthn_rs_proto::PublicKeyCredential =
+        serde_json::from_str(credential_json)
+            .map_err(|e| format!("Invalid credential response: {e}"))?;
+
+    let auth_result = webauthn
+        .finish_securitykey_authentication(&auth_response, &auth_state)
+        .map_err(|e| format!("Verification failed: {e}"))?;
+
+    // Update last_used and counter
+    let db = &services.db;
+    let cred_id_b64 = data_encoding::BASE64URL_NOPAD.encode(auth_result.cred_id().as_ref());
+    if let Ok(Some(cred_model)) = WebauthnCredential::Entity::find()
+        .filter(WebauthnCredential::Column::CredentialId.eq(&cred_id_b64))
+        .one(db)
+        .await
+    {
+        let mut active: WebauthnCredential::ActiveModel = cred_model.clone().into();
+        active.last_used = Set(Some(time::OffsetDateTime::now_utc()));
+
+        if let Ok(mut security_key) =
+            serde_json::from_str::<webauthn_rs::prelude::SecurityKey>(&cred_model.credential_json)
+            && security_key.update_credential(&auth_result) == Some(true)
+            && let Ok(updated_json) = serde_json::to_string(&security_key)
+        {
+            active.credential_json = Set(updated_json);
+        }
+
+        let _ = active.update(db).await;
+    }
+
+    Ok(())
+}

--- a/warpgate-protocol-ssh/src/server/session.rs
+++ b/warpgate-protocol-ssh/src/server/session.rs
@@ -2143,9 +2143,10 @@ impl ServerSession {
         for cred_kind in kinds {
             let method_kind = match cred_kind {
                 CredentialKind::Password => MethodKind::Password,
-                CredentialKind::Totp | CredentialKind::WebUserApproval | CredentialKind::Sso => {
-                    MethodKind::KeyboardInteractive
-                }
+                CredentialKind::Totp
+                | CredentialKind::WebUserApproval
+                | CredentialKind::Sso
+                | CredentialKind::WebAuthn => MethodKind::KeyboardInteractive,
                 CredentialKind::PublicKey => MethodKind::PublicKey,
                 CredentialKind::Certificate => {
                     // Certificate authentication is not supported for SSH protocol

--- a/warpgate-protocol-ssh/src/server/session.rs
+++ b/warpgate-protocol-ssh/src/server/session.rs
@@ -2092,7 +2092,7 @@ impl ServerSession {
         for cred_kind in kinds {
             let method_kind = match cred_kind {
                 CredentialKind::Password => MethodKind::Password,
-                CredentialKind::Totp | CredentialKind::WebUserApproval | CredentialKind::Sso => {
+                CredentialKind::Totp | CredentialKind::WebUserApproval | CredentialKind::Sso | CredentialKind::WebAuthn => {
                     MethodKind::KeyboardInteractive
                 }
                 CredentialKind::PublicKey => MethodKind::PublicKey,

--- a/warpgate-web/src/admin/WebauthnCredentialModal.svelte
+++ b/warpgate-web/src/admin/WebauthnCredentialModal.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+    import {
+        Alert,
+        Button,
+        Form,
+        FormGroup,
+        Input,
+        Modal,
+        ModalBody,
+        ModalFooter,
+    } from '@sveltestrap/sveltestrap'
+
+    interface Props {
+        isOpen: boolean
+        userId: string
+        save: (label: string, signal: AbortSignal) => Promise<void>
+    }
+    let { isOpen = $bindable(), userId, save }: Props = $props()
+
+    let label = $state('')
+    let busy = $state(false)
+    let error: string | null = $state(null)
+    let field: HTMLInputElement | undefined = $state()
+    let abortController: AbortController | null = $state(null)
+    let closing = $state(false)
+
+    async function _save() {
+        if (!label.trim() || closing) return
+        busy = true
+        error = null
+        abortController = new AbortController()
+        try {
+            await save(label.trim(), abortController.signal)
+            close()
+            label = ''
+        } catch (e: unknown) {
+            if (
+                (e instanceof DOMException && e.name === 'AbortError') ||
+                closing
+            )
+                return
+            error = e instanceof Error ? e.message : 'Registration failed'
+        } finally {
+            busy = false
+            abortController = null
+        }
+    }
+
+    function close() {
+        closing = true
+        if (abortController) {
+            abortController.abort()
+            abortController = null
+        }
+        isOpen = false
+        // Reset after the modal transition completes
+        setTimeout(() => {
+            closing = false
+        }, 300)
+    }
+</script>
+
+<Modal toggle={close} {isOpen} on:open={() => field?.focus()}>
+    <Form
+        on:submit={e => {
+        _save()
+        e.preventDefault()
+    }}
+    >
+        <ModalBody>
+            <p>Enter a name for this passkey or security key.</p>
+            <FormGroup floating label="Name (e.g. YubiKey, MacBook Touch ID)">
+                <Input
+                    bind:inner={field}
+                    bind:value={label}
+                    disabled={busy}
+                    required
+                />
+            </FormGroup>
+            {#if error}
+                <Alert color="danger">{error}</Alert>
+            {/if}
+        </ModalBody>
+        <ModalFooter>
+            <Button
+                class="modal-button"
+                color="primary"
+                type="submit"
+                disabled={busy || !label.trim()}
+            >
+                Register
+            </Button>
+            <Button class="modal-button" color="danger" on:click={close}>
+                Cancel
+            </Button>
+        </ModalFooter>
+    </Form>
+</Modal>

--- a/warpgate-web/src/admin/config/users/AuthPolicyEditor.svelte
+++ b/warpgate-web/src/admin/config/users/AuthPolicyEditor.svelte
@@ -40,6 +40,7 @@
         Totp: 'OTP',
         Sso: 'SSO',
         WebUserApproval: 'In-browser auth',
+        WebAuthn: 'Passkey',
     }
 
     const requirePassword = $derived(
@@ -88,6 +89,8 @@
     })
 
     const validCredentials = $derived.by(() => {
+        // Show credential kinds the user has registered, plus WebUserApproval
+        // which is always available (no registration needed).
         const vc = new SvelteSet(
             existingCredentials.map(x => x.kind as CredentialKind),
         )

--- a/warpgate-web/src/admin/config/users/AuthPolicyEditor.svelte
+++ b/warpgate-web/src/admin/config/users/AuthPolicyEditor.svelte
@@ -38,6 +38,7 @@
         Totp: 'OTP',
         Sso: 'SSO',
         WebUserApproval: 'In-browser auth',
+        WebAuthn: 'Passkey',
     }
 
     const requirePassword = $derived(
@@ -86,6 +87,8 @@
     })
 
     const validCredentials = $derived.by(() => {
+        // Show credential kinds the user has registered, plus WebUserApproval
+        // which is always available (no registration needed).
         const vc = new SvelteSet(
             existingCredentials.map(x => x.kind as CredentialKind),
         )

--- a/warpgate-web/src/admin/config/users/CredentialEditor.svelte
+++ b/warpgate-web/src/admin/config/users/CredentialEditor.svelte
@@ -11,11 +11,15 @@
               kind: typeof CredentialKind.Certificate
           } & ExistingCertificateCredential)
         | ({ kind: typeof CredentialKind.Totp } & ExistingOtpCredential)
+        | ({
+              kind: typeof CredentialKind.WebAuthn
+          } & ExistingWebauthnCredential)
 </script>
 
 <script lang="ts">
     import {
         faCertificate,
+        faFingerprint,
         faIdBadge,
         faKey,
         faKeyboard,
@@ -30,6 +34,7 @@
         type ExistingPasswordCredential,
         type ExistingPublicKeyCredential,
         type ExistingSsoCredential,
+        type ExistingWebauthnCredential,
         type ParameterValues,
         type UserRequireCredentialsPolicy,
     } from 'admin/lib/api'
@@ -38,6 +43,8 @@
     import EmptyState from 'common/EmptyState.svelte'
     import Loadable from 'common/Loadable.svelte'
     import { abbreviatePublicKey, possibleCredentials } from 'common/protocols'
+    import { api as gatewayApi } from 'gateway/lib/api'
+    import { serverInfo } from 'gateway/lib/store'
     import { SvelteSet } from 'svelte/reactivity'
     import Fa from 'svelte-fa'
     import CertificateCredentialModal from '../../CertificateCredentialModal.svelte'
@@ -45,6 +52,7 @@
     import CreatePasswordModal from '../../CreatePasswordModal.svelte'
     import PublicKeyCredentialModal from '../../PublicKeyCredentialModal.svelte'
     import SsoCredentialModal from '../../SsoCredentialModal.svelte'
+    import WebauthnCredentialModal from '../../WebauthnCredentialModal.svelte'
     import AuthPolicyEditor from './AuthPolicyEditor.svelte'
 
     interface Props {
@@ -61,10 +69,12 @@
     }: Props = $props()
 
     let credentials: ExistingCredential[] = $state([])
+    const isOwnUser = $derived($serverInfo?.username === username)
     let globalParameters: ParameterValues | undefined = $state()
 
     let creatingPassword = $state(false)
     let creatingOtp = $state(false)
+    let creatingWebauthn = $state(false)
     let editingSsoCredential = $state(false)
     let editingSsoCredentialInstance: ExistingSsoCredential | null =
         $state(null)
@@ -138,6 +148,7 @@
             loadPublicKeys(),
             loadCertificates(),
             loadOtp(),
+            loadWebauthn(),
             loadParameters(),
         ])
     }
@@ -191,11 +202,29 @@
         )
     }
 
+    async function loadWebauthn() {
+        credentials.push(
+            ...(await api.getWebauthnCredentials({ userId })).map(c => ({
+                kind: CredentialKind.WebAuthn,
+                ...c,
+            })),
+        )
+    }
+
     async function deleteCredential(credential: ExistingCredential) {
         if (credential.kind === CredentialKind.Certificate) {
             if (
                 !confirm(
                     'Permanently revoke certificate? This cannot be undone.',
+                )
+            ) {
+                return
+            }
+        }
+        if (credential.kind === CredentialKind.WebAuthn) {
+            if (
+                !confirm(
+                    'Delete this passkey? The user will need to re-register it.',
                 )
             ) {
                 return
@@ -233,6 +262,38 @@
                 id: credential.id,
                 userId,
             })
+        }
+        if (credential.kind === CredentialKind.WebAuthn) {
+            await api.deleteWebauthnCredential({
+                id: credential.id,
+                userId,
+            })
+        }
+
+        // If the user has no more credentials of this kind, remove it from the policy
+        const remainingOfKind = credentials.filter(
+            c => c.kind === credential.kind,
+        )
+        if (remainingOfKind.length === 0) {
+            for (const protocol of [
+                'http',
+                'ssh',
+                'mysql',
+                'postgres',
+                'kubernetes',
+                'vnc',
+                'rdp',
+            ] as const) {
+                if (credentialPolicy[protocol]?.includes(credential.kind)) {
+                    credentialPolicy = {
+                        ...credentialPolicy,
+                        [protocol]:
+                            credentialPolicy[protocol]?.filter(
+                                k => k !== credential.kind,
+                            ) ?? [],
+                    }
+                }
+            }
         }
     }
 
@@ -357,6 +418,29 @@
 
         return response
     }
+
+    function base64UrlToBuffer(base64url: string): ArrayBuffer {
+        const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
+        const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+        const binary = atob(padded)
+        const bytes = new Uint8Array(binary.length)
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i)
+        }
+        return bytes.buffer
+    }
+
+    function bufferToBase64Url(buffer: ArrayBuffer): string {
+        const bytes = new Uint8Array(buffer)
+        let binary = ''
+        for (const byte of bytes) {
+            binary += String.fromCharCode(byte)
+        }
+        return btoa(binary)
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=/g, '')
+    }
 </script>
 
 <div class="d-flex mt-4 mb-2 header">
@@ -397,6 +481,15 @@
         <Button size="sm" color="link" on:click={() => creatingOtp = true}>
             Add OTP
         </Button>
+        {#if isOwnUser}
+            <Button
+                size="sm"
+                color="link"
+                on:click={() => creatingWebauthn = true}
+            >
+                Add passkey
+            </Button>
+        {/if}
         <Button
             size="sm"
             color="link"
@@ -452,6 +545,15 @@
                 {#if credential.kind === 'Totp'}
                     <Fa fw icon={faMobileScreen} />
                     <span class="label me-auto">One-time password</span>
+                {/if}
+                {#if credential.kind === CredentialKind.WebAuthn}
+                    <Fa fw icon={faFingerprint} />
+                    <div class="main me-auto">
+                        <div class="label d-flex align-items-center">
+                            {credential.label}
+                        </div>
+                    </div>
+                    <CredentialUsedStateBadge {credential} />
                 {/if}
                 {#if credential.kind === CredentialKind.Sso}
                     <Fa fw icon={faIdBadge} />
@@ -559,6 +661,80 @@
         onClose={() => {
         editingCertificateCredential = false
     }}
+    />
+{/if}
+
+{#if creatingWebauthn}
+    <WebauthnCredentialModal
+        bind:isOpen={creatingWebauthn}
+        {userId}
+        save={async (label, signal) => {
+            if (credentials.some(c => c.kind === CredentialKind.WebAuthn && c.label === label)) {
+                throw new Error('A passkey with this name already exists')
+            }
+
+            const startResp = await gatewayApi.startWebauthnRegistration()
+            const challengeOptions = JSON.parse(startResp.challengeJson)
+
+            const pubKey = challengeOptions.publicKey
+            pubKey.challenge = base64UrlToBuffer(pubKey.challenge)
+            pubKey.user.id = base64UrlToBuffer(pubKey.user.id)
+            if (pubKey.excludeCredentials) {
+                pubKey.excludeCredentials = pubKey.excludeCredentials.map((c: { id: string }) => ({
+                    ...c,
+                    id: base64UrlToBuffer(c.id),
+                }))
+            }
+
+            let credential: PublicKeyCredential
+            try {
+                const result = await navigator.credentials.create({ publicKey: pubKey, signal })
+                if (!result) throw new Error('Registration was cancelled')
+                credential = result as PublicKeyCredential
+            } catch (e: unknown) {
+                if (e instanceof DOMException && (e.name === 'NotAllowedError' || e.name === 'AbortError')) {
+                    throw e
+                }
+                throw e
+            }
+
+            const response = credential.response as AuthenticatorAttestationResponse
+            const credentialJson = JSON.stringify({
+                id: credential.id,
+                rawId: bufferToBase64Url(credential.rawId),
+                type: credential.type,
+                response: {
+                    attestationObject: bufferToBase64Url(response.attestationObject),
+                    clientDataJSON: bufferToBase64Url(response.clientDataJSON),
+                    transports: response.getTransports ? response.getTransports() : [],
+                },
+            })
+
+            const result = await gatewayApi.completeWebauthnRegistration({
+                registrationCompleteRequest: { credentialJson, label },
+            })
+            credentials.push({ kind: CredentialKind.WebAuthn, id: result.id, label: result.label, dateAdded: new Date(), lastUsed: undefined })
+
+            // Automatically set up a 2FA policy when adding a passkey
+            for (const protocol of ['http', 'ssh'] as ('http' | 'ssh')[]) {
+                for (const ck of [
+                    CredentialKind.Password,
+                    CredentialKind.PublicKey,
+                ]) {
+                    const effectiveCreds = getEffectivePossibleCredentials(protocol)
+                    if (
+                        !credentialPolicy[protocol] &&
+                        credentials.some(x => x.kind === ck) &&
+                        effectiveCreds.has(ck)
+                    ) {
+                        credentialPolicy = {
+                            ...(credentialPolicy ?? {}),
+                            [protocol]: [ck, CredentialKind.WebAuthn],
+                        }
+                    }
+                }
+            }
+        }}
     />
 {/if}
 

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -4406,6 +4406,92 @@
         ],
         "operationId": "revoke_certificate_credential"
       }
+    },
+    "/users/{user_id}/credentials/webauthn": {
+      "get": {
+        "parameters": [
+          {
+            "name": "user_id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ExistingWebauthnCredential"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          }
+        ],
+        "operationId": "get_webauthn_credentials"
+      }
+    },
+    "/users/{user_id}/credentials/webauthn/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "name": "user_id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          },
+          {
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          }
+        ],
+        "operationId": "delete_webauthn_credential"
+      }
     }
   },
   "components": {
@@ -4862,7 +4948,8 @@
           "Certificate",
           "Totp",
           "Sso",
-          "WebUserApproval"
+          "WebUserApproval",
+          "WebAuthn"
         ]
       },
       "DatabaseTargetAuth": {
@@ -5053,6 +5140,31 @@
           },
           "email": {
             "type": "string"
+          }
+        }
+      },
+      "ExistingWebauthnCredential": {
+        "type": "object",
+        "title": "ExistingWebauthnCredential",
+        "required": [
+          "id",
+          "label"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "label": {
+            "type": "string"
+          },
+          "date_added": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_used": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -4399,6 +4399,92 @@
         ],
         "operationId": "revoke_certificate_credential"
       }
+    },
+    "/users/{user_id}/credentials/webauthn": {
+      "get": {
+        "parameters": [
+          {
+            "name": "user_id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ExistingWebauthnCredential"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          }
+        ],
+        "operationId": "get_webauthn_credentials"
+      }
+    },
+    "/users/{user_id}/credentials/webauthn/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "name": "user_id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          },
+          {
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          }
+        ],
+        "operationId": "delete_webauthn_credential"
+      }
     }
   },
   "components": {
@@ -4855,7 +4941,8 @@
           "Certificate",
           "Totp",
           "Sso",
-          "WebUserApproval"
+          "WebUserApproval",
+          "WebAuthn"
         ]
       },
       "DatabaseTargetAuth": {
@@ -5046,6 +5133,31 @@
           },
           "email": {
             "type": "string"
+          }
+        }
+      },
+      "ExistingWebauthnCredential": {
+        "type": "object",
+        "title": "ExistingWebauthnCredential",
+        "required": [
+          "id",
+          "label"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "label": {
+            "type": "string"
+          },
+          "date_added": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_used": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },

--- a/warpgate-web/src/common/protocols.ts
+++ b/warpgate-web/src/common/protocols.ts
@@ -164,16 +164,19 @@ export const possibleCredentials: Record<string, Set<CredentialKind>> = {
         CredentialKind.PublicKey,
         CredentialKind.Totp,
         CredentialKind.WebUserApproval,
+        CredentialKind.WebAuthn,
     ]),
     http: new Set([
         CredentialKind.Password,
         CredentialKind.Totp,
         CredentialKind.Sso,
+        CredentialKind.WebAuthn,
     ]),
     mysql: new Set([CredentialKind.Password]),
     postgres: new Set([
         CredentialKind.Password,
         CredentialKind.WebUserApproval,
+        CredentialKind.WebAuthn,
     ]),
     kubernetes: new Set([
         CredentialKind.Certificate,
@@ -183,12 +186,14 @@ export const possibleCredentials: Record<string, Set<CredentialKind>> = {
         CredentialKind.Password,
         CredentialKind.Totp,
         CredentialKind.WebUserApproval,
+        CredentialKind.WebAuthn,
     ]),
     // Password over NLA, then TOTP / web approval gathered on the holding screen.
     rdp: new Set([
         CredentialKind.Password,
         CredentialKind.Totp,
         CredentialKind.WebUserApproval,
+        CredentialKind.WebAuthn,
     ]),
 }
 

--- a/warpgate-web/src/gateway/CredentialManager.svelte
+++ b/warpgate-web/src/gateway/CredentialManager.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import {
         faCertificate,
+        faFingerprint,
         faIdBadge,
         faKey,
         faKeyboard,
@@ -11,6 +12,7 @@
     import CreateOtpModal from 'admin/CreateOtpModal.svelte'
     import CreatePasswordModal from 'admin/CreatePasswordModal.svelte'
     import PublicKeyCredentialModal from 'admin/PublicKeyCredentialModal.svelte'
+    import WebauthnCredentialModal from 'admin/WebauthnCredentialModal.svelte'
     import CredentialUsedStateBadge from 'common/CredentialUsedStateBadge.svelte'
     import Loadable from 'common/Loadable.svelte'
     import {
@@ -20,6 +22,7 @@
         type ExistingCertificateCredential,
         type ExistingOtpCredential,
         type ExistingPublicKeyCredential,
+        type ExistingWebauthnCredentialSelf,
         PasswordState,
     } from 'gateway/lib/api'
     import { deleteCertificateKey } from 'gateway/lib/certificateStore'
@@ -32,6 +35,9 @@
     let issuingCertificateCredential = $state(false)
     let creatingOtpCredential = $state(false)
     let changingPassword = $state(false)
+    let registeringWebauthn = $state(false)
+    let webauthnError: string | null = $state(null)
+    let creatingWebauthn = $state(false)
 
     const initPromise = init()
 
@@ -116,6 +122,128 @@
             await api.revokeMyCertificate(credential)
             await deleteCertificateKey(credential.id)
         }
+    }
+
+    async function registerWebauthn(label: string, signal: AbortSignal) {
+        if (!creds) return
+        if (creds.webauthn.some(c => c.label === label)) {
+            throw new Error('A passkey with this name already exists')
+        }
+        webauthnError = null
+        registeringWebauthn = true
+        try {
+            // Start registration ceremony
+            const startResp = await api.startWebauthnRegistration()
+            const challengeOptions = JSON.parse(startResp.challengeJson)
+
+            // Call the browser's WebAuthn API
+            let credential: PublicKeyCredential | null
+            try {
+                credential = (await navigator.credentials.create({
+                    publicKey: {
+                        ...challengeOptions.publicKey,
+                        challenge: base64UrlToBuffer(
+                            challengeOptions.publicKey.challenge,
+                        ),
+                        user: {
+                            ...challengeOptions.publicKey.user,
+                            id: base64UrlToBuffer(
+                                challengeOptions.publicKey.user.id,
+                            ),
+                        },
+                        excludeCredentials: (
+                            challengeOptions.publicKey.excludeCredentials ?? []
+                        ).map((c: { id: string }) => ({
+                            ...c,
+                            id: base64UrlToBuffer(c.id),
+                        })),
+                    },
+                    signal,
+                })) as PublicKeyCredential | null
+            } catch (domErr: unknown) {
+                if (
+                    domErr instanceof DOMException &&
+                    (domErr.name === 'NotAllowedError' ||
+                        domErr.name === 'AbortError')
+                ) {
+                    // User cancelled — no error needed
+                    return
+                }
+                throw domErr
+            }
+
+            if (!credential) {
+                return
+            }
+
+            const response =
+                credential.response as AuthenticatorAttestationResponse
+            const credentialJson = JSON.stringify({
+                id: credential.id,
+                rawId: bufferToBase64Url(credential.rawId),
+                type: credential.type,
+                response: {
+                    attestationObject: bufferToBase64Url(
+                        response.attestationObject,
+                    ),
+                    clientDataJSON: bufferToBase64Url(response.clientDataJSON),
+                    transports: response.getTransports
+                        ? response.getTransports()
+                        : [],
+                },
+            })
+
+            // Complete registration
+            const result = await api.completeWebauthnRegistration({
+                registrationCompleteRequest: {
+                    credentialJson,
+                    label,
+                },
+            })
+
+            creds.webauthn.push({
+                id: result.id,
+                label: result.label,
+                dateAdded: new Date(),
+                lastUsed: undefined,
+            })
+        } catch (e: unknown) {
+            webauthnError =
+                e instanceof Error ? e.message : 'Registration failed'
+        } finally {
+            registeringWebauthn = false
+        }
+    }
+
+    async function deleteWebauthn(credential: ExistingWebauthnCredentialSelf) {
+        if (!creds) return
+        if (!confirm('Delete this passkey? You will need to re-register it.'))
+            return
+        creds.webauthn = creds.webauthn.filter(c => c.id !== credential.id)
+        await api.deleteMyWebauthnCredential(credential)
+    }
+
+    function base64UrlToBuffer(base64url: string): ArrayBuffer {
+        const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
+        const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+        const binary = atob(padded)
+        const bytes = new Uint8Array(binary.length)
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i)
+        }
+        return bytes.buffer
+    }
+
+    function bufferToBase64Url(buffer: ArrayBuffer): string {
+        const bytes = new Uint8Array(buffer)
+        let binary = ''
+        for (const byte of bytes) {
+            binary += String.fromCharCode(byte)
+        }
+        return btoa(binary)
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=/g, '')
     }
 </script>
 
@@ -320,6 +448,64 @@
             </Alert>
         {/if}
 
+        <div class="d-flex align-items-center mt-4 mb-2">
+            <h4 class="m-0">Passkeys</h4>
+            <span class="ms-auto"></span>
+            <Button
+                color="link"
+                disabled={registeringWebauthn}
+                onclick={e => {
+                creatingWebauthn = true
+                e.preventDefault()
+            }}
+            >
+                Add passkey
+            </Button>
+        </div>
+
+        {#if webauthnError}
+            <Alert color="danger">{webauthnError}</Alert>
+        {/if}
+
+        <div class="list-group list-group-flush mb-3">
+            {#each creds.webauthn as credential (credential.id)}
+                <div class="list-group-item credential">
+                    <Fa fw icon={faFingerprint} />
+                    <div class="main ms-3">
+                        <div class="label">{credential.label}</div>
+                        {#if credential.dateAdded}
+                            <small class="d-block text-muted">
+                                Added
+                                {new Date(credential.dateAdded).toLocaleDateString()}
+                                {#if credential.lastUsed}
+                                    · Last used
+                                    {new Date(credential.lastUsed).toLocaleDateString()}
+                                {/if}
+                            </small>
+                        {/if}
+                    </div>
+                    <span class="ms-auto"></span>
+                    <Button
+                        class="ms-2"
+                        color="link"
+                        onclick={e => {
+                    deleteWebauthn(credential)
+                    e.preventDefault()
+                }}
+                    >
+                        Delete
+                    </Button>
+                </div>
+            {/each}
+        </div>
+
+        {#if creds.webauthn.length === 0 && Object.values(creds.credentialPolicy).some(l => l?.includes(CredentialKind.WebAuthn))}
+            <Alert color="warning">
+                Your credential policy requires using a passkey for
+                authentication. Without one, you won't be able to log in.
+            </Alert>
+        {/if}
+
         {#if creds.sso.length > 0}
             <div class="d-flex align-items-center mt-4 mb-2">
                 <h4 class="m-0">Single sign-on</h4>
@@ -372,6 +558,14 @@
         onClose={() => {
         issuingCertificateCredential = false
     }}
+    />
+{/if}
+
+{#if creatingWebauthn}
+    <WebauthnCredentialModal
+        bind:isOpen={creatingWebauthn}
+        userId=""
+        save={registerWebauthn}
     />
 {/if}
 

--- a/warpgate-web/src/gateway/Login.svelte
+++ b/warpgate-web/src/gateway/Login.svelte
@@ -28,6 +28,7 @@
     let password = $state('')
     let otp = $state('')
     let busy = $state(false)
+    let webauthnBusy = $state(false)
     let credentialRejected = $state(false)
     let otpInput: HTMLInputElement | undefined = $state()
     let authState: ApiAuthState | undefined = $state()
@@ -103,6 +104,10 @@
                 otpInput?.focus()
             })
         }
+        if (authState === ApiAuthState.WebAuthnNeeded) {
+            // Auto-start the WebAuthn ceremony
+            doWebauthn()
+        }
     }
 
     async function login() {
@@ -170,6 +175,116 @@
             error = await stringifyError(err)
             busy = false
         }
+    }
+
+    async function doWebauthn() {
+        webauthnBusy = true
+        error = null
+        try {
+            // Start authentication ceremony (generates a fresh challenge)
+            const startResp = await api.startWebauthnAuthentication()
+            const challengeOptions = JSON.parse(startResp.challengeJson)
+
+            // Call the browser's WebAuthn API
+            let credential: PublicKeyCredential | null
+            try {
+                credential = (await navigator.credentials.get({
+                    publicKey: {
+                        ...challengeOptions.publicKey,
+                        challenge: base64UrlToBuffer(
+                            challengeOptions.publicKey.challenge,
+                        ),
+                        allowCredentials: (
+                            challengeOptions.publicKey.allowCredentials ?? []
+                        ).map((c: { id: string }) => ({
+                            ...c,
+                            id: base64UrlToBuffer(c.id),
+                        })),
+                    },
+                })) as PublicKeyCredential | null
+            } catch (domErr: unknown) {
+                // User cancelled or timed out — allow retry without error
+                if (
+                    domErr instanceof DOMException &&
+                    domErr.name === 'NotAllowedError'
+                ) {
+                    error = null
+                    return
+                }
+                throw domErr
+            }
+
+            if (!credential) {
+                // Cancelled — allow retry
+                return
+            }
+
+            const response =
+                credential.response as AuthenticatorAssertionResponse
+            const credentialJson = JSON.stringify({
+                id: credential.id,
+                rawId: bufferToBase64Url(credential.rawId),
+                type: credential.type,
+                response: {
+                    authenticatorData: bufferToBase64Url(
+                        response.authenticatorData,
+                    ),
+                    clientDataJSON: bufferToBase64Url(response.clientDataJSON),
+                    signature: bufferToBase64Url(response.signature),
+                    userHandle: response.userHandle
+                        ? bufferToBase64Url(response.userHandle)
+                        : null,
+                },
+            })
+
+            await api.completeWebauthnAuthentication({
+                authenticationCompleteRequest: {
+                    credentialJson,
+                },
+            })
+
+            // Check if auth is now complete
+            try {
+                const state = await api.getDefaultAuthState()
+                authState = state.state
+                if (authState === ApiAuthState.Success) {
+                    await reloadServerInfo()
+                    success()
+                } else {
+                    continueWithState()
+                }
+            } catch {
+                await reloadServerInfo()
+                success()
+            }
+        } catch (err) {
+            error = await stringifyError(err)
+        } finally {
+            webauthnBusy = false
+        }
+    }
+
+    function base64UrlToBuffer(base64url: string): ArrayBuffer {
+        const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
+        const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+        const binary = atob(padded)
+        const bytes = new Uint8Array(binary.length)
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i)
+        }
+        return bytes.buffer
+    }
+
+    function bufferToBase64Url(buffer: ArrayBuffer): string {
+        const bytes = new Uint8Array(buffer)
+        let binary = ''
+        for (const byte of bytes) {
+            binary += String.fromCharCode(byte)
+        }
+        return btoa(binary)
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=/g, '')
     }
 </script>
 
@@ -259,6 +374,19 @@
                     <Fa icon={faArrowRight} />
                 </Button>
             </form>
+        {/if}
+        {#if authState === ApiAuthState.WebAuthnNeeded}
+            <div class="text-center py-4">
+                <p class="mb-3">Use your passkey or security key to continue</p>
+                <Button
+                    color="primary"
+                    class="login-view-button"
+                    disabled={webauthnBusy}
+                    on:click={doWebauthn}
+                >
+                    {webauthnBusy ? 'Waiting...' : 'Authenticate'}
+                </Button>
+            </div>
         {/if}
         {#if (authState === ApiAuthState.NotStarted || authState === ApiAuthState.PasswordNeeded || authState === ApiAuthState.Failed || authState === ApiAuthState.IpRejected) && passwordLoginAllowed && (!passwordLoginMinimized || showPasswordLogin)}
             {@render localLoginForm()}

--- a/warpgate-web/src/gateway/OutOfBandAuth.svelte
+++ b/warpgate-web/src/gateway/OutOfBandAuth.svelte
@@ -25,6 +25,9 @@
     let { params }: Props = $props()
 
     let authState: AuthStateResponseInternal | undefined = $state()
+    let webauthnBusy = $state(false)
+    let webauthnError: string | null = $state(null)
+    let webauthnRequired = $state(false)
 
     let cachingGrace = $derived(authState?.webApprovalCachingGraceSeconds ?? 0)
     let cachingEnabled = $derived(cachingGrace > 0)
@@ -32,6 +35,9 @@
 
     async function reload() {
         authState = await api.getAuthState({ id: params.stateId })
+        // If the session state indicates WebAuthn is needed, the approval should
+        // include a WebAuthn ceremony
+        webauthnRequired = authState?.state === ApiAuthState.WebAuthnNeeded
     }
 
     async function init() {
@@ -39,6 +45,11 @@
     }
 
     async function approve(scope: WebApprovalScope) {
+        // If WebAuthn is required for this session, perform the ceremony first
+        if (webauthnRequired) {
+            const success = await performWebauthnCeremony()
+            if (!success) return
+        }
         await api.approveAuth({
             id: params.stateId,
             approveAuthRequest: { scope },
@@ -47,10 +58,93 @@
         window.close()
     }
 
+    async function performWebauthnCeremony(): Promise<boolean> {
+        webauthnBusy = true
+        webauthnError = null
+        try {
+            const startResp = await api.startWebauthnAuthentication()
+            const challengeOptions = JSON.parse(startResp.challengeJson)
+
+            const credential = (await navigator.credentials.get({
+                publicKey: {
+                    ...challengeOptions.publicKey,
+                    challenge: base64UrlToBuffer(
+                        challengeOptions.publicKey.challenge,
+                    ),
+                    allowCredentials: (
+                        challengeOptions.publicKey.allowCredentials ?? []
+                    ).map((c: { id: string }) => ({
+                        ...c,
+                        id: base64UrlToBuffer(c.id),
+                    })),
+                },
+            })) as PublicKeyCredential | null
+
+            if (!credential) {
+                webauthnError = 'Authentication was cancelled'
+                return false
+            }
+
+            const response =
+                credential.response as AuthenticatorAssertionResponse
+            const credentialJson = JSON.stringify({
+                id: credential.id,
+                rawId: bufferToBase64Url(credential.rawId),
+                type: credential.type,
+                response: {
+                    authenticatorData: bufferToBase64Url(
+                        response.authenticatorData,
+                    ),
+                    clientDataJSON: bufferToBase64Url(response.clientDataJSON),
+                    signature: bufferToBase64Url(response.signature),
+                    userHandle: response.userHandle
+                        ? bufferToBase64Url(response.userHandle)
+                        : null,
+                },
+            })
+
+            await api.completeWebauthnAuthentication({
+                authenticationCompleteRequest: { credentialJson },
+            })
+            return true
+        } catch (e: unknown) {
+            webauthnError =
+                e instanceof Error
+                    ? e.message
+                    : 'WebAuthn authentication failed'
+            return false
+        } finally {
+            webauthnBusy = false
+        }
+    }
+
     async function reject() {
         await api.rejectAuth({ id: params.stateId })
         await reload()
         window.close()
+    }
+
+    function base64UrlToBuffer(base64url: string): ArrayBuffer {
+        const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
+        const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+        const binary = atob(padded)
+        const bytes = new Uint8Array(binary.length)
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i)
+        }
+        return bytes.buffer
+    }
+
+    function bufferToBase64Url(buffer: ArrayBuffer): string {
+        const bytes = new Uint8Array(buffer)
+        let binary = ''
+        for (const byte of bytes) {
+            binary += String.fromCharCode(byte)
+        }
+        return btoa(binary)
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=/g, '')
     }
 </script>
 
@@ -101,15 +195,28 @@
         {:else if authState.state === ApiAuthState.Failed}
             <Alert color="danger"> Rejected </Alert>
         {:else}
+            {#if webauthnRequired}
+                <div class="mb-3">
+                    <Alert color="info">
+                        This session requires security key verification. Touch
+                        your key when prompted.
+                    </Alert>
+                </div>
+            {/if}
+            {#if webauthnError}
+                <Alert color="danger">{webauthnError}</Alert>
+            {/if}
             <div class="d-flex">
                 <div class="ms-auto"></div>
                 {#if cachingEnabled}
                     <ButtonGroup>
                         <AsyncButton
                             color="primary"
+                            disabled={webauthnBusy}
                             click={() => approve(WebApprovalScope.Target)}
                         >
-                            Authorize & remember for {graceLabel}
+                            {webauthnRequired ? 'Verify & authorize' : 'Authorize & remember for'}
+                            {cachingEnabled && !webauthnRequired ? graceLabel : ''}
                         </AsyncButton>
                         <Dropdown class="btn-group">
                             <DropdownToggle
@@ -121,13 +228,15 @@
                                 <DropdownItem
                                     onclick={() => approve(WebApprovalScope.AllTargets)}
                                 >
-                                    Authorize for all targets & remember for
-                                    {graceLabel}
+                                    {webauthnRequired ? 'Verify & authorize' : 'Authorize'}
+                                    for all targets
+                                    {cachingEnabled && !webauthnRequired ? `& remember for ${graceLabel}` : ''}
                                 </DropdownItem>
                                 <DropdownItem
                                     onclick={() => approve(WebApprovalScope.Once)}
                                 >
-                                    Authorize this time only
+                                    {webauthnRequired ? 'Verify & authorize' : 'Authorize'}
+                                    this time only
                                 </DropdownItem>
                             </DropdownMenu>
                         </Dropdown>
@@ -135,9 +244,10 @@
                 {:else}
                     <AsyncButton
                         color="primary"
+                        disabled={webauthnBusy}
                         click={() => approve(WebApprovalScope.Once)}
                     >
-                        Authorize
+                        {webauthnRequired ? 'Verify & authorize' : 'Authorize'}
                     </AsyncButton>
                 {/if}
                 <AsyncButton

--- a/warpgate-web/src/gateway/lib/openapi-schema.json
+++ b/warpgate-web/src/gateway/lib/openapi-schema.json
@@ -295,6 +295,64 @@
         "operationId": "reject_auth"
       }
     },
+    "/auth/webauthn/authentication/start": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationStartResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          },
+          "500": {
+            "description": ""
+          }
+        },
+        "operationId": "start_webauthn_authentication"
+      }
+    },
+    "/auth/webauthn/authentication/complete": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json; charset=utf-8": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthenticationCompleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "400": {
+            "description": ""
+          },
+          "401": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          },
+          "500": {
+            "description": ""
+          }
+        },
+        "operationId": "complete_webauthn_authentication"
+      }
+    },
     "/info": {
       "get": {
         "responses": {
@@ -872,6 +930,46 @@
           }
         ],
         "operationId": "revoke_my_certificate"
+      }
+    },
+    "/profile/credentials/webauthn/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "401": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          },
+          {
+            "ClusterSecurityScheme": []
+          }
+        ],
+        "operationId": "delete_my_webauthn_credential"
       }
     },
     "/profile/api-tokens": {
@@ -1585,6 +1683,90 @@
         ],
         "operationId": "delete_web_desktop_session"
       }
+    },
+    "/auth/webauthn/registration/start": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistrationStartResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": ""
+          },
+          "409": {
+            "description": ""
+          },
+          "500": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          },
+          {
+            "ClusterSecurityScheme": []
+          }
+        ],
+        "operationId": "start_webauthn_registration"
+      }
+    },
+    "/auth/webauthn/registration/complete": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json; charset=utf-8": {
+              "schema": {
+                "$ref": "#/components/schemas/RegistrationCompleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistrationCompleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": ""
+          },
+          "401": {
+            "description": ""
+          },
+          "500": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          },
+          {
+            "ClusterSecurityScheme": []
+          }
+        ],
+        "operationId": "complete_webauthn_registration"
+      }
     }
   },
   "components": {
@@ -1720,6 +1902,7 @@
           "OtpNeeded",
           "SsoNeeded",
           "WebUserApprovalNeeded",
+          "WebAuthnNeeded",
           "PublicKeyNeeded",
           "Success",
           "IpBlocked",
@@ -1773,6 +1956,32 @@
             "type": "integer",
             "format": "int64",
             "description": "When web-approval caching is enabled, the caching window in seconds;\n`None` when caching is disabled."
+          }
+        }
+      },
+      "AuthenticationCompleteRequest": {
+        "type": "object",
+        "title": "AuthenticationCompleteRequest",
+        "required": [
+          "credential_json"
+        ],
+        "properties": {
+          "credential_json": {
+            "type": "string",
+            "description": "JSON-serialized PublicKeyCredential from the browser"
+          }
+        }
+      },
+      "AuthenticationStartResponse": {
+        "type": "object",
+        "title": "AuthenticationStartResponse",
+        "required": [
+          "challenge_json"
+        ],
+        "properties": {
+          "challenge_json": {
+            "type": "string",
+            "description": "JSON-serialized RequestChallengeResponse from webauthn-rs"
           }
         }
       },
@@ -1882,7 +2091,8 @@
           "Certificate",
           "Totp",
           "Sso",
-          "WebUserApproval"
+          "WebUserApproval",
+          "WebAuthn"
         ]
       },
       "CredentialsState": {
@@ -1894,6 +2104,7 @@
           "public_keys",
           "certificates",
           "sso",
+          "webauthn",
           "credential_policy",
           "ldap_linked",
           "password_policy"
@@ -1924,6 +2135,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ExistingSsoCredential"
+            }
+          },
+          "webauthn": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExistingWebauthnCredentialSelf"
             }
           },
           "credential_policy": {
@@ -2052,6 +2269,31 @@
           },
           "email": {
             "type": "string"
+          }
+        }
+      },
+      "ExistingWebauthnCredentialSelf": {
+        "type": "object",
+        "title": "ExistingWebauthnCredentialSelf",
+        "required": [
+          "id",
+          "label"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "label": {
+            "type": "string"
+          },
+          "date_added": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_used": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },
@@ -2478,6 +2720,54 @@
           "rdp": {
             "type": "integer",
             "format": "uint16"
+          }
+        }
+      },
+      "RegistrationCompleteRequest": {
+        "type": "object",
+        "title": "RegistrationCompleteRequest",
+        "required": [
+          "credential_json",
+          "label"
+        ],
+        "properties": {
+          "credential_json": {
+            "type": "string",
+            "description": "JSON-serialized RegisterPublicKeyCredential from the browser"
+          },
+          "label": {
+            "type": "string",
+            "description": "Friendly label for this key (e.g. \"Office Yubikey\", \"Backup key\")"
+          }
+        }
+      },
+      "RegistrationCompleteResponse": {
+        "type": "object",
+        "title": "RegistrationCompleteResponse",
+        "required": [
+          "id",
+          "label"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "label": {
+            "type": "string"
+          }
+        }
+      },
+      "RegistrationStartResponse": {
+        "type": "object",
+        "title": "RegistrationStartResponse",
+        "required": [
+          "challenge_json"
+        ],
+        "properties": {
+          "challenge_json": {
+            "type": "string",
+            "description": "JSON-serialized CreationChallengeResponse from webauthn-rs"
           }
         }
       },

--- a/warpgate-web/src/gateway/lib/openapi-schema.json
+++ b/warpgate-web/src/gateway/lib/openapi-schema.json
@@ -295,6 +295,64 @@
         "operationId": "reject_auth"
       }
     },
+    "/auth/webauthn/authentication/start": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationStartResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          },
+          "500": {
+            "description": ""
+          }
+        },
+        "operationId": "start_webauthn_authentication"
+      }
+    },
+    "/auth/webauthn/authentication/complete": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json; charset=utf-8": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthenticationCompleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "400": {
+            "description": ""
+          },
+          "401": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          },
+          "500": {
+            "description": ""
+          }
+        },
+        "operationId": "complete_webauthn_authentication"
+      }
+    },
     "/info": {
       "get": {
         "responses": {
@@ -872,6 +930,46 @@
           }
         ],
         "operationId": "revoke_my_certificate"
+      }
+    },
+    "/profile/credentials/webauthn/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "401": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          },
+          {
+            "ClusterSecurityScheme": []
+          }
+        ],
+        "operationId": "delete_my_webauthn_credential"
       }
     },
     "/profile/api-tokens": {
@@ -1585,6 +1683,90 @@
         ],
         "operationId": "delete_web_desktop_session"
       }
+    },
+    "/auth/webauthn/registration/start": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistrationStartResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": ""
+          },
+          "409": {
+            "description": ""
+          },
+          "500": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          },
+          {
+            "ClusterSecurityScheme": []
+          }
+        ],
+        "operationId": "start_webauthn_registration"
+      }
+    },
+    "/auth/webauthn/registration/complete": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json; charset=utf-8": {
+              "schema": {
+                "$ref": "#/components/schemas/RegistrationCompleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistrationCompleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": ""
+          },
+          "401": {
+            "description": ""
+          },
+          "500": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          },
+          {
+            "ClusterSecurityScheme": []
+          }
+        ],
+        "operationId": "complete_webauthn_registration"
+      }
     }
   },
   "components": {
@@ -1693,6 +1875,7 @@
           "OtpNeeded",
           "SsoNeeded",
           "WebUserApprovalNeeded",
+          "WebAuthnNeeded",
           "PublicKeyNeeded",
           "Success",
           "IpBlocked",
@@ -1746,6 +1929,32 @@
             "type": "integer",
             "format": "int64",
             "description": "When web-approval caching is enabled, the caching window in seconds;\n`None` when caching is disabled."
+          }
+        }
+      },
+      "AuthenticationCompleteRequest": {
+        "type": "object",
+        "title": "AuthenticationCompleteRequest",
+        "required": [
+          "credential_json"
+        ],
+        "properties": {
+          "credential_json": {
+            "type": "string",
+            "description": "JSON-serialized PublicKeyCredential from the browser"
+          }
+        }
+      },
+      "AuthenticationStartResponse": {
+        "type": "object",
+        "title": "AuthenticationStartResponse",
+        "required": [
+          "challenge_json"
+        ],
+        "properties": {
+          "challenge_json": {
+            "type": "string",
+            "description": "JSON-serialized RequestChallengeResponse from webauthn-rs"
           }
         }
       },
@@ -1851,7 +2060,8 @@
           "Certificate",
           "Totp",
           "Sso",
-          "WebUserApproval"
+          "WebUserApproval",
+          "WebAuthn"
         ]
       },
       "CredentialsState": {
@@ -1863,6 +2073,7 @@
           "public_keys",
           "certificates",
           "sso",
+          "webauthn",
           "credential_policy",
           "ldap_linked",
           "password_policy"
@@ -1893,6 +2104,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ExistingSsoCredential"
+            }
+          },
+          "webauthn": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExistingWebauthnCredentialSelf"
             }
           },
           "credential_policy": {
@@ -2021,6 +2238,31 @@
           },
           "email": {
             "type": "string"
+          }
+        }
+      },
+      "ExistingWebauthnCredentialSelf": {
+        "type": "object",
+        "title": "ExistingWebauthnCredentialSelf",
+        "required": [
+          "id",
+          "label"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "label": {
+            "type": "string"
+          },
+          "date_added": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_used": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },
@@ -2434,6 +2676,54 @@
           "rdp": {
             "type": "integer",
             "format": "uint16"
+          }
+        }
+      },
+      "RegistrationCompleteRequest": {
+        "type": "object",
+        "title": "RegistrationCompleteRequest",
+        "required": [
+          "credential_json",
+          "label"
+        ],
+        "properties": {
+          "credential_json": {
+            "type": "string",
+            "description": "JSON-serialized RegisterPublicKeyCredential from the browser"
+          },
+          "label": {
+            "type": "string",
+            "description": "Friendly label for this key (e.g. \"Office Yubikey\", \"Backup key\")"
+          }
+        }
+      },
+      "RegistrationCompleteResponse": {
+        "type": "object",
+        "title": "RegistrationCompleteResponse",
+        "required": [
+          "id",
+          "label"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "label": {
+            "type": "string"
+          }
+        }
+      },
+      "RegistrationStartResponse": {
+        "type": "object",
+        "title": "RegistrationStartResponse",
+        "required": [
+          "challenge_json"
+        ],
+        "properties": {
+          "challenge_json": {
+            "type": "string",
+            "description": "JSON-serialized CreationChallengeResponse from webauthn-rs"
           }
         }
       },

--- a/warpgate/src/commands/copy_database.rs
+++ b/warpgate/src/commands/copy_database.rs
@@ -45,6 +45,7 @@ macro_rules! with_every_table_in_order {
             OtpCredential,
             SsoCredential,
             CertificateCredential,
+            WebauthnCredential,
         ];
     };
 }


### PR DESCRIPTION
Users can register hardware security keys (YubiKey, Titan Key, any FIDO2 or U2F key) or platform authenticators (Touch ID, Windows Hello) as an authentication factor for logging into Warpgate.

## Description

The primary focus is **hardware key 2FA** (FIDO2/U2F keys as a second factor alongside passwords), but the implementation fully supports **passkeys** (platform authenticators like Touch ID, Windows Hello, iCloud Keychain) as well. Passkeys could theoretically serve as a password replacement (single-factor passwordless login), but that would require a broader decision about refactoring the login flow — see "Not included" below.

Once authenticated with Warpgate (including the passkey step), users access all downstream targets (SSH, HTTP, MySQL, PostgreSQL, Kubernetes, RDP, VNC) normally through their authorized session.

### Scope

- **What it protects:** Login to Warpgate's gateway web UI (the bastion itself)
- **What it supports:** FIDO2 keys, U2F keys (backward compatible), platform authenticators (Touch ID, Windows Hello, phone biometrics)
- **Cluster support:** Authentication endpoints are cluster-safe via `on_login_owner` — works correctly in multi-node deployments
- **Non-browser protocols:** When an SSH/MySQL/PostgreSQL credential policy requires a passkey, the existing web approval flow triggers a WebAuthn ceremony in the browser. The terminal session stays pending until the user touches their key in the approval page.
- **Credential policy:** Admins can require passkeys per-protocol (same as OTP today), e.g. `{"http": ["Password", "WebAuthn"], "ssh": ["Password", "WebAuthn"]}`

### What's included

**Backend:**
- `credentials_webauthn` database entity + migration (m00073) with user_id index
- `CredentialKind::WebAuthn` added to auth enums, credential policy, and auth state machine
- Registration ceremony endpoints (start/complete) using webauthn-rs SecurityKey API
- Authentication ceremony endpoints (start/complete) in auth.rs with cluster proxy support
- Admin API: list and delete credentials per-user (recovery path for lost keys)
- Self-service: register/delete own credentials from gateway profile
- Counter persistence after each authentication (cloned-key detection)
- Failed WebAuthn attempts recorded to existing brute-force protection system

**Frontend:**
- "Add passkey" button in admin user config and gateway profile page
- Registration modal matching existing credential UI patterns
- Login flow handles `WebAuthnNeeded` state with auto-start and graceful retry on cancel/timeout
- Auth policy toggles show "Passkey" option (appears after user registers one)
- Auto-policy upgrade on registration (sets Password + Passkey, same as OTP does)
- Out-of-band auth page triggers WebAuthn ceremony for non-browser protocol web approval
- "Add passkey" hidden when viewing other users (admin can't register a key for someone else — keys are hardware-bound)

**Tests:**
- 3 Rust unit tests: WebAuthn satisfies policy, multi-factor requires both, rejection leaves state unchanged
- 5 Python integration tests: endpoint access control, policy enforcement, replay protection, admin CRUD, regression safety
- All 237 existing tests pass unchanged

### Design decisions

| Decision | Rationale |
|----------|-----------|
| `webauthn-rs` crate (by Kanidm) | De facto Rust WebAuthn library, production-proven |
| SecurityKey API (not Passkey API) | Avoids CredProtect extension conflicts with older U2F keys while still supporting both platform and roaming authenticators |
| `userVerification: "discouraged"` | Touch-only, no PIN required — matches AWS IAM MFA UX |
| `attestation: "none"` | Maximum hardware compatibility, no manufacturer restrictions |
| `residentKey: "discouraged"` | Server-side credential storage, works with older YubiKeys that have limited resident key slots |
| Max 8 keys per user | Matches AWS IAM limit, allows primary + backup keys |
| RP ID from `http.external_host` | Consistent with existing config, includes port for non-standard setups |
| Challenge state in poem session | Single-use (consumed on complete), no DB persistence for incomplete ceremonies |
| `danger_set_user_presence_only_security_keys` | Disables CredProtect that causes "inconsistent parameters" errors on many authenticators |

### Security

- **Phishing-proof:** Challenge is cryptographically bound to the RP origin (WebAuthn spec guarantee)
- **Single-use challenges:** Session state consumed immediately on complete endpoint — prevents replay
- **Counter persistence:** Detects cloned authenticators (stale counter → rejected by webauthn-rs)
- **Credential isolation:** Keys loaded per-user, cross-user usage impossible
- **No secrets in logs:** Credential data, challenges, and attestation objects never logged
- **Rate limiting:** Failed WebAuthn auth attempts recorded to existing brute-force protection
- **TOCTOU-safe:** Credential count re-checked before insert (closes race between start/complete)
- **Label validation:** Empty or >255 char labels rejected
- **Constant-time verification:** Signature verification uses ed25519-dalek/p256 (constant-time internally)
- **Backward compatible:** Existing users/credentials unaffected, new table is purely additive

### Dependencies added

2 direct dependencies:
- `webauthn-rs = "0.5"` (features: `danger-allow-state-serialisation`, `danger-user-presence-only-security-keys`)
- `webauthn-rs-proto = "0.5"`

12 transitive dependencies (x509-parser, serde_cbor_2, base64urlsafedata, asn1-rs, etc.)

All MIT/Apache-2.0 licensed. `cargo deny check` passes clean. No known security advisories.

### Configuration

The `external_host` must match what users see in their browser's address bar. This is already a Warpgate requirement (for cookies, SSO, etc.) — WebAuthn uses the same value.

```yaml
# Behind a reverse proxy (typical production setup)
http:
  external_host: "warpgate.example.com"   # public domain (what users see)
  listen: "0.0.0.0:8888"                  # internal, proxied by nginx/caddy

# Direct access without proxy
http:
  external_host: "warpgate.example.com:8888"
```

No special WebAuthn configuration needed beyond what Warpgate already requires.

**DNS binding:** WebAuthn works with subdomain-based DNS binding (e.g. `target.wg.example.com`) because we enable `allow_subdomains` on the WebAuthn builder. The RP ID is derived from `external_host` (e.g. `wg.example.com`) and any subdomain of it is accepted as a valid origin. However, targets bound to completely unrelated domains (not subdomains of `external_host`) cannot use WebAuthn — this is a WebAuthn spec limitation that all implementations share.

**No `external_host` set:** Falls back to `localhost`. WebAuthn will only work when accessed via `https://localhost`. This is fine for development but in production, `external_host` should always be configured (it's already required for cookies and SSO to work).

### Reusable for future features

The WebAuthn verification logic is exposed as a reusable pub(crate) helper:

webauthn::verify_webauthn_authentication(services, session, &credential_json).await?;

This handles challenge consumption, signature verification, counter update, and last_used in a single call. Future features like step-up authentication (e.g. require key touch before issuing tickets, approving access, or performing destructive admin actions) can use this directly without reimplementing the ceremony logic.


---


### Not included:

**Note:** This PR adds WebAuthn support for Warpgate's **web/browser login** only. It does not address SSH `-sk` key types (`ecdsa-sk`/`ed25519-sk`) requested in #221 — that is a separate SSH-protocol concern. However, for non-browser protocols that support web approval (SSH, PostgreSQL), this PR integrates with the existing web approval flow so users can satisfy a WebAuthn policy requirement by touching their key in the browser approval page.

#### Suggested UX improvement (out of scope but would add after initial PR).

- **Passkey instead of password:** For a non-2FA, passkey only auth policy example (passkey substituting a password) the login UI forces a password. You can type an incorrect password to get past this and then submit passkey in next continue login. Perhaps initial login only takes username/ID then a password type authentication would be extracted into the continue login flow. This way a passkey instead of password could work.

- **Forced enrollment on first login:** When an admin sets a passkey requirement before the user has registered one, the user is currently locked out. A "grace period" flow — where the first login succeeds with password only but forces the user to register a passkey before accessing any targets — would enable admins to enforce passkey requirements from day one without coordination. This would benefit all credential types (OTP, passkey, etc.) and is a separate feature.

- **Resident key mode as a config option:** Currently residentKey is hardcoded to "discouraged" (server-side credential storage, no key slots consumed). This maximizes compatibility but means browsers can't auto-discover credentials. An admin-configurable option in warpgate.yaml could allow choosing between "discouraged" (current default — unlimited capacity, works with all keys, but some browsers require an extra click to select authenticator type) and "preferred" (stores credentials on the key — browsers auto-discover them for smoother UX, but consumes limited hardware key slots: 25-100 per YubiKey model). This would be a one-line config that maps to the WebAuthn residentKey parameter.
#### Bug fix (out of scope but would add after initial PR).

- **Pre-existing bug identified (follow-up PR):** When the last credential of a given type is deleted (e.g. the only OTP device, the only passkey), the auth policy editor's toggle disappears but the policy value still contains the credential kind. Clicking "Update" saves a policy requiring a credential the user can't satisfy, locking them out. This affects all credential types and is a broader fix that should be addressed separately to avoid conflating concerns.

---

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [X] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
