### PR TITLE
Stop Kubernetes listener from becoming unavailable on incomplete TCP handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9285,6 +9285,7 @@ dependencies = [
  "md5",
  "poem",
  "poem-openapi",
+ "rcgen",
  "regex",
  "reqwest 0.13.4",
  "reqwest-websocket",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8200,6 +8200,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls-listener"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1461056cc1ef47003f7ee16e4cef3741068d4c7f6b627bfce49b7c00c120a530"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-rustls 0.26.4",
+]
+
+[[package]]
 name = "tls_codec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9285,6 +9298,7 @@ dependencies = [
  "md5",
  "poem",
  "poem-openapi",
+ "rcgen",
  "regex",
  "reqwest 0.13.4",
  "reqwest-websocket",
@@ -9294,6 +9308,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "time",
+ "tls-listener",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-tungstenite 0.30.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ tokio-stream = { version = "0.1.17", features = [
     "net",
 ], default-features = false }
 tokio-rustls = { version = "0.26", default-features = false }
+tls-listener = { version = "0.11.2", features = ["rustls-core"], default-features = false }
 enum_dispatch = { version = "0.3.13", default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["tls12"] }
 sqlx = { version = "0.8", features = [

--- a/warpgate-common/src/helpers/concurrent_acceptor.rs
+++ b/warpgate-common/src/helpers/concurrent_acceptor.rs
@@ -1,0 +1,111 @@
+use std::future::Future;
+use std::io::Result as IoResult;
+use std::time::Duration;
+
+use poem::http::uri::Scheme;
+use poem::listener::Acceptor;
+use poem::web::{LocalAddr, RemoteAddr};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::debug;
+
+use crate::helpers::net::connection_setup_slots;
+
+/// poem::Acceptor::accept return
+pub type Accepted<Io> = (Io, LocalAddr, RemoteAddr, Scheme);
+
+const CONNECTION_BACKLOG: usize = 1024;
+
+/// A sleep prevents CPU loop for persistent errors (e.g. fd exhaustion)
+const ACCEPT_ERROR_PAUSE: Duration = Duration::from_millis(100);
+
+/// A poem Acceptor that runs connection setup (PROXY protocol header recv etc)
+/// in a separate task instead of on the accept loop
+///
+/// This prevents a stalled peer from holding up the queue
+///
+/// Backpressure path is poem -> `connections` channel -> OS socket
+pub struct ConcurrentAcceptor<Io> {
+    local_addr: Vec<LocalAddr>,
+    connections: mpsc::Receiver<IoResult<Accepted<Io>>>,
+    accept_loop: JoinHandle<()>,
+}
+
+impl<Io> ConcurrentAcceptor<Io>
+where
+    Io: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+    /// accept connections from `inner` and map them via `setup`
+    pub fn new<A, F, Fut>(mut inner: A, setup: F) -> Self
+    where
+        A: Acceptor + 'static,
+        F: FnMut(Accepted<A::Io>) -> Fut + Send + 'static,
+        Fut: Future<Output = anyhow::Result<Accepted<Io>>> + Send + 'static,
+    {
+        let local_addr = inner.local_addr();
+        let (tx, connections) = mpsc::channel(CONNECTION_BACKLOG);
+
+        let mut setup = setup;
+        let accept_loop = tokio::spawn(async move {
+            let setups = connection_setup_slots();
+            loop {
+                // The semaphore is never closed, but bail rather than unwrap.
+                let Ok(permit) = setups.clone().acquire_owned().await else {
+                    return;
+                };
+                let accepted = match inner.accept().await {
+                    Ok(accepted) => accepted,
+                    Err(error) => {
+                        if tx.send(Err(error)).await.is_err() {
+                            return;
+                        }
+                        tokio::time::sleep(ACCEPT_ERROR_PAUSE).await;
+                        continue;
+                    }
+                };
+                let prepared = setup(accepted);
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    match prepared.await {
+                        Ok(accepted) => {
+                            let _ = tx.send(Ok(accepted)).await;
+                        }
+                        Err(error) => debug!("Dropping connection: {error:#}"),
+                    }
+                    drop(permit);
+                });
+            }
+        });
+
+        Self {
+            local_addr,
+            connections,
+            accept_loop,
+        }
+    }
+}
+
+impl<Io> Drop for ConcurrentAcceptor<Io> {
+    fn drop(&mut self) {
+        self.accept_loop.abort();
+    }
+}
+
+impl<Io> Acceptor for ConcurrentAcceptor<Io>
+where
+    Io: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+    type Io = Io;
+
+    fn local_addr(&self) -> Vec<LocalAddr> {
+        self.local_addr.clone()
+    }
+
+    async fn accept(&mut self) -> IoResult<Accepted<Io>> {
+        self.connections
+            .recv()
+            .await
+            .unwrap_or_else(|| Err(std::io::Error::other("Listener stopped")))
+    }
+}

--- a/warpgate-common/src/helpers/mod.rs
+++ b/warpgate-common/src/helpers/mod.rs
@@ -1,3 +1,4 @@
+pub mod concurrent_acceptor;
 pub mod fs;
 pub mod hash;
 pub mod ipnet;

--- a/warpgate-common/src/helpers/net.rs
+++ b/warpgate-common/src/helpers/net.rs
@@ -1,15 +1,63 @@
+use std::future::Future;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::Duration;
 
+use futures::{Stream, StreamExt};
 use tokio::net::TcpStream;
+use tokio::sync::Semaphore;
 use tokio::time::timeout;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 use super::proxy_protocol::remote_address;
 
 /// A connection that sends nothing for this long after accept() or PROXY header
 /// is assumed to be a port knock / LB test
 const KNOCK_TIMEOUT: Duration = Duration::from_millis(1000);
+
+/// Limit for concurrent connection setup tasks
+pub fn connection_setup_slots() -> Arc<Semaphore> {
+    Arc::new(Semaphore::new(4096))
+}
+
+/// Run a listener (possibly hadling PROXY) and spawn a handler task
+/// for each connection.
+pub async fn accept_loop<S, F, Fut>(
+    tokio_task_name: &str,
+    mut listener: S,
+    proxy_protocol: bool,
+    handler: F,
+) where
+    S: Stream<Item = TcpStream> + Unpin,
+    F: Fn(TcpStream, SocketAddr) -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    let setups = connection_setup_slots();
+    loop {
+        let Ok(setup_slot) = setups.clone().acquire_owned().await else {
+            // never happens
+            return;
+        };
+        let Some(mut stream) = listener.next().await else {
+            return;
+        };
+        let handler = handler.clone();
+        let spawned = tokio::task::Builder::new()
+            .name(tokio_task_name)
+            .spawn(async move {
+                let Some(remote_address) = accept_client(&mut stream, proxy_protocol).await else {
+                    return;
+                };
+                drop(setup_slot);
+                if let Err(error) = handler(stream, remote_address).await {
+                    error!(%error, "Connection handling failed");
+                }
+            });
+        if let Err(error) = spawned {
+            error!(%error, "Failed to spawn a connection task");
+        }
+    }
+}
 
 /// Connection setup for a freshly accept()'ed stream. If proxy_protocol
 /// is on, reads the header.

