### PR TITLE
fix(ssh): preserve host key confirmation prompts

### DIFF
--- a/warpgate-protocol-ssh/src/server/service_output.rs
+++ b/warpgate-protocol-ssh/src/server/service_output.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::fmt::Display;
 use std::io::Write as _;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -144,18 +144,32 @@ fn erase_for_width(w: usize) -> String {
     format!("{CURSOR_UP}\r{}\r", " ".repeat(w))
 }
 
+#[derive(Clone, Debug)]
+pub struct ServiceOutputFrame {
+    data: Bytes,
+    generation: u64,
+}
+
+impl ServiceOutputFrame {
+    pub const fn data(&self) -> &Bytes {
+        &self.data
+    }
+}
+
 #[derive(Clone)]
 pub struct ServiceOutput {
     progress_visible: Arc<AtomicBool>,
+    progress_generation: Arc<AtomicU64>,
     last_progress_width: Arc<AtomicUsize>,
     chain: Arc<Mutex<Option<VisualConnectionChainState>>>,
     abort_tx: mpsc::Sender<()>,
-    output_tx: broadcast::Sender<Bytes>,
+    output_tx: broadcast::Sender<ServiceOutputFrame>,
 }
 
 impl ServiceOutput {
     pub fn new() -> Self {
         let progress_visible = Arc::new(AtomicBool::new(false));
+        let progress_generation = Arc::new(AtomicU64::new(0));
         let last_progress_width = Arc::new(AtomicUsize::new(0));
         let chain: Arc<Mutex<Option<VisualConnectionChainState>>> = Arc::new(Mutex::new(None));
         let (abort_tx, mut abort_rx) = mpsc::channel(1);
@@ -165,6 +179,7 @@ impl ServiceOutput {
             let output_tx = output_tx.clone();
             let last_progress_width = last_progress_width.clone();
             let progress_visible = progress_visible.clone();
+            let progress_generation = progress_generation.clone();
             let chain = chain.clone();
             let mut tick = 0usize;
             async move {
@@ -173,12 +188,16 @@ impl ServiceOutput {
                         _ = abort_rx.recv() => return,
                         () = tokio::time::sleep(ANIM_FRAME_DURATION) => {
                             if progress_visible.load(Ordering::Relaxed) {
+                                let generation = progress_generation.load(Ordering::Relaxed);
                                 tick += 1;
                                 let guard = chain.lock().await;
                                 if let Some(c) = &*guard {
                                     let frame = format!("{CURSOR_UP}\r{}", render_connection_chain(c, tick));
                                     last_progress_width.store(frame.len(), Ordering::Relaxed);
-                                    let _ = output_tx.send(Bytes::from(frame.into_bytes()));
+                                    let _ = output_tx.send(ServiceOutputFrame {
+                                        data: Bytes::from(frame.into_bytes()),
+                                        generation,
+                                    });
                                 }
                             }
                         }
@@ -189,6 +208,7 @@ impl ServiceOutput {
 
         Self {
             progress_visible,
+            progress_generation,
             last_progress_width,
             chain,
             abort_tx,
@@ -201,6 +221,7 @@ impl ServiceOutput {
             items: hosts,
             connected_hops: 1,
         });
+        self.progress_generation.fetch_add(1, Ordering::Relaxed);
         self.progress_visible.store(true, Ordering::Relaxed);
     }
 
@@ -213,20 +234,28 @@ impl ServiceOutput {
 
     /// Re-enable the animation (e.g. after pausing for a host-key prompt).
     pub fn show_progress(&self) {
+        self.progress_generation.fetch_add(1, Ordering::Relaxed);
         self.progress_visible.store(true, Ordering::Relaxed);
     }
 
     pub fn stop_progress(&self) {
         self.progress_visible.store(false, Ordering::Relaxed);
+        self.progress_generation.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn progress_visible(&self) -> bool {
         self.progress_visible.load(Ordering::Relaxed)
     }
 
+    pub fn should_render(&self, frame: &ServiceOutputFrame) -> bool {
+        self.progress_visible()
+            && frame.generation == self.progress_generation.load(Ordering::Relaxed)
+    }
+
     #[must_use]
     pub async fn render_final_success_static_frame(&self) -> String {
         self.progress_visible.store(false, Ordering::Relaxed);
+        self.progress_generation.fetch_add(1, Ordering::Relaxed);
         let chain = self.chain.lock().await;
         let graph = if let Some(c) = &*chain {
             let n = c.items.len();
@@ -248,7 +277,7 @@ impl ServiceOutput {
         erase_for_width(self.last_progress_width.load(Ordering::Relaxed))
     }
 
-    pub fn subscribe(&self) -> broadcast::Receiver<Bytes> {
+    pub fn subscribe(&self) -> broadcast::Receiver<ServiceOutputFrame> {
         self.output_tx.subscribe()
     }
 }
@@ -257,5 +286,28 @@ impl Drop for ServiceOutput {
     fn drop(&mut self) {
         let signal = std::mem::replace(&mut self.abort_tx, mpsc::channel(1).0);
         tokio::spawn(async move { signal.send(()).await });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn invalidates_queued_frames_when_progress_pauses() {
+        let output = ServiceOutput::new();
+        output.start_progress(vec![]).await;
+        let queued_frame = ServiceOutputFrame {
+            data: Bytes::new(),
+            generation: output.progress_generation.load(Ordering::Relaxed),
+        };
+
+        assert!(output.should_render(&queued_frame));
+
+        output.stop_progress();
+        assert!(!output.should_render(&queued_frame));
+
+        output.show_progress();
+        assert!(!output.should_render(&queued_frame));
     }
 }

--- a/warpgate-protocol-ssh/src/server/session.rs
+++ b/warpgate-protocol-ssh/src/server/session.rs
@@ -42,7 +42,7 @@ use super::service_output::ServiceOutput;
 use super::session_handle::SessionHandleCommand;
 use crate::compat::ContextExt;
 use crate::server::get_allowed_auth_methods;
-use crate::server::service_output::{VisualConnectionChainItem, paint_fg};
+use crate::server::service_output::{ServiceOutputFrame, VisualConnectionChainItem, paint_fg};
 use crate::server::target_menu::{MenuEvent, spawn_target_menu_loop};
 use crate::{
     ChannelOperation, ConnectionError, DirectTCPIPParams, PtyRequest, RCCommand, RCCommandReply,
@@ -69,7 +69,7 @@ pub enum Event {
     Command(SessionHandleCommand),
     ServerHandler(ServerHandlerEvent),
     ConsoleInput(Bytes),
-    ServiceOutput(Bytes),
+    ServiceOutput(ServiceOutputFrame),
     Client(RCEvent),
     MenuRedraw(u16, u16),
     Menu(MenuEvent),
@@ -216,9 +216,9 @@ impl ServerSession {
         tokio::spawn(async move {
             loop {
                 match so_rx.recv().await {
-                    Ok(data) => {
+                    Ok(frame) => {
                         if so_sender
-                            .send_once(Event::ServiceOutput(data))
+                            .send_once(Event::ServiceOutput(frame))
                             .await
                             .is_err()
                         {
@@ -689,8 +689,13 @@ impl ServerSession {
                         // break;
                     }
                 }
-                Event::ServiceOutput(data) => {
-                    let _ = self.emit_pty_output(&data).await;
+                Event::ServiceOutput(frame) => {
+                    // A connection can pause for an interactive prompt after
+                    // animation frames have already queued. Do not let one
+                    // of those stale frames redraw over the prompt.
+                    if self.service_output.should_render(&frame) {
+                        let _ = self.emit_pty_output(frame.data()).await;
+                    }
                 }
                 Event::Menu(action) => {
                     if let Err(err) = self.handle_menu_event(action).await {


### PR DESCRIPTION
## Problem

When Warpgate paused its SSH connection-status display to ask a user to verify an upstream host key, an already-queued “connecting” status update could arrive afterward and paint over that prompt. The SSH session then looked stuck: the confirmation was still required, but no longer visible for the user to answer.

## Fix

Give connection-status updates a generation and discard updates queued before the display is paused, resumed, restarted, or completed. This preserves the interactive host-key confirmation while leaving host-key verification and SSH authentication behavior unchanged.

## Validation

All required GitHub Actions checks pass, including build, test, lint, formatting, schema, and security checks.