### PR TITLE
Allow clear cache sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ node_modules
 .github
 *.md
 .env
+.DS_Store

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -892,6 +892,32 @@ ADMIN_API_TEST_CASES: list[AdminApiTestCase] = [
         call=lambda api, r: api.get_ip_echo_with_http_info(),
         expected_statuses={200},
     ),
+    AdminApiTestCase(
+        id="list_web_approvals",
+        permission=None,
+        call=lambda api, r: api.list_web_approvals_with_http_info(),
+        expected_statuses={200},
+    ),
+    AdminApiTestCase(
+        id="clear_web_approvals",
+        permission="config_edit",
+        call=lambda api, r: api.clear_web_approvals_with_http_info(),
+        expected_statuses={200},
+    ),
+    AdminApiTestCase(
+        id="clear_web_approvals_for_user",
+        permission="config_edit",
+        call=lambda api, r: api.clear_web_approvals_for_user_with_http_info(r["username"]),
+        expected_statuses={200},
+    ),
+    AdminApiTestCase(
+        id="clear_web_approval_scope_for_user",
+        permission="config_edit",
+        call=lambda api, r: api.clear_web_approval_scope_for_user_with_http_info(
+            r["username"]
+        ),
+        expected_statuses={200},
+    ),
 ]
 
 

--- a/warpgate-admin/src/api/mod.rs
+++ b/warpgate-admin/src/api/mod.rs
@@ -36,6 +36,7 @@ mod ticket_requests_list;
 mod tickets_detail;
 mod tickets_list;
 pub mod users;
+mod web_approvals;
 
 pub use warpgate_common::api::AnySecurityScheme;
 
@@ -86,5 +87,6 @@ pub fn get() -> impl OpenApi {
             certificate_credentials::ListApi,
             certificate_credentials::DetailApi,
         ),
+        web_approvals::Api,
     )
 }

