### PR TITLE
fixed #2379 - do not log LB health checks as failed sessions

### DIFF
--- a/warpgate-common/src/helpers/net.rs
+++ b/warpgate-common/src/helpers/net.rs
@@ -1,12 +1,49 @@
+use std::net::SocketAddr;
 use std::time::Duration;
 
 use tokio::net::TcpStream;
 use tokio::time::timeout;
-use tracing::debug;
+use tracing::{debug, warn};
 
-pub async fn detect_port_knock(stream: &TcpStream) -> bool {
+use super::proxy_protocol::remote_address;
+
+/// A connection that sends nothing for this long after accept() or PROXY header
+/// is assumed to be a port knock / LB test
+const KNOCK_TIMEOUT: Duration = Duration::from_millis(1000);
+
+/// Connection setup for a freshly accept()'ed stream. If proxy_protocol
+/// is on, reads the header.
+///
+/// Returns None if the connection was a port knock
+pub async fn accept_client(stream: &mut TcpStream, proxy_protocol: bool) -> Option<SocketAddr> {
+    let _ = stream.set_nodelay(true);
+
+    if is_closed(stream, KNOCK_TIMEOUT).await {
+        return None;
+    }
+
+    let address = match remote_address(stream, proxy_protocol).await {
+        Ok(address) => address,
+        Err(error) => {
+            warn!(%error, "Failed to read PROXY protocol header");
+            return None;
+        }
+    };
+
+    // A HAProxy health check sends the header and closes the connection.
+    // Its FIN arrives together with the header, so we don't need to wait
+    if proxy_protocol && is_closed(stream, Duration::ZERO).await {
+        return None;
+    }
+
+    Some(address)
+}
+
+/// Wait for up to `budget` for the stream to send something
+/// If it sends nothing, assume it is a knock and return true
+async fn is_closed(stream: &TcpStream, budget: Duration) -> bool {
     let mut buf = [0u8; 1];
-    match timeout(Duration::from_millis(500), stream.peek(&mut buf)).await {
+    match timeout(budget, stream.peek(&mut buf)).await {
         // Closed
         Ok(Ok(0) | Err(_)) => {
             debug!("Client closed connection immediately");
@@ -14,5 +51,59 @@ pub async fn detect_port_knock(stream: &TcpStream) -> bool {
         }
         // Data or still open
         Ok(Ok(_)) | Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    const V1_HEADER: &[u8] = b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 2222\r\n";
+
+    /// Runs `accept_client` against a client that writes `payload` and then hangs up
+    /// unless `keep_open` holds it.
+    async fn accept(payload: &'static [u8], keep_open: bool) -> Option<SocketAddr> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let client = tokio::spawn(async move {
+            let mut stream = TcpStream::connect(address).await.unwrap();
+            stream.write_all(payload).await.unwrap();
+            stream.flush().await.unwrap();
+            if keep_open {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        });
+
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let result = accept_client(&mut stream, true).await;
+        client.abort();
+        result
+    }
+
+    /// A health check behind `send-proxy` sends a complete header and closes.
+    #[tokio::test]
+    async fn header_then_close_is_a_knock() {
+        assert_eq!(accept(V1_HEADER, false).await, None);
+    }
+
+    #[tokio::test]
+    async fn header_then_protocol_data_is_a_client() {
+        let payload = b"PROXY TCP4 1.2.3.4 5.6.7.8 1111 2222\r\nSSH-2.0-Test\r\n";
+        assert!(accept(payload, true).await.is_some());
+    }
+
+    /// A client that has nothing to say yet (server-speaks-first protocols).
+    #[tokio::test]
+    async fn header_then_silence_is_a_client() {
+        assert!(accept(V1_HEADER, true).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn bare_connect_and_close_is_a_knock() {
+        assert_eq!(accept(b"", false).await, None);
     }
 }

--- a/warpgate-protocol-mysql/src/lib.rs
+++ b/warpgate-protocol-mysql/src/lib.rs
@@ -15,7 +15,7 @@ use rustls::ServerConfig;
 use rustls::server::NoClientAuth;
 use tracing::{Instrument, error, info, warn};
 use warpgate_common::ListenEndpoint;
-use warpgate_common::helpers::net::detect_port_knock;
+use warpgate_common::helpers::net::accept_client;
 use warpgate_core::{ProtocolServer, Services, SessionStateInit, State};
 use warpgate_tls::{ResolveServerCert, TlsCertificateAndPrivateKey};
 
@@ -64,21 +64,8 @@ impl ProtocolServer for MySQLProtocolServer {
                     return Ok(());
                 };
 
-                let _ = stream.set_nodelay(true);
-                if detect_port_knock(&stream).await {
+                let Some(remote_address) = accept_client(&mut stream, proxy_protocol).await else {
                     continue;
-                }
-                let remote_address = match warpgate_common::helpers::proxy_protocol::remote_address(
-                    &mut stream,
-                    proxy_protocol,
-                )
-                .await
-                {
-                    Ok(remote_address) => remote_address,
-                    Err(error) => {
-                        warn!(%error, "Failed to read PROXY protocol header");
-                        continue;
-                    }
                 };
 
                 let tls_config = tls_config.clone();

--- a/warpgate-protocol-postgres/src/lib.rs
+++ b/warpgate-protocol-postgres/src/lib.rs
@@ -19,7 +19,7 @@ use session_handle::PostgresSessionHandle;
 use socket2::{Socket, TcpKeepalive};
 use tracing::{Instrument, error, info, warn};
 use warpgate_common::ListenEndpoint;
-use warpgate_common::helpers::net::detect_port_knock;
+use warpgate_common::helpers::net::accept_client;
 use warpgate_core::{ProtocolServer, Services, SessionStateInit, State};
 use warpgate_tls::{ResolveServerCert, TlsCertificateAndPrivateKey};
 
@@ -67,21 +67,8 @@ impl ProtocolServer for PostgresProtocolServer {
                     return Ok(());
                 };
 
-                if detect_port_knock(&stream).await {
+                let Some(remote_address) = accept_client(&mut stream, proxy_protocol).await else {
                     continue;
-                }
-
-                let remote_address = match warpgate_common::helpers::proxy_protocol::remote_address(
-                    &mut stream,
-                    proxy_protocol,
-                )
-                .await
-                {
-                    Ok(remote_address) => remote_address,
-                    Err(error) => {
-                        warn!(%error, "Failed to read PROXY protocol header");
-                        continue;
-                    }
                 };
 
                 // Enable TCP keepalive to prevent idle connections from timing out

--- a/warpgate-protocol-rdp/src/server/mod.rs
+++ b/warpgate-protocol-rdp/src/server/mod.rs
@@ -28,7 +28,7 @@ use tokio::sync::mpsc::{Sender, UnboundedReceiver, UnboundedSender, channel, unb
 use tokio::time::{Instant, timeout_at};
 use tokio_stream::StreamExt;
 use tracing::{Instrument, debug, error, info, info_span, warn};
-use warpgate_common::helpers::net::detect_port_knock;
+use warpgate_common::helpers::net::accept_client;
 use warpgate_common::{ListenEndpoint, Protocol, Target, TargetOptions, TargetRdpOptions};
 use warpgate_core::recordings::DesktopRecorder;
 use warpgate_core::{
@@ -92,21 +92,8 @@ pub async fn bind_server(
 
     Ok(async move {
         while let Some(mut stream) = listener.next().await {
-            let _ = stream.set_nodelay(true);
-            if detect_port_knock(&stream).await {
+            let Some(remote_address) = accept_client(&mut stream, proxy_protocol).await else {
                 continue;
-            }
-            let remote_address = match warpgate_common::helpers::proxy_protocol::remote_address(
-                &mut stream,
-                proxy_protocol,
-            )
-            .await
-            {
-                Ok(remote_address) => remote_address,
-                Err(error) => {
-                    warn!(%error, "Failed to read PROXY protocol header");
-                    continue;
-                }
             };
 
             let services = services.clone();

--- a/warpgate-protocol-ssh/src/server/mod.rs
+++ b/warpgate-protocol-ssh/src/server/mod.rs
@@ -22,7 +22,7 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc::unbounded_channel;
 use tracing::*;
 use warpgate_common::ListenEndpoint;
-use warpgate_common::helpers::net::detect_port_knock;
+use warpgate_common::helpers::net::accept_client;
 use warpgate_core::{Services, SessionStateInit, State};
 use warpgate_db_entities::Parameters;
 
@@ -75,15 +75,9 @@ async fn _handle_connection(
     mut stream: TcpStream,
     proxy_protocol: bool,
 ) -> Result<()> {
-    stream.set_nodelay(true)?;
-
-    if detect_port_knock(&stream).await {
+    let Some(remote_address) = accept_client(&mut stream, proxy_protocol).await else {
         return Ok(());
-    }
-
-    let remote_address =
-        warpgate_common::helpers::proxy_protocol::remote_address(&mut stream, proxy_protocol)
-            .await?;
+    };
 
     let (session_handle, session_handle_rx) = SSHSessionHandle::new();
 

--- a/warpgate-protocol-vnc/src/server/mod.rs
+++ b/warpgate-protocol-vnc/src/server/mod.rs
@@ -21,7 +21,7 @@ use tokio::time::{Instant, timeout_at};
 use tokio_rustls::TlsAcceptor;
 use tokio_stream::StreamExt;
 use tracing::{Instrument, debug, error, info, info_span, warn};
-use warpgate_common::helpers::net::detect_port_knock;
+use warpgate_common::helpers::net::accept_client;
 use warpgate_common::{ListenEndpoint, Protocol, Target, TargetOptions, TargetVncOptions};
 use warpgate_core::recordings::DesktopRecorder;
 use warpgate_core::{Services, SessionStateInit, State, WarpgateServerHandle};
@@ -64,21 +64,8 @@ pub async fn bind_server(
 
     Ok(async move {
         while let Some(mut stream) = listener.next().await {
-            let _ = stream.set_nodelay(true);
-            if detect_port_knock(&stream).await {
+            let Some(remote_address) = accept_client(&mut stream, proxy_protocol).await else {
                 continue;
-            }
-            let remote_address = match warpgate_common::helpers::proxy_protocol::remote_address(
-                &mut stream,
-                proxy_protocol,
-            )
-            .await
-            {
-                Ok(remote_address) => remote_address,
-                Err(error) => {
-                    warn!(%error, "Failed to read PROXY protocol header");
-                    continue;
-                }
             };
 
             let tls_config = tls_config.clone();


### PR DESCRIPTION
## Description

...

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