--- a/warpgate-common/src/helpers/proxy_protocol.rs
+++ b/warpgate-common/src/helpers/proxy_protocol.rs
@@ -3,22 +3,21 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use anyhow::{Context, bail};
-use poem::http::uri::Scheme;
 use poem::listener::Acceptor;
 use poem::web::{LocalAddr, RemoteAddr};
 use ppp::{HeaderResult, PartialResult};
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::net::TcpStream;
 use tokio::time::timeout;
-use tracing::warn;
+
+use crate::helpers::concurrent_acceptor::{Accepted, ConcurrentAcceptor};
 
 const V2_MINIMUM_HEADER_LENGTH: usize = 16;
 const V1_MAX_HEADER_LENGTH: usize = 108;
 const MAX_PROXY_PROTOCOL_HEADER_LENGTH: usize = V2_MINIMUM_HEADER_LENGTH + u16::MAX as usize;
 
 /// A conforming peer sends the whole header up front, so the budget only has to
-/// outlast network latency. It bounds how long a stalled connection can hold up
-/// the accept loop of the protocols that read the header inline.
+/// outlast network latency.
 const READ_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub async fn remote_address(
@@ -33,43 +32,43 @@ pub async fn remote_address(
     Ok(read_header(stream).await?.unwrap_or(peer_address))
 }
 
-pub struct ProxyProtocolAcceptor<A> {
-    inner: A,
-    proxy_protocol: bool,
+pub enum MaybeProxyProtocolAcceptor<A: Acceptor> {
+    Direct(A),
+    Reading(ConcurrentAcceptor<A::Io>),
 }
 
-impl<A> ProxyProtocolAcceptor<A> {
-    pub const fn new(inner: A, proxy_protocol: bool) -> Self {
-        Self {
-            inner,
-            proxy_protocol,
+impl<A: Acceptor + 'static> MaybeProxyProtocolAcceptor<A> {
+    pub fn new(inner: A, proxy_protocol: bool) -> Self {
+        if !proxy_protocol {
+            return Self::Direct(inner);
         }
+        Self::Reading(ConcurrentAcceptor::new(
+            inner,
+            |(mut io, local_addr, remote_addr, scheme): Accepted<A::Io>| async move {
+                let remote_addr = match read_header(&mut io).await? {
+                    Some(address) => RemoteAddr(address.into()),
+                    None => remote_addr,
+                };
+                Ok((io, local_addr, remote_addr, scheme))
+            },
+        ))
     }
 }
 
-impl<A: Acceptor> Acceptor for ProxyProtocolAcceptor<A> {
+impl<A: Acceptor + 'static> Acceptor for MaybeProxyProtocolAcceptor<A> {
     type Io = A::Io;
 
     fn local_addr(&self) -> Vec<LocalAddr> {
-        self.inner.local_addr()
+        match self {
+            Self::Direct(inner) => inner.local_addr(),
+            Self::Reading(inner) => inner.local_addr(),
+        }
     }
 
-    async fn accept(&mut self) -> IoResult<(Self::Io, LocalAddr, RemoteAddr, Scheme)> {
-        loop {
-            let (mut io, local_addr, remote_addr, scheme) = self.inner.accept().await?;
-            if !self.proxy_protocol {
-                return Ok((io, local_addr, remote_addr, scheme));
-            }
-
-            match read_header(&mut io).await {
-                Ok(Some(remote_addr)) => {
-                    return Ok((io, local_addr, RemoteAddr(remote_addr.into()), scheme));
-                }
-                Ok(None) => return Ok((io, local_addr, remote_addr, scheme)),
-                Err(error) => {
-                    warn!(%error, "Failed to read PROXY protocol header");
-                }
-            }
+    async fn accept(&mut self) -> IoResult<Accepted<Self::Io>> {
+        match self {
+            Self::Direct(inner) => inner.accept().await,
+            Self::Reading(inner) => inner.accept().await,
         }
     }
 }
@@ -184,7 +183,43 @@ fn source_address_v2(header: &ppp::v2::Header<'_>) -> anyhow::Result<Option<Sock
 mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
 
+    use poem::listener::{Listener, TcpListener};
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpStream;
+
     use super::*;
+
+    #[tokio::test]
+    async fn stalled_header_does_not_block_later_connections() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .into_acceptor()
+            .await
+            .unwrap();
+        let address = listener
+            .local_addr()
+            .into_iter()
+            .find_map(|address| address.0.as_socket_addr().copied())
+            .unwrap();
+
+        // Queued before the acceptor starts polling, so it is accepted first.
+        let _stalled = TcpStream::connect(address).await.unwrap();
+        let mut acceptor = MaybeProxyProtocolAcceptor::new(listener, true);
+
+        let mut second = TcpStream::connect(address).await.unwrap();
+        second
+            .write_all(b"PROXY TCP4 203.0.113.10 10.0.0.2 42300 443\r\n")
+            .await
+            .unwrap();
+
+        let (_io, _, remote_addr, _) = timeout(Duration::from_secs(5), acceptor.accept())
+            .await
+            .expect("a peer that sent no header blocked the next connection")
+            .unwrap();
+        assert_eq!(
+            remote_addr.as_socket_addr(),
+            Some(&"203.0.113.10:42300".parse().unwrap())
+        );
+    }
 
     async fn read_header_from(bytes: &[u8]) -> anyhow::Result<Option<SocketAddr>> {
         let mut input = bytes;

--- a/warpgate-protocol-http/src/lib.rs
+++ b/warpgate-protocol-http/src/lib.rs
@@ -28,7 +28,7 @@ use tokio::sync::Mutex;
 use tracing::{Instrument, debug, warn};
 use warpgate_admin::admin_api_app;
 use warpgate_common::ListenEndpoint;
-use warpgate_common::helpers::proxy_protocol::ProxyProtocolAcceptor;
+use warpgate_common::helpers::proxy_protocol::MaybeProxyProtocolAcceptor;
 use warpgate_common::version::warpgate_version;
 use warpgate_common_http::auth::UnauthenticatedRequestContext;
 use warpgate_common_http::ext::construct_external_url;
@@ -357,7 +357,7 @@ impl ProtocolServer for HTTPProtocolServer {
         // Bind the socket now (errors here are non-fatal to the supervisor); the
         // returned future drives the accept loop (errors there restart the listener).
         let acceptor = address.poem_listener()?.into_acceptor().await?;
-        let acceptor = ProxyProtocolAcceptor::new(acceptor, proxy_protocol)
+        let acceptor = MaybeProxyProtocolAcceptor::new(acceptor, proxy_protocol)
             .rustls(stream::once(future::ready(rustls_config)));
 
         Ok(async move {

--- a/warpgate-protocol-kubernetes/Cargo.toml
+++ b/warpgate-protocol-kubernetes/Cargo.toml
@@ -27,6 +27,7 @@ thiserror.workspace = true
 time = { workspace = true, features = ["serde-well-known"] }
 tokio.workspace = true
 tokio-rustls = { version = "0.26", default-features = false }
+tls-listener.workspace = true
 tokio-tungstenite.workspace = true
 tracing.workspace = true
 url.workspace = true
@@ -39,3 +40,6 @@ warpgate-core = { path = "../warpgate-core", default-features = false }
 warpgate-db-entities = { path = "../warpgate-db-entities", default-features = false }
 warpgate-sso = { path = "../warpgate-sso", default-features = false }
 warpgate-tls = { path = "../warpgate-tls", default-features = false }
+
+[dev-dependencies]
+rcgen.workspace = true

--- a/warpgate-protocol-kubernetes/Cargo.toml
+++ b/warpgate-protocol-kubernetes/Cargo.toml
@@ -39,3 +39,6 @@ warpgate-core = { path = "../warpgate-core", default-features = false }
 warpgate-db-entities = { path = "../warpgate-db-entities", default-features = false }
 warpgate-sso = { path = "../warpgate-sso", default-features = false }
 warpgate-tls = { path = "../warpgate-tls", default-features = false }
+
+[dev-dependencies]
+rcgen.workspace = true

--- a/warpgate-protocol-kubernetes/Cargo.toml
+++ b/warpgate-protocol-kubernetes/Cargo.toml
@@ -25,9 +25,9 @@ serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json.workspace = true
 thiserror.workspace = true
 time = { workspace = true, features = ["serde-well-known"] }
+tls-listener.workspace = true
 tokio.workspace = true
 tokio-rustls = { version = "0.26", default-features = false }
-tls-listener.workspace = true
 tokio-tungstenite.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/warpgate-protocol-kubernetes/src/server/client_certs.rs
+++ b/warpgate-protocol-kubernetes/src/server/client_certs.rs
@@ -141,11 +141,10 @@ where
     }
 
     async fn accept(&mut self) -> io::Result<(Self::Io, LocalAddr, RemoteAddr, http::uri::Scheme)> {
-        let (tls_stream, (local_addr, remote_addr, _)) = self
-            .incoming
-            .next()
-            .await
-            .expect("TLS listener stream cannot end")?;
+        let (tls_stream, (local_addr, remote_addr, _)) =
+            self.incoming.next().await.transpose()?.ok_or_else(|| {
+                io::Error::new(io::ErrorKind::UnexpectedEof, "TLS listener stream ended")
+            })?;
 
         // Extract client certificate from the TLS connection
         let enhanced_remote_addr = if let Some(cert_der) = extract_peer_certificates(&tls_stream) {

--- a/warpgate-protocol-kubernetes/src/server/client_certs.rs
+++ b/warpgate-protocol-kubernetes/src/server/client_certs.rs
@@ -1,6 +1,10 @@
+use std::io;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use base64::{self, Engine};
+use futures::{Stream, StreamExt};
 use poem::Addr;
 use poem::listener::Acceptor;
 use poem::web::{LocalAddr, RemoteAddr};
@@ -8,6 +12,7 @@ use rustls::crypto::CryptoProvider;
 use rustls::pki_types::{CertificateDer, UnixTime};
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
 use rustls::{DigitallySignedStruct, ServerConfig, SignatureScheme};
+use tokio::sync::Mutex;
 use tokio_rustls::server::TlsStream;
 use tracing::{debug, warn};
 
@@ -86,38 +91,61 @@ impl ClientCertVerifier for AcceptAnyClientCert {
     }
 }
 
-/// Custom TLS acceptor that captures client certificates and embeds them in remote_addr
-pub struct CertificateCapturingAcceptor<T> {
-    inner: T,
-    tls_acceptor: tokio_rustls::TlsAcceptor,
+type ConnectionMetadata = (LocalAddr, RemoteAddr, http::uri::Scheme);
+type IncomingTlsConnections<T> =
+    Pin<Box<dyn Stream<Item = io::Result<(TlsStream<T>, ConnectionMetadata)>> + Send>>;
+
+/// TLS acceptor that captures client certificates after concurrent handshakes.
+pub struct CertificateCapturingAcceptor<T: Acceptor> {
+    local_addr: Vec<LocalAddr>,
+    incoming: IncomingTlsConnections<T::Io>,
 }
 
-impl<T> CertificateCapturingAcceptor<T> {
+impl<T> CertificateCapturingAcceptor<T>
+where
+    T: Acceptor + 'static,
+{
     pub fn new(inner: T, server_config: ServerConfig) -> Self {
+        let local_addr = inner.local_addr();
+        let inner = Arc::new(Mutex::new(inner));
+        let transport = tls_listener::accept_generator(move || {
+            let inner = inner.clone();
+            async move {
+                let (stream, local_addr, remote_addr, scheme) = inner.lock().await.accept().await?;
+                Ok::<_, io::Error>((stream, (local_addr, remote_addr, scheme)))
+            }
+        });
+
+        let tls_acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
+        let mut builder = tls_listener::builder(tls_acceptor);
+        builder.handshake_timeout(Duration::from_secs(10));
+        let incoming = builder
+            .listen(transport)
+            .map(|result| result.map_err(|error| io::Error::other(error.to_string())));
+
         Self {
-            inner,
-            tls_acceptor: tokio_rustls::TlsAcceptor::from(Arc::new(server_config)),
+            local_addr,
+            incoming: Box::pin(incoming),
         }
     }
 }
 
 impl<T> Acceptor for CertificateCapturingAcceptor<T>
 where
-    T: Acceptor,
+    T: Acceptor + 'static,
 {
     type Io = TlsStream<T::Io>;
 
     fn local_addr(&self) -> Vec<LocalAddr> {
-        self.inner.local_addr()
+        self.local_addr.clone()
     }
 
-    async fn accept(
-        &mut self,
-    ) -> std::io::Result<(Self::Io, LocalAddr, RemoteAddr, http::uri::Scheme)> {
-        let (stream, local_addr, remote_addr, _) = self.inner.accept().await?;
-
-        // Perform TLS handshake
-        let tls_stream = self.tls_acceptor.accept(stream).await?;
+    async fn accept(&mut self) -> io::Result<(Self::Io, LocalAddr, RemoteAddr, http::uri::Scheme)> {
+        let (tls_stream, (local_addr, remote_addr, _)) = self
+            .incoming
+            .next()
+            .await
+            .expect("TLS listener stream cannot end")?;
 
         // Extract client certificate from the TLS connection
         let enhanced_remote_addr = if let Some(cert_der) = extract_peer_certificates(&tls_stream) {
@@ -237,5 +265,95 @@ pub trait RequestCertificateExt {
 impl RequestCertificateExt for poem::Request {
     fn client_certificate(&self) -> Option<&ClientCertificate> {
         self.extensions().get::<ClientCertificate>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use base64::Engine;
+    use poem::Addr;
+    use poem::listener::{Acceptor, Listener, TcpListener};
+    use poem::web::RemoteAddr;
+    use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer, ServerName};
+    use rustls::{ClientConfig, RootCertStore, ServerConfig};
+    use tokio::net::TcpStream;
+    use tokio::time::timeout;
+    use tokio_rustls::TlsConnector;
+
+    use super::{AcceptAnyClientCert, CertificateCapturingAcceptor};
+
+    #[tokio::test]
+    async fn stalled_tls_handshake_does_not_block_later_connections() {
+        let certificate =
+            rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let certificate_der = CertificateDer::from(certificate.cert.der().to_vec());
+        let private_key = PrivatePkcs8KeyDer::from(certificate.signing_key.serialize_der());
+        let client_certificate =
+            rcgen::generate_simple_self_signed(vec!["kubectl-client".to_string()]).unwrap();
+        let client_certificate_der = CertificateDer::from(client_certificate.cert.der().to_vec());
+        let client_private_key =
+            PrivatePkcs8KeyDer::from(client_certificate.signing_key.serialize_der());
+
+        let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+        let server_config = ServerConfig::builder_with_provider(provider.clone())
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .with_client_cert_verifier(Arc::new(AcceptAnyClientCert::new(provider.clone())))
+            .with_single_cert(vec![certificate_der.clone()], private_key.into())
+            .unwrap();
+
+        let mut roots = RootCertStore::empty();
+        roots.add(certificate_der).unwrap();
+        let client_config = ClientConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .with_root_certificates(roots)
+            .with_client_auth_cert(
+                vec![client_certificate_der.clone()],
+                client_private_key.into(),
+            )
+            .unwrap();
+
+        let tcp_acceptor = TcpListener::bind("127.0.0.1:0")
+            .into_acceptor()
+            .await
+            .unwrap();
+        let address = tcp_acceptor
+            .local_addr()
+            .into_iter()
+            .find_map(|address| address.0.as_socket_addr().copied())
+            .unwrap();
+
+        // Queue a connection that will never send a TLS ClientHello before the
+        // acceptor starts polling, ensuring it is accepted first.
+        let stalled_connection = TcpStream::connect(address).await.unwrap();
+        let mut acceptor = CertificateCapturingAcceptor::new(tcp_acceptor, server_config);
+
+        // A later, valid TLS handshake must still complete.
+        let second_connection = TcpStream::connect(address).await.unwrap();
+        let connector = TlsConnector::from(Arc::new(client_config));
+        let server_name = ServerName::try_from("localhost").unwrap().to_owned();
+        let ((_, _, remote_addr, _), second_tls) = timeout(Duration::from_secs(1), async {
+            tokio::try_join!(
+                acceptor.accept(),
+                connector.connect(server_name, second_connection),
+            )
+        })
+        .await
+        .expect("a stalled TLS handshake blocked the next connection")
+        .expect("the second TLS handshake failed");
+        let RemoteAddr(Addr::Custom("captured-cert", value)) = remote_addr else {
+            panic!("client certificate was not captured")
+        };
+        let captured_certificate = base64::engine::general_purpose::STANDARD
+            .decode(value.split("|cert:").nth(1).unwrap())
+            .unwrap();
+        assert_eq!(captured_certificate, client_certificate_der.as_ref());
+
+        drop(second_tls);
+        drop(stalled_connection);
     }
 }

--- a/warpgate-protocol-kubernetes/src/server/client_certs.rs
+++ b/warpgate-protocol-kubernetes/src/server/client_certs.rs
@@ -1,15 +1,19 @@
 use std::sync::Arc;
+use std::time::Duration;
 
+use anyhow::Context;
 use base64::{self, Engine};
 use poem::Addr;
 use poem::listener::Acceptor;
-use poem::web::{LocalAddr, RemoteAddr};
+use poem::web::RemoteAddr;
 use rustls::crypto::CryptoProvider;
 use rustls::pki_types::{CertificateDer, UnixTime};
 use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
 use rustls::{DigitallySignedStruct, ServerConfig, SignatureScheme};
+use tokio::time::timeout;
 use tokio_rustls::server::TlsStream;
 use tracing::{debug, warn};
+use warpgate_common::helpers::concurrent_acceptor::ConcurrentAcceptor;
 
 /// Client certificate verifier that proves the peer holds the presented
 /// certificate's private key (by verifying the handshake signature) but does
@@ -86,63 +90,50 @@ impl ClientCertVerifier for AcceptAnyClientCert {
     }
 }
 
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Custom TLS acceptor that captures client certificates and embeds them in remote_addr
-pub struct CertificateCapturingAcceptor<T> {
-    inner: T,
-    tls_acceptor: tokio_rustls::TlsAcceptor,
-}
-
-impl<T> CertificateCapturingAcceptor<T> {
-    pub fn new(inner: T, server_config: ServerConfig) -> Self {
-        Self {
-            inner,
-            tls_acceptor: tokio_rustls::TlsAcceptor::from(Arc::new(server_config)),
-        }
-    }
-}
-
-impl<T> Acceptor for CertificateCapturingAcceptor<T>
+pub fn certificate_capturing_acceptor<A>(
+    inner: A,
+    server_config: ServerConfig,
+) -> ConcurrentAcceptor<TlsStream<A::Io>>
 where
-    T: Acceptor,
+    A: Acceptor + 'static,
 {
-    type Io = TlsStream<T::Io>;
-
-    fn local_addr(&self) -> Vec<LocalAddr> {
-        self.inner.local_addr()
-    }
-
-    async fn accept(
-        &mut self,
-    ) -> std::io::Result<(Self::Io, LocalAddr, RemoteAddr, http::uri::Scheme)> {
-        let (stream, local_addr, remote_addr, _) = self.inner.accept().await?;
-
-        // Perform TLS handshake
-        let tls_stream = self.tls_acceptor.accept(stream).await?;
-
-        // Extract client certificate from the TLS connection
-        let enhanced_remote_addr = if let Some(cert_der) = extract_peer_certificates(&tls_stream) {
-            // Serialize certificate as base64 and embed in remote_addr
-            let cert_b64 = base64::engine::general_purpose::STANDARD.encode(&cert_der);
-            let original_remote_addr_str = match &remote_addr.0 {
-                Addr::SocketAddr(addr) => addr.to_string(),
-                Addr::Unix(_) => remote_addr.to_string(),
-                Addr::Custom(_, _) => "".into(),
-            };
-            RemoteAddr(Addr::Custom(
-                "captured-cert",
-                format!("{original_remote_addr_str}|cert:{cert_b64}").into(),
+    let tls_acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
+    ConcurrentAcceptor::new(inner, move |(stream, local_addr, remote_addr, _)| {
+        let tls_acceptor = tls_acceptor.clone();
+        async move {
+            let tls_stream = timeout(HANDSHAKE_TIMEOUT, tls_acceptor.accept(stream))
+                .await
+                .context("TLS handshake timed out")?
+                .context("TLS handshake failed")?;
+            let remote_addr = embed_client_certificate(&tls_stream, remote_addr);
+            Ok((
+                tls_stream,
+                local_addr,
+                remote_addr,
+                http::uri::Scheme::HTTPS,
             ))
-        } else {
-            remote_addr
-        };
+        }
+    })
+}
 
-        Ok((
-            tls_stream,
-            local_addr,
-            enhanced_remote_addr,
-            http::uri::Scheme::HTTPS,
-        ))
-    }
+/// Smuggle the peer certificate in the RemoteAddr
+fn embed_client_certificate<T>(tls_stream: &TlsStream<T>, remote_addr: RemoteAddr) -> RemoteAddr {
+    let Some(cert_der) = extract_peer_certificates(tls_stream) else {
+        return remote_addr;
+    };
+    let cert_b64 = base64::engine::general_purpose::STANDARD.encode(&cert_der);
+    let original_remote_addr_str = match &remote_addr.0 {
+        Addr::SocketAddr(addr) => addr.to_string(),
+        Addr::Unix(_) => remote_addr.to_string(),
+        Addr::Custom(_, _) => "".into(),
+    };
+    RemoteAddr(Addr::Custom(
+        "captured-cert",
+        format!("{original_remote_addr_str}|cert:{cert_b64}").into(),
+    ))
 }
 
 /// Extract peer certificates from the TLS stream
@@ -237,5 +228,95 @@ pub trait RequestCertificateExt {
 impl RequestCertificateExt for poem::Request {
     fn client_certificate(&self) -> Option<&ClientCertificate> {
         self.extensions().get::<ClientCertificate>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use base64::Engine;
+    use poem::Addr;
+    use poem::listener::{Acceptor, Listener, TcpListener};
+    use poem::web::RemoteAddr;
+    use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer, ServerName};
+    use rustls::{ClientConfig, RootCertStore, ServerConfig};
+    use tokio::net::TcpStream;
+    use tokio::time::timeout;
+    use tokio_rustls::TlsConnector;
+
+    use super::{AcceptAnyClientCert, certificate_capturing_acceptor};
+
+    #[tokio::test]
+    async fn stalled_tls_handshake_does_not_block_later_connections() {
+        let certificate =
+            rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let certificate_der = CertificateDer::from(certificate.cert.der().to_vec());
+        let private_key = PrivatePkcs8KeyDer::from(certificate.signing_key.serialize_der());
+        let client_certificate =
+            rcgen::generate_simple_self_signed(vec!["kubectl-client".to_string()]).unwrap();
+        let client_certificate_der = CertificateDer::from(client_certificate.cert.der().to_vec());
+        let client_private_key =
+            PrivatePkcs8KeyDer::from(client_certificate.signing_key.serialize_der());
+
+        let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+        let server_config = ServerConfig::builder_with_provider(provider.clone())
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .with_client_cert_verifier(Arc::new(AcceptAnyClientCert::new(provider.clone())))
+            .with_single_cert(vec![certificate_der.clone()], private_key.into())
+            .unwrap();
+
+        let mut roots = RootCertStore::empty();
+        roots.add(certificate_der).unwrap();
+        let client_config = ClientConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .with_root_certificates(roots)
+            .with_client_auth_cert(
+                vec![client_certificate_der.clone()],
+                client_private_key.into(),
+            )
+            .unwrap();
+
+        let tcp_acceptor = TcpListener::bind("127.0.0.1:0")
+            .into_acceptor()
+            .await
+            .unwrap();
+        let address = tcp_acceptor
+            .local_addr()
+            .into_iter()
+            .find_map(|address| address.0.as_socket_addr().copied())
+            .unwrap();
+
+        // Queue a connection that will never send a TLS ClientHello before the
+        // acceptor starts polling, ensuring it is accepted first.
+        let stalled_connection = TcpStream::connect(address).await.unwrap();
+        let mut acceptor = certificate_capturing_acceptor(tcp_acceptor, server_config);
+
+        // A later, valid TLS handshake must still complete.
+        let second_connection = TcpStream::connect(address).await.unwrap();
+        let connector = TlsConnector::from(Arc::new(client_config));
+        let server_name = ServerName::try_from("localhost").unwrap().to_owned();
+        let ((_, _, remote_addr, _), second_tls) = timeout(Duration::from_secs(1), async {
+            tokio::try_join!(
+                acceptor.accept(),
+                connector.connect(server_name, second_connection),
+            )
+        })
+        .await
+        .expect("a stalled TLS handshake blocked the next connection")
+        .expect("the second TLS handshake failed");
+        let RemoteAddr(Addr::Custom("captured-cert", value)) = remote_addr else {
+            panic!("client certificate was not captured")
+        };
+        let captured_certificate = base64::engine::general_purpose::STANDARD
+            .decode(value.split("|cert:").nth(1).unwrap())
+            .unwrap();
+        assert_eq!(captured_certificate, client_certificate_der.as_ref());
+
+        drop(second_tls);
+        drop(stalled_connection);
     }
 }

--- a/warpgate-protocol-kubernetes/src/server/mod.rs
+++ b/warpgate-protocol-kubernetes/src/server/mod.rs
@@ -8,13 +8,13 @@ use poem::{EndpointExt, Route, Server};
 use rustls::ServerConfig;
 use tracing::info;
 use warpgate_common::ListenEndpoint;
-use warpgate_common::helpers::proxy_protocol::ProxyProtocolAcceptor;
+use warpgate_common::helpers::proxy_protocol::MaybeProxyProtocolAcceptor;
 use warpgate_common_http::auth::UnauthenticatedRequestContext;
 use warpgate_core::Services;
 use warpgate_tls::{SingleCertResolver, TlsCertificateAndPrivateKey};
 
 use crate::correlator::RequestCorrelator;
-use crate::server::client_certs::{AcceptAnyClientCert, CertificateCapturingAcceptor};
+use crate::server::client_certs::{AcceptAnyClientCert, certificate_capturing_acceptor};
 use crate::server::handlers::handle_api_request;
 
 pub mod auth;
@@ -58,8 +58,8 @@ pub async fn bind_server(
         )));
 
     let tcp_acceptor = address.poem_listener()?.into_acceptor().await?;
-    let tcp_acceptor = ProxyProtocolAcceptor::new(tcp_acceptor, proxy_protocol);
-    let cert_capturing_acceptor = CertificateCapturingAcceptor::new(tcp_acceptor, tls_config);
+    let tcp_acceptor = MaybeProxyProtocolAcceptor::new(tcp_acceptor, proxy_protocol);
+    let cert_capturing_acceptor = certificate_capturing_acceptor(tcp_acceptor, tls_config);
 
     Ok(async move {
         Server::new_with_acceptor(cert_capturing_acceptor)

--- a/warpgate-protocol-mysql/src/lib.rs
+++ b/warpgate-protocol-mysql/src/lib.rs
@@ -55,7 +55,7 @@ impl ProtocolServer for MySQLProtocolServer {
             certificate_and_key.into(),
         ))));
 
-        let mut listener = address.tcp_accept_stream().await?;
+        let listener = address.tcp_accept_stream().await?;
 
         let services = self.services;
         Ok(async move {

--- a/warpgate-protocol-mysql/src/lib.rs
+++ b/warpgate-protocol-mysql/src/lib.rs
@@ -9,13 +9,13 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use futures::FutureExt;
 use futures::future::BoxFuture;
-use futures::{FutureExt, StreamExt};
 use rustls::ServerConfig;
 use rustls::server::NoClientAuth;
 use tracing::{Instrument, error, info, warn};
 use warpgate_common::ListenEndpoint;
-use warpgate_common::helpers::net::accept_client;
+use warpgate_common::helpers::net::accept_loop;
 use warpgate_core::{ProtocolServer, Services, SessionStateInit, State};
 use warpgate_tls::{ResolveServerCert, TlsCertificateAndPrivateKey};
 
@@ -59,58 +59,57 @@ impl ProtocolServer for MySQLProtocolServer {
 
         let services = self.services;
         Ok(async move {
-            loop {
-                let Some(mut stream) = listener.next().await else {
-                    return Ok(());
-                };
+            accept_loop(
+                "MySQL connection",
+                listener,
+                proxy_protocol,
+                move |stream, remote_address| {
+                    let tls_config = tls_config.clone();
+                    let services = services.clone();
+                    async move {
+                        let (session_handle, mut abort_rx) = MySqlSessionHandle::new();
 
-                let Some(remote_address) = accept_client(&mut stream, proxy_protocol).await else {
-                    continue;
-                };
+                        let server_handle = State::register_session(
+                            &services.state,
+                            crate::common::PROTOCOL_NAME,
+                            SessionStateInit {
+                                remote_address: Some(remote_address),
+                                handle: Box::new(session_handle),
+                            },
+                        )
+                        .await
+                        .context("registering session")?;
 
-                let tls_config = tls_config.clone();
-                let services = services.clone();
-                tokio::spawn(async move {
-                    let (session_handle, mut abort_rx) = MySqlSessionHandle::new();
+                        let wrapped_stream = {
+                            let guard = server_handle.lock().await;
+                            guard.wrap_stream(stream).await?
+                        };
 
-                    let server_handle = State::register_session(
-                        &services.state,
-                        crate::common::PROTOCOL_NAME,
-                        SessionStateInit {
-                            remote_address: Some(remote_address),
-                            handle: Box::new(session_handle),
-                        },
-                    )
-                    .await
-                    .context("registering session")?;
+                        let session = MySqlSession::new(
+                            server_handle,
+                            services,
+                            wrapped_stream,
+                            tls_config,
+                            remote_address,
+                        )
+                        .await;
+                        let span = session.make_logging_span();
+                        tokio::select! {
+                            result = session.run().instrument(span) => match result {
+                                Ok(()) => info!("Session ended"),
+                                Err(e) => error!(error=%e, "Session failed"),
+                            },
+                            _ = abort_rx.recv() => {
+                                warn!("Session aborted by admin");
+                            },
+                        }
 
-                    let wrapped_stream = {
-                        let guard = server_handle.lock().await;
-                        guard.wrap_stream(stream).await?
-                    };
-
-                    let session = MySqlSession::new(
-                        server_handle,
-                        services,
-                        wrapped_stream,
-                        tls_config,
-                        remote_address,
-                    )
-                    .await;
-                    let span = session.make_logging_span();
-                    tokio::select! {
-                        result = session.run().instrument(span) => match result {
-                            Ok(()) => info!("Session ended"),
-                            Err(e) => error!(error=%e, "Session failed"),
-                        },
-                        _ = abort_rx.recv() => {
-                            warn!("Session aborted by admin");
-                        },
+                        Ok(())
                     }
-
-                    Ok::<(), anyhow::Error>(())
-                });
-            }
+                },
+            )
+            .await;
+            Ok(())
         }
         .boxed())
     }

--- a/warpgate-protocol-postgres/src/lib.rs
+++ b/warpgate-protocol-postgres/src/lib.rs
@@ -56,7 +56,7 @@ impl ProtocolServer for PostgresProtocolServer {
             certificate_and_key.into(),
         ))));
 
-        let mut listener = address
+        let listener = address
             .tcp_accept_stream()
             .await
             .context("accepting connection")?;

--- a/warpgate-protocol-postgres/src/lib.rs
+++ b/warpgate-protocol-postgres/src/lib.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use futures::FutureExt;
 use futures::future::BoxFuture;
-use futures::{FutureExt, StreamExt};
 use rustls::ServerConfig;
 use rustls::server::NoClientAuth;
 use session::PostgresSession;
@@ -19,7 +19,7 @@ use session_handle::PostgresSessionHandle;
 use socket2::{Socket, TcpKeepalive};
 use tracing::{Instrument, error, info, warn};
 use warpgate_common::ListenEndpoint;
-use warpgate_common::helpers::net::accept_client;
+use warpgate_common::helpers::net::accept_loop;
 use warpgate_core::{ProtocolServer, Services, SessionStateInit, State};
 use warpgate_tls::{ResolveServerCert, TlsCertificateAndPrivateKey};
 
@@ -62,80 +62,79 @@ impl ProtocolServer for PostgresProtocolServer {
             .context("accepting connection")?;
         let services = self.services;
         Ok(async move {
-            loop {
-                let Some(mut stream) = listener.next().await else {
-                    return Ok(());
-                };
+            accept_loop(
+                "PostgreSQL connection",
+                listener,
+                proxy_protocol,
+                move |stream, remote_address| {
+                    let tls_config = tls_config.clone();
+                    let services = services.clone();
+                    async move {
+                        // Enable TCP keepalive to prevent idle connections from timing out
+                        // This is especially important during web auth approval wait
+                        // Use socket2 to configure keepalive (tokio TcpStream doesn't expose it directly)
+                        let stream = (|| {
+                            let socket = Socket::from(stream.into_std()?);
+                            let keepalive = TcpKeepalive::new()
+                                .with_time(Duration::from_secs(60)) // Start keepalive after 60s of inactivity
+                                .with_interval(Duration::from_secs(10)) // Send probes every 10s
+                                .with_retries(3); // 3 retries before considering dead
+                            socket.set_tcp_keepalive(&keepalive)?;
+                            socket.set_tcp_nodelay(true)?;
+                            tokio::net::TcpStream::from_std(socket.into())
+                        })();
 
-                let Some(remote_address) = accept_client(&mut stream, proxy_protocol).await else {
-                    continue;
-                };
+                        let stream = match stream {
+                            Ok(stream) => stream,
+                            Err(error) => {
+                                warn!(%error, "Failed to set up an accepted connection");
+                                return Ok(());
+                            }
+                        };
 
-                // Enable TCP keepalive to prevent idle connections from timing out
-                // This is especially important during web auth approval wait
-                // Use socket2 to configure keepalive (tokio TcpStream doesn't expose it directly)
-                let stream = (|| {
-                    let socket = Socket::from(stream.into_std()?);
-                    let keepalive = TcpKeepalive::new()
-                        .with_time(Duration::from_secs(60)) // Start keepalive after 60s of inactivity
-                        .with_interval(Duration::from_secs(10)) // Send probes every 10s
-                        .with_retries(3); // 3 retries before considering dead
-                    socket.set_tcp_keepalive(&keepalive)?;
-                    socket.set_tcp_nodelay(true)?;
-                    tokio::net::TcpStream::from_std(socket.into())
-                })();
+                        let (session_handle, mut abort_rx) = PostgresSessionHandle::new();
 
-                let stream = match stream {
-                    Ok(stream) => stream,
-                    Err(error) => {
-                        warn!(%error, "Failed to set up an accepted connection");
-                        continue;
+                        let server_handle = State::register_session(
+                            &services.state,
+                            crate::common::PROTOCOL_NAME,
+                            SessionStateInit {
+                                remote_address: Some(remote_address),
+                                handle: Box::new(session_handle),
+                            },
+                        )
+                        .await?;
+
+                        let wrapped_stream = {
+                            let guard = server_handle.lock().await;
+                            guard.wrap_stream(stream).await?
+                        };
+
+                        let session = PostgresSession::new(
+                            server_handle,
+                            services,
+                            wrapped_stream,
+                            tls_config,
+                            remote_address,
+                        )
+                        .await;
+
+                        let span = session.make_logging_span();
+                        tokio::select! {
+                            result = session.run().instrument(span) => match result {
+                                Ok(()) => info!("Session ended"),
+                                Err(e) => error!(error=%e, "Session failed"),
+                            },
+                            _ = abort_rx.recv() => {
+                                warn!("Session aborted by admin");
+                            },
+                        }
+
+                        Ok(())
                     }
-                };
-
-                let tls_config = tls_config.clone();
-                let services = services.clone();
-                tokio::spawn(async move {
-                    let (session_handle, mut abort_rx) = PostgresSessionHandle::new();
-
-                    let server_handle = State::register_session(
-                        &services.state,
-                        crate::common::PROTOCOL_NAME,
-                        SessionStateInit {
-                            remote_address: Some(remote_address),
-                            handle: Box::new(session_handle),
-                        },
-                    )
-                    .await?;
-
-                    let wrapped_stream = {
-                        let guard = server_handle.lock().await;
-                        guard.wrap_stream(stream).await?
-                    };
-
-                    let session = PostgresSession::new(
-                        server_handle,
-                        services,
-                        wrapped_stream,
-                        tls_config,
-                        remote_address,
-                    )
-                    .await;
-
-                    let span = session.make_logging_span();
-                    tokio::select! {
-                        result = session.run().instrument(span) => match result {
-                            Ok(()) => info!("Session ended"),
-                            Err(e) => error!(error=%e, "Session failed"),
-                        },
-                        _ = abort_rx.recv() => {
-                            warn!("Session aborted by admin");
-                        },
-                    }
-
-                    Ok::<(), anyhow::Error>(())
-                });
-            }
+                },
+            )
+            .await;
+            Ok(())
         }
         .boxed())
     }

--- a/warpgate-protocol-rdp/src/server/mod.rs
+++ b/warpgate-protocol-rdp/src/server/mod.rs
@@ -88,7 +88,7 @@ pub async fn bind_server(
     cert_pem: String,
     key_pem: String,
 ) -> Result<BoxFuture<'static, Result<()>>> {
-    let mut listener = address.tcp_accept_stream().await?;
+    let listener = address.tcp_accept_stream().await?;
 
     Ok(async move {
         accept_loop(

--- a/warpgate-protocol-rdp/src/server/mod.rs
+++ b/warpgate-protocol-rdp/src/server/mod.rs
@@ -19,16 +19,15 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use tokio::io::copy_bidirectional;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::{Sender, UnboundedReceiver, UnboundedSender, channel, unbounded_channel};
 use tokio::time::{Instant, timeout_at};
-use tokio_stream::StreamExt;
 use tracing::{Instrument, debug, error, info, info_span, warn};
-use warpgate_common::helpers::net::accept_client;
+use warpgate_common::helpers::net::accept_loop;
 use warpgate_common::{ListenEndpoint, Protocol, Target, TargetOptions, TargetRdpOptions};
 use warpgate_core::recordings::DesktopRecorder;
 use warpgate_core::{
@@ -92,54 +91,51 @@ pub async fn bind_server(
     let mut listener = address.tcp_accept_stream().await?;
 
     Ok(async move {
-        while let Some(mut stream) = listener.next().await {
-            let Some(remote_address) = accept_client(&mut stream, proxy_protocol).await else {
-                continue;
-            };
+        accept_loop(
+            "RDP connection",
+            listener,
+            proxy_protocol,
+            move |stream, remote_address| {
+                let services = services.clone();
+                let cert_pem = cert_pem.clone();
+                let key_pem = key_pem.clone();
+                async move {
+                    let (session_handle, mut abort_rx) = RdpSessionHandle::new();
 
-            let services = services.clone();
-            let cert_pem = cert_pem.clone();
-            let key_pem = key_pem.clone();
-            tokio::spawn(async move {
-                let (session_handle, mut abort_rx) = RdpSessionHandle::new();
+                    let server_handle = State::register_session(
+                        &services.state,
+                        PROTOCOL_NAME,
+                        SessionStateInit {
+                            remote_address: Some(remote_address),
+                            handle: Box::new(session_handle),
+                        },
+                    )
+                    .await
+                    .context("registering session")?;
 
-                let server_handle = match State::register_session(
-                    &services.state,
-                    PROTOCOL_NAME,
-                    SessionStateInit {
-                        remote_address: Some(remote_address),
-                        handle: Box::new(session_handle),
-                    },
-                )
-                .await
-                {
-                    Ok(h) => h,
-                    Err(error) => {
-                        error!(%error, "Failed to register session");
-                        return;
+                    let span = info_span!("RDP", session=%server_handle.lock().await.id());
+
+                    tokio::select! {
+                        result = handle_connection(
+                            services,
+                            server_handle.clone(),
+                            stream,
+                            remote_address,
+                            cert_pem,
+                            key_pem,
+                        ).instrument(span) => match result {
+                            Ok(()) => info!("Session ended"),
+                            Err(error) => error!(%error, "Session failed"),
+                        },
+                        _ = abort_rx.recv() => {
+                            warn!("Session aborted by admin");
+                        }
                     }
-                };
-
-                let span = info_span!("RDP", session=%server_handle.lock().await.id());
-
-                tokio::select! {
-                    result = handle_connection(
-                        services,
-                        server_handle.clone(),
-                        stream,
-                        remote_address,
-                        cert_pem,
-                        key_pem,
-                    ).instrument(span) => match result {
-                        Ok(()) => info!("Session ended"),
-                        Err(error) => error!(%error, "Session failed"),
-                    },
-                    _ = abort_rx.recv() => {
-                        warn!("Session aborted by admin");
-                    }
+                    Ok(())
                 }
-            });
-        }
+            },
+        )
+        .await;
 
         Ok(())
     }

--- a/warpgate-protocol-ssh/src/server/mod.rs
+++ b/warpgate-protocol-ssh/src/server/mod.rs
@@ -6,12 +6,13 @@ mod session;
 mod session_handle;
 mod target_menu;
 use std::borrow::Cow;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use futures::FutureExt;
 use futures::future::BoxFuture;
-use futures::{FutureExt, StreamExt};
 use russh::keys::{Algorithm, HashAlg, PrivateKey};
 use russh::{MethodKind, MethodSet, Preferred};
 pub use russh_handler::ServerHandler;
@@ -21,7 +22,7 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc::unbounded_channel;
 use tracing::*;
 use warpgate_common::ListenEndpoint;
-use warpgate_common::helpers::net::accept_client;
+use warpgate_common::helpers::net::accept_loop;
 use warpgate_core::{Services, SessionStateInit, State};
 use warpgate_db_entities::Parameters;
 
@@ -45,24 +46,22 @@ pub async fn bind_server(
         }
     });
 
-    let mut listener = address.tcp_accept_stream().await?;
+    let listener = address.tcp_accept_stream().await?;
 
     Ok(async move {
-        while let Some(stream) = listener.next().await {
-            let russh_config_init = russh_config_init.clone();
-            let services = services.clone();
-
-            tokio::task::Builder::new()
-                .name("SSH new connection setup")
-                .spawn(async move {
-                    if let Err(e) =
-                        _handle_connection(services, russh_config_init, stream, proxy_protocol)
-                            .await
-                    {
-                        error!(%e, "Connection handling failed");
-                    }
-                })?;
-        }
+        accept_loop(
+            "SSH connection",
+            listener,
+            proxy_protocol,
+            move |stream, remote_address| {
+                let russh_config_init = russh_config_init.clone();
+                let services = services.clone();
+                async move {
+                    _handle_connection(services, russh_config_init, stream, remote_address).await
+                }
+            },
+        )
+        .await;
         Ok(())
     }
     .boxed())
@@ -71,13 +70,9 @@ pub async fn bind_server(
 async fn _handle_connection(
     services: Services,
     russh_config_init: Arc<RusshConfigInit>,
-    mut stream: TcpStream,
-    proxy_protocol: bool,
+    stream: TcpStream,
+    remote_address: SocketAddr,
 ) -> Result<()> {
-    let Some(remote_address) = accept_client(&mut stream, proxy_protocol).await else {
-        return Ok(());
-    };
-
     let (session_handle, session_handle_rx) = SSHSessionHandle::new();
 
     let server_handle = State::register_session(

--- a/warpgate-protocol-vnc/src/server/mod.rs
+++ b/warpgate-protocol-vnc/src/server/mod.rs
@@ -19,9 +19,8 @@ use tokio::net::TcpStream;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Instant, timeout_at};
 use tokio_rustls::TlsAcceptor;
-use tokio_stream::StreamExt;
 use tracing::{Instrument, debug, error, info, info_span, warn};
-use warpgate_common::helpers::net::accept_client;
+use warpgate_common::helpers::net::accept_loop;
 use warpgate_common::{ListenEndpoint, Protocol, Target, TargetOptions, TargetVncOptions};
 use warpgate_core::recordings::DesktopRecorder;
 use warpgate_core::{Services, SessionStateInit, State, WarpgateServerHandle};
@@ -60,56 +59,52 @@ pub async fn bind_server(
     ))));
     let tls_config = Arc::new(tls_config);
 
-    let mut listener = address.tcp_accept_stream().await?;
+    let listener = address.tcp_accept_stream().await?;
 
     Ok(async move {
-        while let Some(mut stream) = listener.next().await {
-            let Some(remote_address) = accept_client(&mut stream, proxy_protocol).await else {
-                continue;
-            };
+        accept_loop(
+            "VNC connection",
+            listener,
+            proxy_protocol,
+            move |stream, remote_address| {
+                let tls_config = tls_config.clone();
+                let services = services.clone();
+                async move {
+                    let (session_handle, mut abort_rx) = VncSessionHandle::new();
 
-            let tls_config = tls_config.clone();
-            let services = services.clone();
-            tokio::spawn(async move {
-                let (session_handle, mut abort_rx) = VncSessionHandle::new();
+                    let server_handle = State::register_session(
+                        &services.state,
+                        PROTOCOL_NAME,
+                        SessionStateInit {
+                            remote_address: Some(remote_address),
+                            handle: Box::new(session_handle),
+                        },
+                    )
+                    .await
+                    .context("registering session")?;
 
-                let server_handle = match State::register_session(
-                    &services.state,
-                    PROTOCOL_NAME,
-                    SessionStateInit {
-                        remote_address: Some(remote_address),
-                        handle: Box::new(session_handle),
-                    },
-                )
-                .await
-                {
-                    Ok(h) => h,
-                    Err(error) => {
-                        error!(%error, "Failed to register session");
-                        return;
+                    let span = info_span!("VNC", session=%server_handle.lock().await.id());
+
+                    tokio::select! {
+                        result = handle_connection(
+                            services,
+                            server_handle.clone(),
+                            stream,
+                            tls_config,
+                            remote_address,
+                        ).instrument(span) => match result {
+                            Ok(()) => info!("Session ended"),
+                            Err(error) => error!(%error, "Session failed"),
+                        },
+                        _ = abort_rx.recv() => {
+                            warn!("Session aborted by admin");
+                        }
                     }
-                };
-
-                let span = info_span!("VNC", session=%server_handle.lock().await.id());
-
-                tokio::select! {
-                    result = handle_connection(
-                        services,
-                        server_handle.clone(),
-                        stream,
-                        tls_config,
-                        remote_address,
-                    ).instrument(span) => match result {
-                        Ok(()) => info!("Session ended"),
-                        Err(error) => error!(%error, "Session failed"),
-                    },
-                    _ = abort_rx.recv() => {
-                        warn!("Session aborted by admin");
-                    }
+                    Ok(())
                 }
-            });
-        }
-
+            },
+        )
+        .await;
         Ok(())
     }
     .boxed())


### PR DESCRIPTION
## Description
Warpgate's Kubernetes listener has the following properties:
1. All TCP handshakes are serially accepted on the connection accept loop
2. Warpgate does not enforce a timeout on how long a TCP handshake can take

As a consequence of this, when a client does not complete its TCP handshake, the Kubernetes listener becomes completely unavailable and the Kubernetes feature of Warpgate stops working entirely. We are dealing with issues where our Kubernetes listener just stops listening every few days, and we suspect it is because bots are hitting the port without finishing up their TCP handshake.

This is resolved by:
1. Handle TLS handshaking on the per-connection task
2. Add a 10s timeout for TCP handshaking

Most of this is implemented in the tls-listener dependency, which I pull in as part of this PR.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