--- a/warpgate-admin/src/api/web_approvals.rs
+++ b/warpgate-admin/src/api/web_approvals.rs
@@ -1,0 +1,288 @@
+//! Admin visibility into, and revocation of, cached web-approval auth
+//! bypasses (see [`warpgate_core::AuthStateStore`]). The cache is per-node
+//! in-memory, so a clear (or the list) fans out to every other cluster node,
+//! the same way session termination does in `sessions_list`.
+
+use poem::Request;
+use poem::http::StatusCode;
+use poem_openapi::param::{Path, Query};
+use poem_openapi::payload::Json;
+use poem_openapi::{ApiResponse, Object, OpenApi};
+use time::OffsetDateTime;
+use tracing::warn;
+use warpgate_common::auth::WebApprovalScopeKey;
+use warpgate_common::{AdminPermission, WarpgateError};
+use warpgate_common_http::{AuthenticatedRequestContext, is_cluster_peer_request};
+
+use super::ClusterOrAdminContext;
+use super::cluster_proxy::{fan_out_to_peers, parse_forwarded_body};
+
+pub struct Api;
+
+#[derive(Object)]
+struct ActiveWebApprovalInfo {
+    username: String,
+    remote_ip: String,
+    protocol: String,
+    /// Human-readable summary of what the approval covers: a target name,
+    /// `*` for all targets, or `sign-in` for an untargeted portal/menu login.
+    scope: String,
+    /// The target name when this approval is scoped to one target — echo
+    /// this back (with `all_targets: false`) to revoke just this row via
+    /// `clear_web_approval_scope_for_user`.
+    scope_target: Option<String>,
+    /// Whether this approval covers every target — echo this back to revoke
+    /// just this row.
+    all_targets: bool,
+    granted_at: OffsetDateTime,
+}
+
+#[derive(Object)]
+struct ClearWebApprovalsResult {
+    cleared_count: u64,
+}
+
+#[derive(ApiResponse)]
+enum ListWebApprovalsResponse {
+    #[oai(status = 200)]
+    Ok(Json<Vec<ActiveWebApprovalInfo>>),
+}
+
+#[derive(ApiResponse)]
+enum ClearWebApprovalsResponse {
+    #[oai(status = 200)]
+    Ok(Json<ClearWebApprovalsResult>),
+}
+
+fn scope_label(scope: &WebApprovalScopeKey) -> String {
+    match scope {
+        WebApprovalScopeKey::Untargeted => "sign-in".to_string(),
+        WebApprovalScopeKey::Target(name) => name.clone(),
+        WebApprovalScopeKey::AllTargets => "*".to_string(),
+    }
+}
+
+fn scope_key(target: Option<String>, all_targets: bool) -> WebApprovalScopeKey {
+    if all_targets {
+        WebApprovalScopeKey::AllTargets
+    } else if let Some(target) = target {
+        WebApprovalScopeKey::Target(target)
+    } else {
+        WebApprovalScopeKey::Untargeted
+    }
+}
+
+#[OpenApi]
+impl Api {
+    /// List currently active (unexpired) cached web-approval bypasses across
+    /// the whole cluster.
+    #[oai(
+        path = "/web-approvals",
+        method = "get",
+        operation_id = "list_web_approvals"
+    )]
+    async fn list_web_approvals(
+        &self,
+        req: &Request,
+        admin: ClusterOrAdminContext,
+    ) -> Result<ListWebApprovalsResponse, WarpgateError> {
+        let mut result = local_web_approvals(&admin).await?;
+
+        // Peer-forwarded copies of this request must not fan out again.
+        if !is_cluster_peer_request(req, &admin.services().cluster_token) {
+            result.extend(web_approvals_from_peers(&admin, req).await);
+        }
+
+        Ok(ListWebApprovalsResponse::Ok(Json(result)))
+    }
+
+    /// Clear every cached web-approval bypass, on this node and the rest of
+    /// the cluster, immediately requiring re-approval for anything that was
+    /// relying on one.
+    #[oai(
+        path = "/web-approvals",
+        method = "delete",
+        operation_id = "clear_web_approvals"
+    )]
+    async fn clear_web_approvals(
+        &self,
+        req: &Request,
+        admin: ClusterOrAdminContext,
+        /// Clear only this node's own cache instead of the whole cluster's.
+        /// Set on cluster-forwarded copies of the request.
+        local_only: Query<Option<bool>>,
+    ) -> Result<ClearWebApprovalsResponse, WarpgateError> {
+        admin.require(AdminPermission::ConfigEdit)?;
+
+        let mut cleared = admin.services().clear_web_approvals().await as u64;
+
+        if !local_only.unwrap_or(false) {
+            cleared = cleared.saturating_add(clear_on_peers(&admin, req).await);
+        }
+
+        Ok(ClearWebApprovalsResponse::Ok(Json(
+            ClearWebApprovalsResult {
+                cleared_count: cleared,
+            },
+        )))
+    }
+
+    /// Clear cached web-approval bypasses for a single user, on this node and
+    /// the rest of the cluster.
+    #[oai(
+        path = "/web-approvals/:username",
+        method = "delete",
+        operation_id = "clear_web_approvals_for_user"
+    )]
+    async fn clear_web_approvals_for_user(
+        &self,
+        req: &Request,
+        admin: ClusterOrAdminContext,
+        username: Path<String>,
+        /// Clear only this node's own cache instead of the whole cluster's.
+        /// Set on cluster-forwarded copies of the request.
+        local_only: Query<Option<bool>>,
+    ) -> Result<ClearWebApprovalsResponse, WarpgateError> {
+        admin.require(AdminPermission::ConfigEdit)?;
+
+        let mut cleared = admin
+            .services()
+            .clear_web_approvals_for_user(&username.0)
+            .await as u64;
+
+        if !local_only.unwrap_or(false) {
+            cleared = cleared.saturating_add(clear_on_peers(&admin, req).await);
+        }
+
+        Ok(ClearWebApprovalsResponse::Ok(Json(
+            ClearWebApprovalsResult {
+                cleared_count: cleared,
+            },
+        )))
+    }
+
+    /// Clear cached web-approval bypasses for a single user, restricted to one
+    /// scope (a target, or every target via `all_targets`) — for revoking a
+    /// single row of the admin approvals list rather than the whole user.
+    #[oai(
+        path = "/web-approvals/:username/scope",
+        method = "delete",
+        operation_id = "clear_web_approval_scope_for_user"
+    )]
+    #[allow(clippy::too_many_arguments)]
+    async fn clear_web_approval_scope_for_user(
+        &self,
+        req: &Request,
+        admin: ClusterOrAdminContext,
+        username: Path<String>,
+        /// Target name to revoke. Ignored when `all_targets` is set; omitted
+        /// together with `all_targets: false` for the untargeted (sign-in)
+        /// scope.
+        target: Query<Option<String>>,
+        /// Revoke the all-targets grant instead of a single target.
+        all_targets: Query<Option<bool>>,
+        /// Clear only this node's own cache instead of the whole cluster's.
+        /// Set on cluster-forwarded copies of the request.
+        local_only: Query<Option<bool>>,
+    ) -> Result<ClearWebApprovalsResponse, WarpgateError> {
+        admin.require(AdminPermission::ConfigEdit)?;
+
+        let scope = scope_key(target.0, all_targets.unwrap_or(false));
+        let mut cleared = admin
+            .services()
+            .clear_web_approvals_for_user_and_scope(&username.0, &scope)
+            .await as u64;
+
+        if !local_only.unwrap_or(false) {
+            cleared = cleared.saturating_add(clear_on_peers(&admin, req).await);
+        }
+
+        Ok(ClearWebApprovalsResponse::Ok(Json(
+            ClearWebApprovalsResult {
+                cleared_count: cleared,
+            },
+        )))
+    }
+}
+
+async fn local_web_approvals(
+    ctx: &AuthenticatedRequestContext,
+) -> Result<Vec<ActiveWebApprovalInfo>, WarpgateError> {
+    Ok(ctx
+        .services()
+        .list_active_web_approvals()
+        .await?
+        .into_iter()
+        .map(|(key, age)| {
+            let age = time::Duration::try_from(age).unwrap_or(time::Duration::ZERO);
+            let scope_target = match &key.scope {
+                WebApprovalScopeKey::Target(name) => Some(name.clone()),
+                WebApprovalScopeKey::Untargeted | WebApprovalScopeKey::AllTargets => None,
+            };
+            ActiveWebApprovalInfo {
+                username: key.username,
+                remote_ip: key.remote_ip.to_string(),
+                protocol: key.protocol.to_string(),
+                scope: scope_label(&key.scope),
+                all_targets: matches!(key.scope, WebApprovalScopeKey::AllTargets),
+                scope_target,
+                granted_at: OffsetDateTime::now_utc() - age,
+            }
+        })
+        .collect())
+}
+
+/// The same list from every other node, so the admin UI sees the whole
+/// cluster. Best effort: a peer that fails or answers unexpectedly
+/// contributes nothing rather than failing the request.
+async fn web_approvals_from_peers(
+    ctx: &AuthenticatedRequestContext,
+    req: &Request,
+) -> Vec<ActiveWebApprovalInfo> {
+    let mut results = vec![];
+    for (hostname, response) in fan_out_to_peers(ctx, req, req.original_uri().path()).await {
+        if response.status() != StatusCode::OK {
+            let status = response.status();
+            warn!(node = %hostname, %status, "Failed to list web approvals on a cluster node");
+            continue;
+        }
+        match parse_forwarded_body::<Vec<ActiveWebApprovalInfo>>(response).await {
+            Ok(items) => results.extend(items),
+            Err(error) => {
+                warn!(node = %hostname, %error, "Malformed web approval list from a cluster node");
+            }
+        }
+    }
+    results
+}
+
+/// Forward a clear request to every other registered cluster node, summing up
+/// how many entries each one cleared.
+///
+/// Best effort: an unreachable peer is logged, not raised — its cache expires
+/// on its own once the grace period elapses.
+async fn clear_on_peers(ctx: &AuthenticatedRequestContext, req: &Request) -> u64 {
+    // `local_only` stops the peers from fanning out again.
+    let separator = if req.original_uri().query().is_some() {
+        "&"
+    } else {
+        "?"
+    };
+    let path = format!("{}{separator}local_only=true", req.original_uri().path());
+
+    let mut total = 0u64;
+    for (hostname, response) in fan_out_to_peers(ctx, req, &path).await {
+        if response.status() != StatusCode::OK {
+            let status = response.status();
+            warn!(node = %hostname, %status, "Failed to clear web approvals on a cluster node");
+            continue;
+        }
+        match parse_forwarded_body::<ClearWebApprovalsResult>(response).await {
+            Ok(result) => total = total.saturating_add(result.cleared_count),
+            Err(error) => {
+                warn!(node = %hostname, %error, "Malformed clear-web-approvals response from a cluster node");
+            }
+        }
+    }
+    total
+}

