### PR TITLE
fixed #2392 - cast the log `values` JSON column to text when searching

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -276,7 +276,11 @@ ADMIN_API_TEST_CASES: list[AdminApiTestCase] = [
     AdminApiTestCase(
         id="get_logs",
         permission=None,
-        call=lambda api, r: api.get_logs_with_http_info(sdk.GetLogsRequest(search="")),
+        # A non-empty search is what actually exercises the filter - an empty one
+        # is skipped, hiding e.g. Postgres rejecting lower() on the JSON column
+        call=lambda api, r: api.get_logs_with_http_info(
+            sdk.GetLogsRequest(search="test")
+        ),
         expected_statuses={200},
     ),
     AdminApiTestCase(

--- a/warpgate-admin/src/api/common.rs
+++ b/warpgate-admin/src/api/common.rs
@@ -1,6 +1,6 @@
 use sea_orm::prelude::Expr;
-use sea_orm::sea_query::{Func, IntoCondition};
-use sea_orm::{ColumnTrait, Condition, EntityTrait, ModelTrait, QueryFilter};
+use sea_orm::sea_query::{Alias, Func, IntoCondition, SimpleExpr};
+use sea_orm::{ColumnTrait, Condition, DbBackend, EntityTrait, ModelTrait, QueryFilter};
 use warpgate_common::{AdminPermission, AdminPermissionSet, WarpgateError};
 pub use warpgate_common_http::RequestAuthorization;
 use warpgate_db_entities::{AdminRole, User};
@@ -79,11 +79,32 @@ where
     C: ColumnTrait,
     I: IntoIterator<Item = C>,
 {
+    case_insensitive_search_expr(search, columns.into_iter().map(|c| Expr::col(c).into()))
+}
+
+/// [`case_insensitive_search`] over arbitrary expressions, for columns that need
+/// to be coerced into text first - see [`json_as_text`].
+pub fn case_insensitive_search_expr<I>(search: &str, expressions: I) -> impl IntoCondition
+where
+    I: IntoIterator<Item = SimpleExpr>,
+{
     let search_pattern = format!("%{}%", search.to_lowercase());
 
-    columns
+    expressions
         .into_iter()
-        .fold(Condition::any(), |condition, column| {
-            condition.add(Expr::expr(Func::lower(Expr::col(column))).like(search_pattern.clone()))
+        .fold(Condition::any(), |condition, expression| {
+            condition.add(Expr::expr(Func::lower(expression)).like(search_pattern.clone()))
         })
+}
+
+/// Casts a JSON column to text so that string functions such as `lower()` can be
+/// applied to it.
+///
+/// Postgres has no `lower(json)` overload and won't coerce implicitly, unlike
+/// SQLite and MySQL. MySQL in turn spells the cast target `char`, not `text`.
+pub fn json_as_text<C: ColumnTrait>(backend: DbBackend, column: C) -> SimpleExpr {
+    Expr::col(column).cast_as(match backend {
+        DbBackend::MySql => Alias::new("char"),
+        DbBackend::Postgres | DbBackend::Sqlite => Alias::new("text"),
+    })
 }

--- a/warpgate-admin/src/api/logs.rs
+++ b/warpgate-admin/src/api/logs.rs
@@ -1,13 +1,14 @@
 use poem_openapi::payload::Json;
 use poem_openapi::{ApiResponse, Object, OpenApi};
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
+use sea_orm::prelude::Expr;
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
 use time::OffsetDateTime;
 use uuid::Uuid;
 use warpgate_common::WarpgateError;
 use warpgate_db_entities::LogEntry;
 
 use super::AdminContext;
-use crate::api::common::case_insensitive_search;
+use crate::api::common::{case_insensitive_search_expr, json_as_text};
 
 pub struct Api;
 
@@ -81,12 +82,13 @@ impl Api {
         if let Some(ref search) = body.search
             && !search.is_empty()
         {
-            q = q.filter(case_insensitive_search(
+            q = q.filter(case_insensitive_search_expr(
                 search,
                 [
-                    LogEntry::Column::Text,
-                    LogEntry::Column::Username,
-                    LogEntry::Column::Values,
+                    Expr::col(LogEntry::Column::Text).into(),
+                    Expr::col(LogEntry::Column::Username).into(),
+                    // `values` is a JSON column and needs an explicit cast on Postgres
+                    json_as_text(db.get_database_backend(), LogEntry::Column::Values),
                 ],
             ));
         }


### PR DESCRIPTION
## Description

Fixes #2392.

`POST /@warpgate/admin/api/logs` returns a 500 for any non-empty `search` on Postgres:

```
error returned from database: function lower(json) does not exist
```

`case_insensitive_search` wraps each column in `lower()`, and `log.values` is a JSON
column. Postgres has no `lower(json)` overload and won't coerce implicitly — SQLite and
MySQL do, which is why this only surfaces on Postgres.

The `values` column is now cast to text before `lower()` is applied. `case_insensitive_search`
gains an expression-taking sibling so the other five call sites, which are all plain text
columns, are left alone. MySQL spells the cast target `char` rather than `text`, hence the
match on the backend.

`tests/test_api.py` already runs against Postgres, but its `get_logs` case passed
`search=""` — which short-circuits the filter entirely, so the broken path was never
exercised. It now passes a non-empty search.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
