### PR TITLE
fixed #2378 - don't report env vars as unknown config keys

### DIFF
--- a/warpgate/src/config.rs
+++ b/warpgate/src/config.rs
@@ -1,4 +1,6 @@
-use std::sync::Arc;
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::sync::{Arc, LazyLock};
 
 use anyhow::{Context, Result};
 use config::{Config, Environment, File, FileFormat};
@@ -9,6 +11,29 @@ use warpgate_common::helpers::fs::secure_file;
 use warpgate_common::{
     GlobalParams, WarpgateConfig, WarpgateConfigStore, clear_config_warnings, emit_config_warning,
 };
+
+/// Lowercased `WARPGATE_*` variable names that map onto a config key, taken
+/// from the schema so they track the struct.
+static CONFIG_ENV_VARS: LazyLock<HashSet<String>> = LazyLock::new(|| {
+    schemars::schema_for!(WarpgateConfigStore)
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .into_iter()
+        .flat_map(|p| p.keys().map(|k| format!("warpgate_{k}")))
+        .collect()
+});
+
+/// Keep only the `WARPGATE_*` variables that name a config key - the rest are
+/// read directly by Warpgate (`WARPGATE_CONFIG`) or injected by the platform
+/// (Kubernetes' `WARPGATE_PORT`, ...) and would land in the store as unknown
+/// keys. Case-insensitive, non-Unicode skipped, as [`Environment`]'s own scan.
+fn config_env_source(
+    vars: impl Iterator<Item = (OsString, OsString)>,
+) -> config::Map<String, String> {
+    vars.filter_map(|(key, value)| Some((key.into_string().ok()?, value.into_string().ok()?)))
+        .filter(|(key, _)| CONFIG_ENV_VARS.contains(&key.to_lowercase()))
+        .collect()
+}
 
 pub fn load_config(params: &GlobalParams, secure: bool) -> Result<WarpgateConfig> {
     clear_config_warnings();
@@ -21,7 +46,10 @@ pub fn load_config(params: &GlobalParams, secure: bool) -> Result<WarpgateConfig
                 .context("Invalid config path")?,
             FileFormat::Yaml,
         ))
-        .add_source(Environment::with_prefix("WARPGATE"))
+        .add_source(
+            Environment::with_prefix("WARPGATE")
+                .source(Some(config_env_source(std::env::vars_os()))),
+        )
         .build()
         .context("Could not load config")?
         .try_deserialize()