--- a/warpgate-core/src/auth_state_store.rs
+++ b/warpgate-core/src/auth_state_store.rs
@@ -7,6 +7,7 @@ use tokio::sync::{Mutex, broadcast};
 use uuid::Uuid;
 use warpgate_common::auth::{
     AuthResult, AuthState, CredentialKind, CredentialPolicy, WebApprovalMatchKey,
+    WebApprovalScopeKey,
 };
 use warpgate_common::helpers::ipnet::WarpgateIpNet;
 use warpgate_common::helpers::username::username_eq_ci;
@@ -376,6 +377,51 @@ impl AuthStateStore {
         Ok(true)
     }
 
+    /// Clears every remembered web approval, immediately revoking all
+    /// outstanding auth-bypass grants. Returns the number of entries cleared.
+    pub fn clear_recent_approvals(&mut self) -> usize {
+        let count = self.recent_approvals.len();
+        self.recent_approvals.clear();
+        count
+    }
+
+    /// Clears remembered web approvals for a single user (case-insensitive),
+    /// immediately revoking that user's outstanding bypass grants. Returns the
+    /// number of entries cleared.
+    pub fn clear_recent_approvals_for_user(&mut self, username: &str) -> usize {
+        let before = self.recent_approvals.len();
+        self.recent_approvals
+            .retain(|key, _| !username_eq_ci(&key.username, username));
+        before - self.recent_approvals.len()
+    }
+
+    /// Clears remembered web approvals for a single user and scope
+    /// (case-insensitive username match), immediately revoking just that
+    /// target's — or, for [`WebApprovalScopeKey::AllTargets`], every
+    /// target's — bypass grant. Returns the number of entries cleared.
+    pub fn clear_recent_approvals_for_user_and_scope(
+        &mut self,
+        username: &str,
+        scope: &WebApprovalScopeKey,
+    ) -> usize {
+        let before = self.recent_approvals.len();
+        self.recent_approvals
+            .retain(|key, _| !(username_eq_ci(&key.username, username) && &key.scope == scope));
+        before - self.recent_approvals.len()
+    }
+
+    /// Remembered web approvals still within `grace`, paired with how long ago
+    /// each was granted. For admin visibility into active bypass grants.
+    pub fn list_active_approvals(&self, grace: Duration) -> Vec<(WebApprovalMatchKey, Duration)> {
+        self.recent_approvals
+            .iter()
+            .filter_map(|(key, at)| {
+                let age = at.elapsed();
+                (age < grace).then(|| (key.clone(), age))
+            })
+            .collect()
+    }
+
     pub fn vacuum(&mut self) {
         self.store
             .retain(|_, (_, started_at)| started_at.elapsed() < *TIMEOUT);
@@ -708,6 +754,72 @@ mod tests {
         assert!(!store.recent_approval_is_fresh(&for_target("prod"), grace));
         // ...nor be mistaken for an all-targets grant.
         assert!(!store.recent_approval_is_fresh(&for_target("prod").for_all_targets(), grace));
+    }
+
+    #[test]
+    fn clear_recent_approvals_removes_everything() {
+        let mut store = AuthStateStore::new();
+        store.record_web_approval(for_target("prod"));
+        store.record_web_approval(approval_key(WebApprovalScopeKey::AllTargets));
+
+        assert_eq!(store.clear_recent_approvals(), 2);
+        assert_eq!(store.clear_recent_approvals(), 0);
+
+        let grace = Duration::from_secs(3600);
+        assert!(!store.recent_approval_is_fresh(&for_target("prod"), grace));
+        assert!(!store.recent_approval_is_fresh(
+            &approval_key(WebApprovalScopeKey::AllTargets),
+            grace
+        ));
+    }
+
+    #[test]
+    fn clear_recent_approvals_for_user_only_removes_that_users_entries() {
+        let mut store = AuthStateStore::new();
+        store.record_web_approval(for_target("prod"));
+
+        let mut other_user = for_target("prod");
+        other_user.username = "bob".into();
+        store.record_web_approval(other_user.clone());
+
+        // Case-insensitive, matching the rest of the auth path.
+        assert_eq!(store.clear_recent_approvals_for_user("ALICE"), 1);
+
+        let grace = Duration::from_secs(3600);
+        assert!(!store.recent_approval_is_fresh(&for_target("prod"), grace));
+        assert!(store.recent_approval_is_fresh(&other_user, grace));
+    }
+
+    #[test]
+    fn clear_recent_approvals_for_user_and_scope_only_removes_the_matching_scope() {
+        let mut store = AuthStateStore::new();
+        store.record_web_approval(for_target("prod"));
+        store.record_web_approval(for_target("staging"));
+
+        assert_eq!(
+            store.clear_recent_approvals_for_user_and_scope(
+                "alice",
+                &WebApprovalScopeKey::Target("prod".into())
+            ),
+            1
+        );
+
+        let grace = Duration::from_secs(3600);
+        assert!(!store.recent_approval_is_fresh(&for_target("prod"), grace));
+        assert!(store.recent_approval_is_fresh(&for_target("staging"), grace));
+    }
+
+    #[test]
+    fn list_active_approvals_only_returns_entries_within_grace() {
+        let mut store = AuthStateStore::new();
+        store.record_web_approval(for_target("prod"));
+
+        let grace = Duration::from_secs(3600);
+        let active = store.list_active_approvals(grace);
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].0, for_target("prod"));
+
+        assert!(store.list_active_approvals(Duration::ZERO).is_empty());
     }
 
     #[test]

