### PR TITLE
Default web approval action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ node_modules
 .github
 *.md
 .env
+.DS_Store

--- a/warpgate-admin/src/api/parameters.rs
+++ b/warpgate-admin/src/api/parameters.rs
@@ -66,6 +66,7 @@ struct ParameterValues {
     pub password_login_mode: Parameters::PasswordLoginMode,
     /// Deprecated in 0.26: superseded by `password_login_mode`
     pub minimize_password_login: bool,
+    pub default_web_approval_scope: Parameters::DefaultWebApprovalScope,
     pub ticket_self_service_enabled: bool,
     pub ticket_auto_approve_existing_access: bool,
     pub ticket_max_duration_seconds: Option<i64>,
@@ -112,6 +113,7 @@ struct ParameterUpdate {
     pub ssh_client_auth_keyboard_interactive: Option<bool>,
     pub ssh_host_key_verification: Option<Parameters::SshHostKeyVerificationMode>,
     pub password_login_mode: Option<Parameters::PasswordLoginMode>,
+    pub default_web_approval_scope: Option<Parameters::DefaultWebApprovalScope>,
     pub ticket_self_service_enabled: Option<bool>,
     pub ticket_auto_approve_existing_access: Option<bool>,
     #[oai(deserialize_with = "parse_nullable")]
@@ -209,6 +211,7 @@ impl Api {
             password_login_mode: parameters.password_login_mode,
             minimize_password_login: parameters.password_login_mode
                 == Parameters::PasswordLoginMode::Minimized,
+            default_web_approval_scope: parameters.default_web_approval_scope,
             ticket_self_service_enabled: parameters.ticket_self_service_enabled,
             ticket_auto_approve_existing_access: parameters.ticket_auto_approve_existing_access,
             ticket_max_duration_seconds: parameters.ticket_max_duration_seconds,
@@ -302,6 +305,8 @@ impl Api {
             .map_or(NotSet, Set);
         parameters.ssh_host_key_verification = body.ssh_host_key_verification.map_or(NotSet, Set);
         parameters.password_login_mode = body.password_login_mode.map_or(NotSet, Set);
+        parameters.default_web_approval_scope =
+            body.default_web_approval_scope.map_or(NotSet, Set);
         parameters.ticket_self_service_enabled =
             body.ticket_self_service_enabled.map_or(NotSet, Set);
         parameters.ticket_auto_approve_existing_access =

--- a/warpgate-core/src/services.rs
+++ b/warpgate-core/src/services.rs
@@ -178,6 +178,15 @@ impl Services {
             .map(Duration::from_secs))
     }
 
+    /// Which action is the one-click default in the in-browser web approval dialog.
+    pub async fn default_web_approval_scope(
+        &self,
+    ) -> Result<Parameters::DefaultWebApprovalScope, WarpgateError> {
+        Ok(Parameters::Entity::get(&self.db)
+            .await?
+            .default_web_approval_scope)
+    }
+
     /// If a matching web approval is still within the grace period, satisfies the
     /// pending `WebUserApproval` requirement and logs an audit event
     pub async fn try_web_approval_bypass(

--- a/warpgate-db-entities/src/Parameters.rs
+++ b/warpgate-db-entities/src/Parameters.rs
@@ -49,6 +49,26 @@ pub enum PasswordLoginMode {
     Disabled,
 }
 
+/// Which action is the one-click default in the in-browser web approval
+/// dialog. Variant names match `WebApprovalScope` in
+/// `warpgate-protocol-http`'s auth API.
+#[derive(
+    Debug, Default, PartialEq, Eq, Serialize, Clone, Copy, Enum, EnumIter, DeriveActiveEnum,
+)]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::N(32))")]
+pub enum DefaultWebApprovalScope {
+    /// Approve without remembering.
+    #[sea_orm(string_value = "Once")]
+    Once,
+    /// Approve and remember for this target only.
+    #[default]
+    #[sea_orm(string_value = "Target")]
+    Target,
+    /// Approve and remember for all targets.
+    #[sea_orm(string_value = "AllTargets")]
+    AllTargets,
+}
+
 /// What to do when a target's SSH host key isn't in the known hosts list.
 #[derive(
     Debug, Default, PartialEq, Eq, Serialize, Clone, Copy, Enum, EnumIter, DeriveActiveEnum,
@@ -165,6 +185,7 @@ pub struct Model {
     pub ssh_client_auth_keyboard_interactive: bool,
     pub ssh_host_key_verification: SshHostKeyVerificationMode,
     pub password_login_mode: PasswordLoginMode,
+    pub default_web_approval_scope: DefaultWebApprovalScope,
     pub ticket_self_service_enabled: bool,
     pub ticket_auto_approve_existing_access: bool,
     pub ticket_max_duration_seconds: Option<i64>,
@@ -269,6 +290,7 @@ impl Entity {
                         get_config_migration_values().ssh_host_key_verification
                     ),
                     password_login_mode: Set(PasswordLoginMode::Enabled),
+                    default_web_approval_scope: Set(DefaultWebApprovalScope::Target),
                     ticket_self_service_enabled: Set(false),
                     ticket_auto_approve_existing_access: Set(true),
                     ticket_max_duration_seconds: Set(Some(28800)),

--- a/warpgate-db-migrations/src/lib.rs
+++ b/warpgate-db-migrations/src/lib.rs
@@ -81,6 +81,7 @@ mod m00074_encryption_key_rotation;
 mod m00075_hash_ticket_and_api_token_secrets;
 mod m00076_open_targets_in_new_tab;
 mod m00077_session_user_target_id;
+mod m00078_default_web_approval_scope;
 
 pub(crate) mod helpers;
 
@@ -167,6 +168,7 @@ impl MigratorTrait for Migrator {
             Box::new(m00075_hash_ticket_and_api_token_secrets::Migration),
             Box::new(m00076_open_targets_in_new_tab::Migration),
             Box::new(m00077_session_user_target_id::Migration),
+            Box::new(m00078_default_web_approval_scope::Migration),
         ]
     }
 }

