### PR TITLE
Ensure check-host-key returns host key from the actual host being checked, not from first jump host

### DIFF
--- a/warpgate-admin/src/api/ssh_connection_test.rs
+++ b/warpgate-admin/src/api/ssh_connection_test.rs
@@ -1,6 +1,7 @@
 use poem_openapi::payload::{Json, PlainText};
 use poem_openapi::{ApiResponse, Object, OpenApi};
-use russh::keys::PublicKeyBase64;
+use russh::keys::{PublicKey, PublicKeyBase64};
+use tracing::{info, warn};
 use uuid::Uuid;
 use warpgate_common::{AdminPermission, WarpgateError};
 use warpgate_protocol_ssh::{RCCommand, RCEvent, RemoteClient, resolve_ssh_chain};
@@ -45,7 +46,7 @@ impl Api {
         let ssh_chain = resolve_ssh_chain(admin.services(), body.target_id, admin.auth.username())
             .await?
             .into_iter()
-            .map(|x| x.ssh_options)
+            .map(|x| (x.target_id, x.ssh_options))
             .collect::<Vec<_>>();
 
         let mut handles = RemoteClient::create(Uuid::new_v4(), admin.services().clone())?;
@@ -54,12 +55,18 @@ impl Api {
             .send((RCCommand::Connect(ssh_chain), None));
 
         let fut = async move {
-            let key = loop {
+            let key: PublicKey = loop {
                 match handles.event_rx.recv().await {
-                    Some(RCEvent::HostKeyReceived(key)) => break key,
-                    Some(RCEvent::HostKeyUnknown(key, reply)) => {
-                        let _ = reply.send(true);
-                        break key;
+                    Some(RCEvent::HostKeyReceived(target_id, key)) => {
+                        if body.target_id == target_id {
+                            break key;
+                        }
+                    }
+                    Some(RCEvent::HostKeyUnknown(target_id, key, reply)) => {
+                        let _ = reply.send(false);
+                        if body.target_id == target_id {
+                            break key;
+                        }
                     }
                     Some(RCEvent::ConnectionError(err)) => return Err(anyhow::Error::from(err)),
                     Some(RCEvent::Error(err)) => return Err(err),

--- a/warpgate-protocol-ssh/src/client/handler.rs
+++ b/warpgate-protocol-ssh/src/client/handler.rs
@@ -1,9 +1,11 @@
 use russh::Channel;
 use russh::client::{ChannelOpenHandle, Msg, Session};
 use russh::keys::{PublicKey, PublicKeyBase64};
+use sea_orm::sea_query::ExprTrait;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 use tracing::*;
+use uuid::Uuid;
 use warpgate_common::{SessionId, TargetSSHOptions};
 use warpgate_core::Services;
 use warpgate_db_entities::Parameters;

--- a/warpgate-protocol-ssh/src/client/mod.rs
+++ b/warpgate-protocol-ssh/src/client/mod.rs
@@ -78,6 +78,7 @@ pub enum ConnectionError {
 }
 
 pub struct ResolvedSshChainHost {
+    pub target_id: Uuid,
     pub name: String,
     pub ssh_options: TargetSSHOptions,
 }
@@ -158,6 +159,7 @@ pub async fn resolve_ssh_chain(
         }
 
         jumps.push(ResolvedSshChainHost {
+            target_id: id,
             name: t.name.clone(),
             ssh_options: opts,
         });
@@ -192,8 +194,8 @@ pub enum RCEvent {
     HopConnected,
     // ForwardedTCPIP(Uuid, DirectTCPIPParams),
     Done,
-    HostKeyReceived(PublicKey),
-    HostKeyUnknown(PublicKey, oneshot::Sender<bool>),
+    HostKeyReceived(Uuid, PublicKey),
+    HostKeyUnknown(Uuid, PublicKey, oneshot::Sender<bool>),
     ForwardedTcpIp(Uuid, ForwardedTcpIpParams),
     ForwardedStreamlocal(Uuid, ForwardedStreamlocalParams),
     ForwardedAgent(Uuid),
@@ -223,7 +225,7 @@ impl RCEvent {
             | Self::ConnectionError(_)
             | Self::HopConnected
             | Self::Done
-            | Self::HostKeyReceived(_)
+            | Self::HostKeyReceived(_, _)
             | Self::HostKeyUnknown(..)
             | Self::ForwardedTcpIp(..)
             | Self::ForwardedStreamlocal(..)
@@ -237,7 +239,7 @@ pub type RCCommandReply = oneshot::Sender<Result<(), SshClientError>>;
 
 #[derive(Clone, Debug)]
 pub enum RCCommand {
-    Connect(Vec<TargetSSHOptions>),
+    Connect(Vec<(Uuid, TargetSSHOptions)>),
     Channel(Uuid, ChannelOperation),
     ForwardTCPIP(String, u32),
     CancelTCPIPForward(String, u32),
@@ -649,11 +651,11 @@ impl RemoteClient {
     /// `channel_open_direct_tcpip` through the previous session.
     async fn connect_chain(
         &mut self,
-        chain: Vec<TargetSSHOptions>,
+        chain: Vec<(Uuid, TargetSSHOptions)>,
     ) -> Result<(Handle<ClientHandler>, UnboundedReceiver<ClientHandlerEvent>), ConnectionError>
     {
         let mut iter = chain.into_iter();
-        let first = iter.next().ok_or(ConnectionError::Resolve)?;
+        let (first_id, first) = iter.next().ok_or(ConnectionError::Resolve)?;
 
         let config = self.build_ssh_config(&first).await;
         let address_str = format!("{}:{}", first.host, first.port);
@@ -672,11 +674,11 @@ impl RemoteClient {
         };
         let fut = russh::client::connect(config, address, handler);
         let (mut session, mut active_rx) = self
-            .wait_for_connection(&first, fut, event_rx, false)
+            .wait_for_connection(first_id, &first, fut, event_rx, false)
             .boxed()
             .await?;
 
-        for ssh_options in iter {
+        for (target_id, ssh_options) in iter {
             let _ = self.tx.send(RCEvent::HopConnected).await;
             info!(
                 host = %ssh_options.host,
@@ -703,7 +705,7 @@ impl RemoteClient {
             };
             let fut = russh::client::connect_stream(config, stream, handler);
             let (new_session, new_rx) = self
-                .wait_for_connection(&ssh_options, fut, event_rx, false)
+                .wait_for_connection(target_id, &ssh_options, fut, event_rx, false)
                 .boxed()
                 .await?;
             session = new_session;
@@ -713,7 +715,10 @@ impl RemoteClient {
         Ok((session, active_rx))
     }
 
-    async fn connect(&mut self, chain: Vec<TargetSSHOptions>) -> Result<(), ConnectionError> {
+    async fn connect(
+        &mut self,
+        chain: Vec<(Uuid, TargetSSHOptions)>,
+    ) -> Result<(), ConnectionError> {
         let (session, mut event_rx) = self.connect_chain(chain).boxed().await?;
 
         self.session = Some(Arc::new(Mutex::new(session)));
@@ -739,6 +744,7 @@ impl RemoteClient {
 
     async fn wait_for_connection<Fut>(
         &mut self,
+        target_id: Uuid,
         ssh_options: &TargetSSHOptions,
         fut_connect: Fut,
         mut event_rx: UnboundedReceiver<ClientHandlerEvent>,
@@ -754,10 +760,10 @@ impl RemoteClient {
                 Some(event) = event_rx.recv() => {
                     match event {
                         ClientHandlerEvent::HostKeyReceived(key) => {
-                            self.tx.send(RCEvent::HostKeyReceived(key)).await.map_err(|_| ConnectionError::Internal)?;
+                            self.tx.send(RCEvent::HostKeyReceived(target_id, key)).await.map_err(|_| ConnectionError::Internal)?;
                         }
                         ClientHandlerEvent::HostKeyUnknown(key, reply) => {
-                            self.tx.send(RCEvent::HostKeyUnknown(key, reply)).await.map_err(|_| ConnectionError::Internal)?;
+                            self.tx.send(RCEvent::HostKeyUnknown(target_id, key, reply)).await.map_err(|_| ConnectionError::Internal)?;
                         }
                         _ => {}
                     }

--- a/warpgate-protocol-ssh/src/server/session.rs
+++ b/warpgate-protocol-ssh/src/server/session.rs
@@ -502,7 +502,10 @@ impl ServerSession {
         let visual_chain = self.make_visual_connection_chain(&ssh_chain[..]).await?;
         self.rc_state = RCState::Connecting;
         self.send_command(RCCommand::Connect(
-            ssh_chain.into_iter().map(|x| x.ssh_options).collect(),
+            ssh_chain
+                .into_iter()
+                .map(|x| (authorization.target().id, x.ssh_options))
+                .collect(),
         ))
         .map_err(|_| anyhow::anyhow!("cannot send command"))?;
         self.emit_pty_output(b"\r\n").await?;
@@ -1172,8 +1175,8 @@ impl ServerSession {
                     return self.fail_on_channel_writer_error(error).await;
                 }
             }
-            RCEvent::Done | RCEvent::HostKeyReceived(_) => {}
-            RCEvent::HostKeyUnknown(key, reply) => {
+            RCEvent::Done | RCEvent::HostKeyReceived(_, _) => {}
+            RCEvent::HostKeyUnknown(_, key, reply) => {
                 self.handle_unknown_host_key(key, reply).await?;
             }
             RCEvent::ForwardedTcpIp(id, params) => {

--- a/warpgate-web-ssh/src/manager.rs
+++ b/warpgate-web-ssh/src/manager.rs
@@ -126,7 +126,7 @@ impl WebSshClientManager {
         let ssh_chain = resolve_ssh_chain(services, target.id, Some(&username))
             .await?
             .into_iter()
-            .map(|x| x.ssh_options)
+            .map(|x| (x.target_id, x.ssh_options))
             .collect::<Vec<_>>();
         rc_handles
             .command_tx
@@ -210,10 +210,10 @@ fn spawn_event_loop(
                                 })
                                 .await;
                         }
-                        RCEvent::HostKeyReceived(key) => {
+                        RCEvent::HostKeyReceived(target_id, key) => {
                             debug!(%session_id, "Host key received: {}", key.algorithm());
                         }
-                        RCEvent::HostKeyUnknown(key, reply) => {
+                        RCEvent::HostKeyUnknown(target_id, key, reply) => {
                             let mode = match Parameters::Entity::get(&services.db).await {
                                 Ok(p) => p.ssh_host_key_verification,
                                 Err(e) => {


### PR DESCRIPTION
## Description
When resolving the ssh chain, track the `target_id` for each host, and feed it back into the raised `HostKeyReceived` / `HostKeyUnknown`  `RCEvent`s, so that the procedure can match the one for the actual check target and break out only for it.
Fixes #2412

The implementation can be improved, I'm not too fond of having the target_id being a tuple field in multiple places.
Firing this off so it can receive review and feedback before being finalized.  

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [x] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)