--- a/warpgate-core/src/services.rs
+++ b/warpgate-core/src/services.rs
@@ -7,7 +7,7 @@ use sea_orm::sea_query::Expr;
 use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 use tokio::sync::Mutex;
 use tracing::warn;
-use warpgate_common::auth::{AuthState, CredentialKind};
+use warpgate_common::auth::{AuthState, CredentialKind, WebApprovalMatchKey, WebApprovalScopeKey};
 use warpgate_common::{GlobalParams, Protocol, Secret, SessionId, WarpgateConfig, WarpgateError};
 use warpgate_db_entities::Parameters;
 
@@ -192,5 +192,51 @@ impl Services {
             .await
             .try_web_approval_bypass(state_arc, grace)
             .await
+    }
+
+    /// Clears every remembered web approval on this node, immediately revoking
+    /// all of its outstanding auth-bypass grants. Returns the number of
+    /// entries cleared.
+    pub async fn clear_web_approvals(&self) -> usize {
+        self.auth_state_store.lock().await.clear_recent_approvals()
+    }
+
+    /// Clears remembered web approvals for a single user, immediately revoking
+    /// that user's outstanding bypass grants. Returns the number cleared.
+    pub async fn clear_web_approvals_for_user(&self, username: &str) -> usize {
+        self.auth_state_store
+            .lock()
+            .await
+            .clear_recent_approvals_for_user(username)
+    }
+
+    /// Clears remembered web approvals for a single user and scope,
+    /// immediately revoking just that target's — or, for
+    /// [`WebApprovalScopeKey::AllTargets`], every target's — bypass grant.
+    /// Returns the number cleared.
+    pub async fn clear_web_approvals_for_user_and_scope(
+        &self,
+        username: &str,
+        scope: &WebApprovalScopeKey,
+    ) -> usize {
+        self.auth_state_store
+            .lock()
+            .await
+            .clear_recent_approvals_for_user_and_scope(username, scope)
+    }
+
+    /// Active (still-within-grace) remembered web approvals, for admin
+    /// visibility. Empty if web-approval caching is disabled.
+    pub async fn list_active_web_approvals(
+        &self,
+    ) -> Result<Vec<(WebApprovalMatchKey, Duration)>, WarpgateError> {
+        let Some(grace) = self.web_approval_grace_period().await? else {
+            return Ok(vec![]);
+        };
+        Ok(self
+            .auth_state_store
+            .lock()
+            .await
+            .list_active_approvals(grace))
     }
 }

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate Web Admin",
-    "version": "v0.28.0-beta.3-modified"
+    "version": "v0.28.2-1-g250f869b-modified"
   },
   "servers": [
     {
@@ -4399,10 +4399,247 @@
         ],
         "operationId": "revoke_certificate_credential"
       }
