### PR TITLE
fix: sort SSH target menu with natural numeric order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,6 +4488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "natord"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
+
+[[package]]
 name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9408,6 +9414,7 @@ dependencies = [
  "dialoguer",
  "ed25519-dalek 3.0.0",
  "futures",
+ "natord",
  "ratatui",
  "russh",
  "sea-orm",

--- a/warpgate-protocol-ssh/Cargo.toml
+++ b/warpgate-protocol-ssh/Cargo.toml
@@ -13,6 +13,7 @@ curve25519-dalek = { version = "5.0.0", default-features = false } # pin due to 
 dialoguer.workspace = true
 ed25519-dalek = { version = "3.0.0", default-features = false } # pin due to build fail on x86 in 2.1
 futures.workspace = true
+natord = { version = "1.0", default-features = false }
 ratatui = { version = "0.30", default-features = false, features = [
     "crossterm",
     "unstable-backend-writer",

--- a/warpgate-protocol-ssh/src/server/target_menu.rs
+++ b/warpgate-protocol-ssh/src/server/target_menu.rs
@@ -161,7 +161,7 @@ impl<T: Clone> TargetMenu<T> {
         terminal_width: u16,
         terminal_height: u16,
     ) -> Result<Self, WarpgateError> {
-        entries.sort_by(|a, b| a.label.cmp(&b.label));
+        entries.sort_by(|a, b| natord::compare_ignore_case(&a.label, &b.label));
         let terminal = Terminal::with_options(
             VirtualTerminalBackend::new(Size::new(terminal_width, terminal_height)),
             TerminalOptions {
@@ -645,5 +645,45 @@ mod tests {
         menu.terminal_height = 24;
         let out = menu.render().expect("render after resize failed");
         assert!(out.contains("alpha"));
+    }
+
+    // Lexicographic sort places "210-db" directly under "20-web" (issue #2433).
+    // Natural/human sort puts numeric prefixes in numeric order: 20, 22, 210.
+    #[test]
+    fn sorts_targets_in_natural_numeric_order() {
+        let mut menu = TargetMenu::new(
+            vec![
+                MenuEntry {
+                    label: "210-db".into(),
+                    value: 210,
+                },
+                MenuEntry {
+                    label: "20-web".into(),
+                    value: 20,
+                },
+                MenuEntry {
+                    label: "22-app".into(),
+                    value: 22,
+                },
+            ],
+            "user".into(),
+            120,
+            40,
+        )
+        .expect("menu creation should succeed");
+
+        menu.render().expect("initial render failed");
+
+        // First item is 20-web under both sorts; the second item is the
+        // regression: lexicographic would select 210-db, natural selects 22-app.
+        let result = menu.handle_input(b"\x1b[B");
+        assert!(matches!(result, Some(MenuInputResult::Redraw)));
+        menu.render().expect("redraw failed");
+
+        let result = menu.handle_input(b"\r");
+        assert!(
+            matches!(result, Some(MenuInputResult::Selected(22))),
+            "expected 22-app as second item in natural order"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The SSH target picker sorted labels with `String::cmp`, so names like `210-…` sat directly under `20-…`. The web UI already uses case-insensitive natural sort; this applies the same order in `TargetMenu`.

Fixes #2433

## Test plan

- [x] `cargo test -p warpgate-protocol-ssh --lib sorts_targets_in_natural_numeric_order`