@@ -229,6 +257,79 @@ mod tests {
 
         let (store, _) = deserialize_store_collecting_ignored(value).unwrap();
         assert_eq!(store.ssh.keepalive_interval, Some(Duration::from_secs(60)));
+    }
+
+    /// #2378: the Docker image sets `WARPGATE_CONFIG`, which used to reach the
+    /// store as an unknown `config` key and warn on every install.
+    #[test]
+    fn docker_config_env_var_produces_no_warning() {
+        let vars = [
+            (
+                OsString::from("WARPGATE_CONFIG"),
+                OsString::from("/data/warpgate.yaml"),
+            ),
+            (
+                OsString::from("WARPGATE_ADMIN_TOKEN"),
+                OsString::from("token"),
+            ),
+        ]
+        .into_iter();
+
+        let value: serde_yaml::Value = Config::builder()
+            .add_source(File::from_str(
+                "external_host: bastion.example\n",
+                FileFormat::Yaml,
+            ))
+            .add_source(Environment::with_prefix("WARPGATE").source(Some(config_env_source(vars))))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        let (store, ignored) = deserialize_store_collecting_ignored(value).unwrap();
+        assert!(ignored.is_empty(), "unexpected ignored keys: {ignored:?}");
+        assert_eq!(store.external_host.as_deref(), Some("bastion.example"));
+    }
+
+    #[test]
+    fn env_source_keeps_only_config_keys() {
+        let vars = [
+            ("WARPGATE_CONFIG", "/data/warpgate.yaml"),
+            ("WARPGATE_ADMIN_TOKEN", "token"),
+            ("WARPGATE_PORT_8888_TCP_ADDR", "10.0.0.1"), // injected by Kubernetes
+            ("PATH", "/usr/bin"),
+            ("WARPGATE_EXTERNAL_HOST", "bastion.example"),
+            ("warpgate_database_url", "sqlite:/data/db"), // matched case-insensitively
+        ]
+        .into_iter()
+        .map(|(k, v)| (OsString::from(k), OsString::from(v)));
+
+        let mut kept: Vec<_> = config_env_source(vars).into_keys().collect();
+        kept.sort();
+        assert_eq!(kept, ["WARPGATE_EXTERNAL_HOST", "warpgate_database_url"]);
+    }
+
+    #[test]
+    fn env_source_skips_non_unicode_vars() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStringExt;
+
+            let vars = [
+                (OsString::from_vec(vec![0xff, 0xfe]), OsString::from("x")),
+                (
+                    OsString::from("WARPGATE_EXTERNAL_HOST"),
+                    OsString::from("b"),
+                ),
+            ]
+            .into_iter();
+
+            let source = config_env_source(vars);
+            assert_eq!(
+                source.keys().collect::<Vec<_>>(),
+                ["WARPGATE_EXTERNAL_HOST"]
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #2378.

### The problem

Every 0.27.x Docker install shows a config warning banner for a key that isn't in `warpgate.yaml`:

> Ignoring unknown config key `config` — likely a typo or a misplaced key; it has NO effect

The reporter's config is clean, and everything works — the warning is a false positive.

### The finding

Three independent, individually-correct pieces meet:

1. `docker/Dockerfile` sets `ENV WARPGATE_CONFIG=/data/warpgate.yaml`. That is the env fallback for the `--config` CLI flag (`warpgate/src/main.rs`), not a config key.
2. `load_config` layers `Environment::with_prefix("WARPGATE")` over the YAML file. With no separator configured, that source maps **every** `WARPGATE_*` variable to a top-level config key — so `WARPGATE_CONFIG` becomes `config`.
3. 0.27 added the `serde_ignored` unknown-key check, which correctly reports `config` as a key `WarpgateConfigStore` doesn't know.

So the warning fires on every Docker install regardless of config contents, and equally for any other `WARPGATE_*` variable in the environment — including ones Warpgate itself defines (`WARPGATE_ADMIN_TOKEN`, `WARPGATE_ADMIN_PASSWORD`, `WARPGATE_PEER_ADDRESS`, …) and ones the platform injects.

### The solution

Feed the environment source only the variables that name an actual config key. The accepted names are derived from `WarpgateConfigStore`'s own JSON schema (`schemars::schema_for!`), so they track the struct — add a config field and its `WARPGATE_*` override keeps working with nothing to maintain.

Matching is case-insensitive and non-Unicode variables are skipped, mirroring what `config::Environment` already does when it scans the process environment itself (`config-0.15.25/src/env.rs:269` lowercases before prefix matching; `:350` uses `env::vars_os()` and skips non-Unicode keys).

Incidental benefit: `WARPGATE_ADMIN_TOKEN` / `WARPGATE_ADMIN_PASSWORD` / `WARPGATE_NEW_USER_PASSWORD` values are no longer copied into the intermediate config tree, and those names no longer appear in operator-visible warning text.

### Alternatives dismissed

**A hardcoded deny-list of Warpgate's own env vars.** The obvious fix, and the one I wrote first. It doesn't hold: Kubernetes injects `WARPGATE_PORT`, `WARPGATE_SERVICE_HOST`, `WARPGATE_PORT_8888_TCP_ADDR`, … into every pod for any Service named `warpgate*`. No hand-maintained list can enumerate what the platform invents, so the deny-list is both incomplete and a permanent maintenance tax.

**Suppress the warning for env-derived keys, leaving the env source untouched.** Smaller diff, and it would keep typo diagnostics for `WARPGATE_*` overrides. Rejected because it still needs the same environment introspection to decide which ignored keys came from env, and it leaves credential values merged into the config store — the thing worth avoiding.

**`#[serde(deny_unknown_fields)]` on the config structs.** Orthogonal to this bug, and it would turn today's warning into a hard startup failure, breaking the deprecation/migration path the loader deliberately supports.

**Document the warning as harmless.** It is on by default for every Docker user. A warning that everyone learns to ignore devalues the real ones the 0.27 check was added to surface.

### Risk

Low blast radius — one function, config load path only — but the behaviour changes are worth naming:

- **Lost diagnostic.** A `WARPGATE_*` variable that isn't a config key now produces no warning at all. A typo'd override (`WARPGATE_EXTERNALHOST=…`) is silently inert where it previously surfaced as an unknown key. Its *effect* is unchanged — it never applied — but the signal is gone. This is the direct cost of removing the false positives, and I don't see a way to have both without re-introducing an unenumerable deny-list.
- **`WARPGATE_WEB_ADMIN` is no longer accepted** for the deprecated `web_admin` → `http` rename, since `web_admin` isn't in the schema. Setting an entire config section through a flat env var never worked anyway (no separator is configured), so this should be theoretical.
- **Schema/serde coupling.** Override names now come from schemars property names. A future `#[serde(rename = "…")]` without a matching `#[schemars(rename)]` would silently break that variable's override, with no compile error. The added test covers presence, not renames.
- **Fail-open on schema shape.** If `properties` ever stops being a flat root object (e.g. a `#[serde(flatten)]` on `WarpgateConfigStore`), the accepted set empties and *all* `WARPGATE_*` overrides are dropped silently. The new test asserts a non-empty result, so CI catches it. I'd normally assert the invariant in code, but `clippy::expect_used` and `clippy::unwrap_used` are denied repo-wide.
- **Non-Unicode value on a valid config key** is now dropped silently, where the `config` crate previously raised a clean error. Requires a `config::Map<String, String>` source; pathological in practice.

### Testing

`docker_config_env_var_produces_no_warning` is the regression test for this issue: it runs the loader's real file + environment pipeline with `WARPGATE_CONFIG` set the way the Docker image sets it, and asserts nothing is reported as an unknown key. Reverting just the env-source change makes it fail with the reported symptom:

```
unexpected ignored keys: ["admin_token", "config"]
```

- `cargo test -p warpgate` — 8 config tests pass, 3 new (the regression test above, plus `env_source_keeps_only_config_keys` and `env_source_skips_non_unicode_vars`).
- `cargo clippy -p warpgate --all-features` — no findings in the changed file.
- `cargo fmt` applied.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [x] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)