+    },
+    "/web-approvals": {
+      "get": {
+        "summary": "List currently active (unexpired) cached web-approval bypasses across\nthe whole cluster.",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActiveWebApprovalInfo"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          },
+          {
+            "ClusterTokenSecurityScheme": []
+          }
+        ],
+        "operationId": "list_web_approvals"
+      },
+      "delete": {
+        "summary": "Clear every cached web-approval bypass, on this node and the rest of\nthe cluster, immediately requiring re-approval for anything that was\nrelying on one.",
+        "parameters": [
+          {
+            "name": "local_only",
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "description": "Clear only this node's own cache instead of the whole cluster's.\nSet on cluster-forwarded copies of the request.",
+            "required": false,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClearWebApprovalsResult"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          },
+          {
+            "ClusterTokenSecurityScheme": []
+          }
+        ],
+        "operationId": "clear_web_approvals"
+      }
+    },
+    "/web-approvals/{username}": {
+      "delete": {
+        "summary": "Clear cached web-approval bypasses for a single user, on this node and\nthe rest of the cluster.",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          },
+          {
+            "name": "local_only",
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "description": "Clear only this node's own cache instead of the whole cluster's.\nSet on cluster-forwarded copies of the request.",
+            "required": false,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClearWebApprovalsResult"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          },
+          {
+            "ClusterTokenSecurityScheme": []
+          }
+        ],
+        "operationId": "clear_web_approvals_for_user"
+      }
+    },
+    "/web-approvals/{username}/scope": {
+      "delete": {
+        "summary": "Clear cached web-approval bypasses for a single user, restricted to one\nscope (a target, or every target via `all_targets`) — for revoking a\nsingle row of the admin approvals list rather than the whole user.",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true,
+            "deprecated": false,
+            "explode": true
+          },
+          {
+            "name": "target",
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "description": "Target name to revoke. Ignored when `all_targets` is set; omitted\ntogether with `all_targets: false` for the untargeted (sign-in)\nscope.",
+            "required": false,
+            "deprecated": false,
+            "explode": true
+          },
+          {
+            "name": "all_targets",
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "description": "Revoke the all-targets grant instead of a single target.",
+            "required": false,
+            "deprecated": false,
+            "explode": true
+          },
+          {
+            "name": "local_only",
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "description": "Clear only this node's own cache instead of the whole cluster's.\nSet on cluster-forwarded copies of the request.",
+            "required": false,
+            "deprecated": false,
+            "explode": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClearWebApprovalsResult"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "TokenSecurityScheme": []
+          },
+          {
+            "CookieSecurityScheme": []
+          },
+          {
+            "ClusterTokenSecurityScheme": []
+          }
+        ],
+        "operationId": "clear_web_approval_scope_for_user"
+      }
     }
   },
   "components": {
     "schemas": {
+      "ActiveWebApprovalInfo": {
+        "type": "object",
+        "title": "ActiveWebApprovalInfo",
+        "required": [
+          "username",
+          "remote_ip",
+          "protocol",
+          "scope",
+          "all_targets",
+          "granted_at"
+        ],
+        "properties": {
+          "username": {
+            "type": "string"
+          },
+          "remote_ip": {
+            "type": "string"
+          },
+          "protocol": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string",
+            "description": "Human-readable summary of what the approval covers: a target name,\n`*` for all targets, or `sign-in` for an untargeted portal/menu login."
+          },
+          "scope_target": {
+            "type": "string",
+            "description": "The target name when this approval is scoped to one target — echo\nthis back (with `all_targets: false`) to revoke just this row via\n`clear_web_approval_scope_for_user`."
+          },
+          "all_targets": {
+            "type": "boolean",
+            "description": "Whether this approval covers every target — echo this back to revoke\njust this row."
+          },
+          "granted_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
       "AddSshKnownHostRequest": {
         "type": "object",
         "title": "AddSshKnownHostRequest",
@@ -4720,6 +4957,19 @@
           },
           "remote_key_base64": {
             "type": "string"
+          }
+        }
+      },
+      "ClearWebApprovalsResult": {
+        "type": "object",
+        "title": "ClearWebApprovalsResult",
+        "required": [
+          "cleared_count"
+        ],
+        "properties": {
+          "cleared_count": {
+            "type": "integer",
+            "format": "uint64"
           }
         }
       },

--- a/warpgate-web/src/admin/status/Status.svelte
+++ b/warpgate-web/src/admin/status/Status.svelte
@@ -13,6 +13,9 @@
         '/login-protection': wrap({
             asyncComponent: () => import('./LoginProtection.svelte'),
         }),
+        '/web-approvals': wrap({
+            asyncComponent: () => import('./WebApprovals.svelte'),
+        }),
         '/network': wrap({
             asyncComponent: () => import('./NetworkStatus.svelte'),
         }),
@@ -43,6 +46,14 @@
             title="Network status"
             description="Listeners, certificates and client IP detection"
             href="/status/network"
+        />
+
+        <NavListItem
+            small
+            class="mb-2"
+            title="Web approvals"
+            description="View and revoke cached approval bypasses"
+            href="/status/web-approvals"
         />
     {/snippet}
 </SidebarNavContainer>

--- a/warpgate-web/src/admin/status/WebApprovals.svelte
+++ b/warpgate-web/src/admin/status/WebApprovals.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+    import { Alert, Button, Input } from '@sveltestrap/sveltestrap'
+    import { api, type ActiveWebApprovalInfo } from 'admin/lib/api'
+    import AsyncButton from 'common/AsyncButton.svelte'
+    import DelayedSpinner from 'common/DelayedSpinner.svelte'
+    import { stringifyError } from 'common/errors'
+    import RelativeDate from 'common/RelativeDate.svelte'
+    import { onMount } from 'svelte'
+
+    let loading = $state(true)
+    let error: string | undefined = $state()
+    let approvals: ActiveWebApprovalInfo[] | undefined = $state()
+    let usernameToClear = $state('')
+
+    let usersWithActiveCache = $derived(
+        [...new Set((approvals ?? []).map(a => a.username))].sort(),
+    )
+
+    async function load() {
+        loading = true
+        error = undefined
+        try {
+            approvals = await api.listWebApprovals()
+        } catch (err) {
+            error = await stringifyError(err)
+        } finally {
+            loading = false
+        }
+    }
+
+    load()
+
+    $effect(() => {
+        if (usernameToClear && !usersWithActiveCache.includes(usernameToClear)) {
+            usernameToClear = ''
+        }
+    })
+
+    onMount(() => {
+        const refreshTimer = setInterval(load, 30_000)
+        return () => {
+            clearInterval(refreshTimer)
+        }
+    })
+
+    async function clearAll() {
+        if (
+            !confirm(
+                'Clear every cached approval bypass? Everyone currently relying on one will be asked to approve again on their next connection.',
+            )
+        ) {
+            return
+        }
+        try {
+            await api.clearWebApprovals()
+            await load()
+        } catch (err) {
+            error = await stringifyError(err)
+        }
+    }
+
+    async function clearForUser(username: string) {
+        if (
+            !confirm(
+                `Clear cached approval bypasses for ${username}? They'll be asked to approve again on their next connection.`,
+            )
+        ) {
+            return
+        }
+        try {
+            await api.clearWebApprovalsForUser({ username })
+            await load()
+        } catch (err) {
+            error = await stringifyError(err)
+        }
+    }
+
+    async function clearForSelectedUser() {
+        if (!usernameToClear) {
+            return
+        }
+        await clearForUser(usernameToClear)
+        usernameToClear = ''
+    }
+
+    function scopeDescription(approval: ActiveWebApprovalInfo) {
+        return approval.allTargets ? 'all targets' : `target "${approval.scope}"`
+    }
+
+    async function revokeApproval(approval: ActiveWebApprovalInfo) {
+        if (
+            !confirm(
+                `Revoke ${approval.username}'s cached approval for ${scopeDescription(approval)}? They'll be asked to approve again on their next connection to it.`,
+            )
+        ) {
+            return
+        }
+        try {
+            await api.clearWebApprovalScopeForUser({
+                username: approval.username,
+                target: approval.scopeTarget,
+                allTargets: approval.allTargets,
+            })
+            await load()
+        } catch (err) {
+            error = await stringifyError(err)
+        }
+    }
+</script>
+
+<div class="container-max-md">
+    <div class="page-summary-bar">
+        <h1>web approvals</h1>
+        <AsyncButton color="danger" outline click={clearAll}>
+            Clear all
+        </AsyncButton>
+    </div>
+
+    <p class="text-muted">
+        Cached approval bypasses let a previously-approved login skip
+        re-approval for a while. Clear them here to force re-approval
+        immediately &mdash; for example during offboarding or after a
+        suspected key compromise.
+    </p>
+
+    {#if error}
+        <Alert color="danger" dismissible onclose={() => { error = undefined }}>
+            {error}
+            <Button color="link" size="sm" onclick={load}>Retry</Button>
+        </Alert>
+    {/if}
+
+    <div class="d-flex gap-2 mb-3">
+        <Input type="select" bind:value={usernameToClear} disabled={usersWithActiveCache.length === 0}>
+            <option value="">
+                {usersWithActiveCache.length > 0 ? 'Select a user…' : 'No users with an active cache'}
+            </option>
+            {#each usersWithActiveCache as username (username)}
+                <option value={username}>{username}</option>
+            {/each}
+        </Input>
+        <AsyncButton
+            color="secondary"
+            outline
+            disabled={!usernameToClear}
+            click={clearForSelectedUser}
+        >
+            Clear all for user
+        </AsyncButton>
+    </div>
+
+    {#if loading && !approvals}
+        <DelayedSpinner />
+    {:else if approvals && approvals.length > 0}
+        <div class="section-header">
+            <h5 class="m-0">Active approvals</h5>
+            <span class="badge text-bg-secondary">{approvals.length}</span>
+        </div>
+        <div class="list-group list-group-flush mb-3">
+            {#each approvals as approval (`${approval.username}-${approval.remoteIp}-${approval.protocol}-${approval.scope}`)}
+                <div class="list-group-item">
+                    <div class="d-flex align-items-center w-100">
+                        <div>
+                            <strong>{approval.username}</strong>
+                            <small class="d-block text-muted">
+                                {approval.protocol}
+                                &middot; {approval.scope}
+                                &middot; from {approval.remoteIp}
+                                &middot; approved
+                                <RelativeDate
+                                    date={new Date(approval.grantedAt)}
+                                />
+                            </small>
+                        </div>
+                        <AsyncButton
+                            class="ms-auto"
+                            color="link"
+                            click={() => revokeApproval(approval)}
+                        >
+                            Revoke
+                        </AsyncButton>
+                    </div>
+                </div>
+            {/each}
+        </div>
+    {:else}
+        <p class="text-muted">No active approval bypasses.</p>
+    {/if}
+</div>
+
+<style lang="scss">
+    .section-header {
+        display: flex;
+        align-items: center;
+        gap: .5rem;
+        margin-bottom: .5rem;
+    }
+</style>


### PR DESCRIPTION
## Description

Following [this issue](https://github.com/warp-tech/warpgate/issues/2334)

Administrators had no way to invalidate active authentication-approval bypasses (the cached "remembered web approval" that lets a login skip re-approval for the configured grace period) without waiting it out. This adds that capability, for use during offboarding, a suspected key compromise, or a policy change.

### Backend (`warpgate-admin`, `warpgate-core`)
- `GET /web-approvals` — list currently active (unexpired) cached bypasses,
  aggregated across the cluster.
- `DELETE /web-approvals` — clear every cached bypass (global).
- `DELETE /web-approvals/:username` — clear all cached bypasses for one user.
- `DELETE /web-approvals/:username/scope` — clear a single target's (or,
  via `all_targets`, every target's) bypass for one user, for row-level
  revoke from the UI.

All mutating endpoints require the `config_edit` admin permission. The
cache is per-node in-memory, so clears fan out to every other cluster node
(same pattern as session termination), and reads aggregate results from
all nodes too.

### Web Admin UI
New "Web approvals" page under Status: lists active bypasses (user,
protocol, target/scope, source IP, granted-at), with:
- a "Clear all" button,
- a dropdown of users currently holding a cached bypass, to clear all of
  that user's bypasses,
- a per-row "Revoke" action that clears only that row's specific
  target/scope rather than the whole user.

### Tests
- Unit tests for the new `AuthStateStore` / `Services` methods
  (clear all / clear for user / clear for user+scope / list active).
- Added the missing `AdminApiTestCase` entries for the 4 new operations so
  the admin-API permission-coverage test passes.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [X] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
