### PR TITLE
Reformat with biome 2.5.6 and ignore the lru advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -74,6 +74,7 @@ ignore = [
     "RUSTSEC-2026-0104", # an older pinned version of rustls-webpki used by AWS SDK
     "RUSTSEC-2026-0173", # proc-macro-error2 is unmaintained - waiting for a sea-orm update
     "RUSTSEC-2026-0195", # quick-xml memory exhaustion - we don't parse untrusted XML
+    "RUSTSEC-2026-0253", # lru: unsound LruCache::pop - an old version pinned by aws-sdk-s3
     "RUSTSEC-2026-0194", # quick-xml quadratic time - see above
     "RUSTSEC-2021-0141", # dotenv is unmaintaned - only used for dev
 ]

--- a/warpgate-web/package.json
+++ b/warpgate-web/package.json
@@ -12,7 +12,7 @@
         "check": "svelte-check --compiler-warnings 'a11y-no-noninteractive-element-interactions:ignore,a11y-click-events-have-key-events:ignore,a11y-no-static-element-interactions:ignore' --tsconfig ./tsconfig.json",
         "lint": "npm run biome && svelte-check",
         "biome": "biome",
-        "format": "biome format --fix",
+        "format": "biome check --fix && biome format --fix",
         "postinstall": "npm run openapi:client:gateway && npm run openapi:client:admin",
         "openapi:schema:gateway": "cargo run -p warpgate-protocol-http > src/gateway/lib/openapi-schema.json",
         "openapi:schema:admin": "cargo run -p warpgate-admin > src/admin/lib/openapi-schema.json",

--- a/warpgate-web/src/admin/config/users/AuthPolicyEditor.svelte
+++ b/warpgate-web/src/admin/config/users/AuthPolicyEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { faWarning } from '@fortawesome/free-solid-svg-icons'
     import { Alert, Input, Tooltip } from '@sveltestrap/sveltestrap'
     import {
         CredentialKind,
@@ -6,9 +7,8 @@
     } from 'admin/lib/api'
     import InfoBox from 'common/InfoBox.svelte'
     import { SvelteSet } from 'svelte/reactivity'
-    import type { ExistingCredential } from './CredentialEditor.svelte'
     import Fa from 'svelte-fa'
-    import { faWarning } from '@fortawesome/free-solid-svg-icons'
+    import type { ExistingCredential } from './CredentialEditor.svelte'
 
     type ProtocolID =
         | 'http'
@@ -179,10 +179,7 @@
                     on:change={() => toggle(type)}
                 />
                 {#if enabled && !isAvailable(type)}
-                    <Fa
-                        icon={faWarning}
-                        class="text-warning"
-                    />
+                    <Fa icon={faWarning} class="text-warning" />
                 {/if}
             </div>
             {#if disabled}

--- a/warpgate-web/src/common/CollapsibleBlock.svelte
+++ b/warpgate-web/src/common/CollapsibleBlock.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import { faChevronRight } from '@fortawesome/free-solid-svg-icons'
+    import { autosave } from 'common/autosave'
     import type { Snippet } from 'svelte'
     import Fa from 'svelte-fa'
-    import { autosave } from 'common/autosave'
 
     interface Props {
         label: string

--- a/warpgate-web/src/common/ConnectionInstructions.svelte
+++ b/warpgate-web/src/common/ConnectionInstructions.svelte
@@ -211,7 +211,10 @@
         label="Example SSH command"
         value={makeExampleSSHCommand(opts)}
     />
-    <CollapsibleBlock label="Advanced" persistKey="connectionInstructionsAdvancedOpen">
+    <CollapsibleBlock
+        label="Advanced"
+        persistKey="connectionInstructionsAdvancedOpen"
+    >
         <div class="mt-3">
             <CopyableTextArea
                 label="Example SCP command"
@@ -247,7 +250,10 @@
         label="Example MySQL command"
         value={makeExampleMySQLCommand(opts)}
     />
-    <CollapsibleBlock label="Advanced" persistKey="connectionInstructionsAdvancedOpen">
+    <CollapsibleBlock
+        label="Advanced"
+        persistKey="connectionInstructionsAdvancedOpen"
+    >
         <div class="mt-3">
             <CopyableTextArea
                 label="Example database URL"
@@ -275,7 +281,10 @@
         label="Example PostgreSQL command"
         value={makeExamplePostgreSQLCommand(opts)}
     />
-    <CollapsibleBlock label="Advanced" persistKey="connectionInstructionsAdvancedOpen">
+    <CollapsibleBlock
+        label="Advanced"
+        persistKey="connectionInstructionsAdvancedOpen"
+    >
         <div class="mt-3">
             <CopyableTextArea
                 label="Example database URL"


### PR DESCRIPTION
Two CI checks fail on every recently-run pull request against `main`, and neither is caused by the branch they fail on. Both are one-line-scale fixes.

## Description

### biome — three files drifted, and nothing on `main` checks them

`.github/workflows/biome.yml` runs `on: [pull_request]` only, so `main` itself is never formatted-checked. Three files were changed by merges that did not run the formatter:

| file | last changed |
|---|---|
| `warpgate-web/src/admin/config/users/AuthPolicyEditor.svelte` | 55af452e6, 11 Aug |
| `warpgate-web/src/common/CollapsibleBlock.svelte` | ce970460a, 12 Aug |
| `warpgate-web/src/common/ConnectionInstructions.svelte` | ce970460a, 12 Aug |

Every pull request opened or updated since then inherits the four errors: formatting in `AuthPolicyEditor` and `ConnectionInstructions`, import order in `CollapsibleBlock`. `biome check --write` is the whole change; no behaviour is
touched.

### cargo-deny — an advisory in a transitive dependency we cannot raise

`RUSTSEC-2026-0253`, an unsound `LruCache::pop` in `lru` 0.16.4. That version is pinned by `aws-sdk-s3` 1.137.0 and cannot be raised from here: the fix landed in `lru` 0.18.2, which is a breaking change for a `0.x` crate. The other `lru` in
the tree — 0.18.2, via `ratatui-core` — is unaffected.

Added to the existing ignore list beside `RUSTSEC-2026-0104`, which is there for the same reason and the same SDK. Happy to drop this hunk if you would rather wait for an `aws-sdk-s3` bump.

### Pull requests currently red for these two reasons

#2432, #2429, #2427, #2413, #2397 — every open PR whose checks have run since 12 August. (#2396 and #2387 are green only because their last run predates the drift.)

### Verified with the versions the workflows pin

`biome` 2.5.6, per `.github/workflows/biome.yml`:

```
Checked 154 files. No fixes applied.
```

`cargo-deny` 0.18.9, per `.github/workflows/cargo-deny.yml`:

```
advisories ok, bans ok, licenses ok, sources ok
```

Worth using the pinned versions rather than whatever is installed locally:
`cargo-deny` 0.20.2 passes on `main` **without** this change, because it treats
the `unsound` class differently, so confirming against it would prove nothing.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*