### PR TITLE
feat(helm): add service.externalTrafficPolicy to preserve client source IP

### DIFF
--- a/helm/warpgate/templates/service.yaml
+++ b/helm/warpgate/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- end}}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}

--- a/helm/warpgate/values.yaml
+++ b/helm/warpgate/values.yaml
@@ -148,6 +148,11 @@ setup:
 service:
   annotations: {}
   type: ClusterIP
+  # For LoadBalancer/NodePort services, set to "Local" to preserve the client
+  # source IP - required for accurate audit logging and login protection on the
+  # L4 listeners (SSH/RDP/MySQL/PostgreSQL). Empty uses the cluster default
+  # ("Cluster"), which SNATs the connection and hides the real client IP.
+  externalTrafficPolicy: ""
   ports:
     ssh: 2222
     http: 8888


### PR DESCRIPTION
Warpgate's L4 listeners (SSH/RDP/MySQL/PostgreSQL) are exposed through a `LoadBalancer` Service. With the default `externalTrafficPolicy: Cluster`, kube-proxy SNATs incoming connections, so Warpgate sees the cluster/node IP instead of the real client. This breaks the audit trail and the IP-based login protection — both of which the admin **Network status** page explicitly warns about ("Your setup must ensure that Warpgate can see the actual client's IP address...").

This adds an optional `service.externalTrafficPolicy` value:

- rendered only when `service.type` is `LoadBalancer` or `NodePort`;
- **empty by default**, so existing installs are unchanged (the API server keeps applying the `Cluster` default);
- set it to `Local` to preserve the client source IP.

Verified with `helm template`: the field renders only when set (`--set service.type=LoadBalancer --set service.externalTrafficPolicy=Local`) and is absent with defaults.