--- a/warpgate-db-migrations/src/m00078_default_web_approval_scope.rs
+++ b/warpgate-db-migrations/src/m00078_default_web_approval_scope.rs
@@ -1,0 +1,36 @@
+use sea_orm_migration::prelude::*;
+
+use crate::m00010_parameters::parameters;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(parameters::Entity)
+                    .add_column(
+                        ColumnDef::new(Alias::new("default_web_approval_scope"))
+                            .string()
+                            .not_null()
+                            .default("Target"),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(parameters::Entity)
+                    .drop_column(Alias::new("default_web_approval_scope"))
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/warpgate-protocol-http/src/api/auth.rs
+++ b/warpgate-protocol-http/src/api/auth.rs
@@ -121,6 +121,8 @@ struct AuthStateResponseInternal {
     /// When web-approval caching is enabled, the caching window in seconds;
     /// `None` when caching is disabled.
     pub web_approval_caching_grace_seconds: Option<i64>,
+    /// Which action is the one-click default in the approval dialog.
+    pub default_web_approval_scope: WebApprovalScope,
 }
 
 /// How an web approval should be remembered for bypass
@@ -129,6 +131,16 @@ enum WebApprovalScope {
     Once,
     Target,
     AllTargets,
+}
+
+impl From<Parameters::DefaultWebApprovalScope> for WebApprovalScope {
+    fn from(scope: Parameters::DefaultWebApprovalScope) -> Self {
+        match scope {
+            Parameters::DefaultWebApprovalScope::Once => Self::Once,
+            Parameters::DefaultWebApprovalScope::Target => Self::Target,
+            Parameters::DefaultWebApprovalScope::AllTargets => Self::AllTargets,
+        }
+    }
 }
 
 #[derive(Object)]
@@ -846,6 +858,8 @@ async fn serialize_auth_state_inner(
         .await?
         .and_then(|d| i64::try_from(d.as_secs()).ok());
 
+    let default_web_approval_scope = services.default_web_approval_scope().await?.into();
+
     Ok(AuthStateResponseInternal {
         id: state.session_id().to_string(),
         protocol: state.protocol().to_string(),
@@ -854,6 +868,7 @@ async fn serialize_auth_state_inner(
         state: state.verify().into(),
         identification_string: state.identification_string().to_owned(),
         web_approval_caching_grace_seconds,
+        default_web_approval_scope,
     })
 }
 

--- a/warpgate-web/src/admin/config/Parameters.svelte
+++ b/warpgate-web/src/admin/config/Parameters.svelte
@@ -4,6 +4,7 @@
     import {
         AnalyticsConsent,
         api,
+        type DefaultWebApprovalScope,
         type OpenTargetsInNewTabMode,
         type ParameterValues,
         type PasswordLoginMode,
@@ -666,6 +667,34 @@
                                     it for new sessions by the same user to the
                                     same target from the same IP. Blank = never
                                     cache approvals.
+                                </HelpText>
+
+                                <FormGroup
+                                    floating
+                                    label="Default web approval action"
+                                >
+                                    <select
+                                        id="defaultWebApprovalScope"
+                                        class="form-select"
+                                        value={parameters.defaultWebApprovalScope ?? 'Target'}
+                                        onchange={e => parameters.defaultWebApprovalScope = e.currentTarget.value as DefaultWebApprovalScope}
+                                    >
+                                        <option value="Target">
+                                            Authorize & remember (single target)
+                                        </option>
+                                        <option value="AllTargets">
+                                            Authorize for all targets & remember
+                                        </option>
+                                        <option value="Once">
+                                            Authorize this time only
+                                        </option>
+                                    </select>
+                                </FormGroup>
+                                <HelpText>
+                                    Which action is the one-click default in
+                                    the in-browser approval dialog. Only
+                                    relevant while a web approval cache period
+                                    is set above.
                                 </HelpText>
 
                                 <FormGroup>

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate Web Admin",
-    "version": "v0.28.0-beta.3-modified"
+    "version": "v0.28.2-1-g250f869b-modified"
   },
   "servers": [
     {
@@ -4936,6 +4936,15 @@
           }
         }
       },
+      "DefaultWebApprovalScope": {
+        "type": "string",
+        "description": "Which action is the one-click default in the in-browser web approval\ndialog. Variant names match `WebApprovalScope` in\n`warpgate-protocol-http`'s auth API.",
+        "enum": [
+          "Once",
+          "Target",
+          "AllTargets"
+        ]
+      },
       "DenyTicketRequestBody": {
         "type": "object",
         "title": "DenyTicketRequestBody",
@@ -5653,6 +5662,9 @@
           "password_login_mode": {
             "$ref": "#/components/schemas/PasswordLoginMode"
           },
+          "default_web_approval_scope": {
+            "$ref": "#/components/schemas/DefaultWebApprovalScope"
+          },
           "ticket_self_service_enabled": {
             "type": "boolean"
           },
@@ -5780,6 +5792,7 @@
           "ssh_host_key_verification",
           "password_login_mode",
           "minimize_password_login",
+          "default_web_approval_scope",
           "ticket_self_service_enabled",
           "ticket_auto_approve_existing_access",
           "ticket_require_description",
@@ -5836,6 +5849,9 @@
           "minimize_password_login": {
             "type": "boolean",
             "description": "Deprecated in 0.26: superseded by `password_login_mode`"
+          },
+          "default_web_approval_scope": {
+            "$ref": "#/components/schemas/DefaultWebApprovalScope"
           },
           "ticket_self_service_enabled": {
             "type": "boolean"

--- a/warpgate-web/src/gateway/OutOfBandAuth.svelte
+++ b/warpgate-web/src/gateway/OutOfBandAuth.svelte
@@ -30,6 +30,25 @@
     let cachingEnabled = $derived(cachingGrace > 0)
     let graceLabel = $derived(formatDurationAsHumantime(cachingGrace))
 
+    function labelForScope(scope: WebApprovalScope): string {
+        switch (scope) {
+            case WebApprovalScope.Target:
+                return `Authorize & remember for ${graceLabel}`
+            case WebApprovalScope.AllTargets:
+                return `Authorize for all targets & remember for ${graceLabel}`
+            case WebApprovalScope.Once:
+                return 'Authorize this time only'
+        }
+    }
+
+    const allScopes = [
+        WebApprovalScope.Target,
+        WebApprovalScope.AllTargets,
+        WebApprovalScope.Once,
+    ]
+    let primaryScope = $derived(authState?.defaultWebApprovalScope ?? WebApprovalScope.Target)
+    let otherScopes = $derived(allScopes.filter(s => s !== primaryScope))
+
     async function reload() {
         authState = await api.getAuthState({ id: params.stateId })
     }
@@ -107,9 +126,9 @@
                     <ButtonGroup>
                         <AsyncButton
                             color="primary"
-                            click={() => approve(WebApprovalScope.Target)}
+                            click={() => approve(primaryScope)}
                         >
-                            Authorize & remember for {graceLabel}
+                            {labelForScope(primaryScope)}
                         </AsyncButton>
                         <Dropdown class="btn-group">
                             <DropdownToggle
@@ -118,17 +137,13 @@
                                 class="ps-2"
                             />
                             <DropdownMenu end>
-                                <DropdownItem
-                                    onclick={() => approve(WebApprovalScope.AllTargets)}
-                                >
-                                    Authorize for all targets & remember for
-                                    {graceLabel}
-                                </DropdownItem>
-                                <DropdownItem
-                                    onclick={() => approve(WebApprovalScope.Once)}
-                                >
-                                    Authorize this time only
-                                </DropdownItem>
+                                {#each otherScopes as scope (scope)}
+                                    <DropdownItem
+                                        onclick={() => approve(scope)}
+                                    >
+                                        {labelForScope(scope)}
+                                    </DropdownItem>
+                                {/each}
                             </DropdownMenu>
                         </Dropdown>
                     </ButtonGroup>

--- a/warpgate-web/src/gateway/lib/openapi-schema.json
+++ b/warpgate-web/src/gateway/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate HTTP proxy",
-    "version": "v0.28.0-beta.3-modified"
+    "version": "v0.28.2-1-g250f869b-modified"
   },
   "servers": [
     {
@@ -1720,7 +1720,8 @@
           "protocol",
           "started",
           "state",
-          "identification_string"
+          "identification_string",
+          "default_web_approval_scope"
         ],
         "properties": {
           "id": {
@@ -1746,6 +1747,17 @@
             "type": "integer",
             "format": "int64",
             "description": "When web-approval caching is enabled, the caching window in seconds;\n`None` when caching is disabled."
+          },
+          "default_web_approval_scope": {
+            "description": "Which action is the one-click default in the approval dialog.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WebApprovalScope"
+              },
+              {
+                "description": "Which action is the one-click default in the approval dialog."
+              }
+            ]
           }
         }
       },


### PR DESCRIPTION
## Description

Following [this issue](https://github.com/warp-tech/warpgate/issues/2333)

Adds a new admin parameter, "Default web approval action", to configure which action is presented as the primary (one-click) button in the in-browser web approval dialog (`OutOfBandAuth`), among:

- Authorize & remember (single target) — default, matches current behavior
- Authorize for all targets & remember
- Authorize this time only

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
