### PR TITLE
Granular cache duration hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ node_modules
 .github
 *.md
 .env
+.DS_Store

--- a/warpgate-admin/src/api/ldap_servers.rs
+++ b/warpgate-admin/src/api/ldap_servers.rs
@@ -77,6 +77,7 @@ impl ImportApi {
                         ldap_object_uuid: Set(Some(user.object_uuid)),
                         ldap_server_id: Set(Some(server.id)),
                         allowed_ip_ranges: Set(serde_json::Value::Null),
+                        web_approval_grace_period_seconds: Set(None),
                     };
                     values.insert(db).await?;
                     imported.push(user.username.clone());

--- a/warpgate-admin/src/api/roles.rs
+++ b/warpgate-admin/src/api/roles.rs
@@ -18,6 +18,7 @@ struct RoleDataRequest {
     name: String,
     description: Option<String>,
     is_default: Option<bool>,
+    web_approval_grace_period_seconds: Option<i64>,
 }
 
 #[derive(ApiResponse)]
@@ -81,6 +82,7 @@ impl ListApi {
             name: Set(body.name.clone()),
             description: Set(body.description.clone().unwrap_or_default()),
             is_default: Set(body.is_default.unwrap_or(false)),
+            web_approval_grace_period_seconds: Set(body.web_approval_grace_period_seconds),
         };
 
         let role = values.insert(db).await.map_err(WarpgateError::from)?;
@@ -169,6 +171,7 @@ impl DetailApi {
         model.name = Set(body.name.clone());
         model.description = Set(body.description.clone().unwrap_or_default());
         model.is_default = Set(body.is_default.unwrap_or(current_is_default));
+        model.web_approval_grace_period_seconds = Set(body.web_approval_grace_period_seconds);
         let role = model.update(db).await?;
 
         Ok(UpdateRoleResponse::Ok(Json(role.into())))

--- a/warpgate-admin/src/api/users.rs
+++ b/warpgate-admin/src/api/users.rs
@@ -30,6 +30,7 @@ struct UserDataRequest {
     description: Option<String>,
     rate_limit_bytes_per_second: Option<u32>,
     allowed_ip_ranges: Option<Vec<String>>,
+    web_approval_grace_period_seconds: Option<i64>,
 }
 
 #[derive(ApiResponse)]
@@ -109,6 +110,7 @@ impl ListApi {
             ldap_server_id: Set(None),
             ldap_object_uuid: Set(None),
             allowed_ip_ranges: Set(serde_json::Value::Null),
+            web_approval_grace_period_seconds: Set(None),
         };
 
         let user = values.insert(db).await.map_err(WarpgateError::from)?;
@@ -262,6 +264,7 @@ impl DetailApi {
                 .map_err(WarpgateError::from)?,
             None => serde_json::Value::Null,
         });
+        model.web_approval_grace_period_seconds = Set(body.web_approval_grace_period_seconds);
         let user = model.update(db).await?;
 
         warpgate_core::rate_limiting::apply_new_rate_limits(

--- a/warpgate-common/src/config/mod.rs
+++ b/warpgate-common/src/config/mod.rs
@@ -151,6 +151,7 @@ pub struct User {
     pub rate_limit_bytes_per_second: Option<i64>,
     pub ldap_server_id: Option<Uuid>,
     pub allowed_ip_ranges: Option<Vec<WarpgateIpNet>>,
+    pub web_approval_grace_period_seconds: Option<i64>,
 }
 
 #[derive(Debug, Clone, Object)]
@@ -174,6 +175,7 @@ pub struct Role {
     pub name: String,
     pub description: String,
     pub is_default: bool,
+    pub web_approval_grace_period_seconds: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Object)]

--- a/warpgate-core/src/auth_state_store.rs
+++ b/warpgate-core/src/auth_state_store.rs
@@ -442,6 +442,7 @@ mod tests {
             rate_limit_bytes_per_second: None,
             ldap_server_id: None,
             allowed_ip_ranges: None,
+            web_approval_grace_period_seconds: None,
         }
     }
 

--- a/warpgate-core/src/config_providers/db.rs
+++ b/warpgate-core/src/config_providers/db.rs
@@ -244,6 +244,7 @@ impl DatabaseConfigProvider {
             ldap_server_id: Set(ldap_server_id),
             ldap_object_uuid: Set(ldap_object_uuid),
             allowed_ip_ranges: Set(serde_json::Value::Null),
+            web_approval_grace_period_seconds: Set(None),
         }
         .insert(db)
         .await?;

--- a/warpgate-core/src/services.rs
+++ b/warpgate-core/src/services.rs
@@ -7,9 +7,10 @@ use sea_orm::sea_query::Expr;
 use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 use tokio::sync::Mutex;
 use tracing::warn;
+use uuid::Uuid;
 use warpgate_common::auth::{AuthState, CredentialKind};
 use warpgate_common::{GlobalParams, Protocol, Secret, SessionId, WarpgateConfig, WarpgateError};
-use warpgate_db_entities::Parameters;
+use warpgate_db_entities::{Parameters, Role, User, UserRoleAssignment};
 
 use crate::cluster::Cluster;
 use crate::db::connect_to_db_and_migrate;
@@ -168,14 +169,17 @@ impl Services {
         ))
     }
 
-    /// Configured web-approval caching window, or `None` if caching is disabled.
-    pub async fn web_approval_grace_period(&self) -> Result<Option<Duration>, WarpgateError> {
-        Ok(Parameters::Entity::get(&self.db)
-            .await?
-            .web_approval_grace_period_seconds
-            .filter(|s| *s > 0)
-            .and_then(|s| u64::try_from(s).ok())
-            .map(Duration::from_secs))
+    /// Effective web-approval caching window for `user_id`, or `None` if
+    /// caching is disabled. Resolved through the user > role > global
+    /// override hierarchy: a user-level override wins outright; otherwise the
+    /// shortest override among the user's currently active roles wins; else
+    /// the global default applies. An explicit `0` at any level means
+    /// "disabled at this level" and does not fall through further.
+    pub async fn effective_web_approval_grace_period(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Option<Duration>, WarpgateError> {
+        resolve_web_approval_grace_period(&self.db, user_id).await
     }
 
     /// If a matching web approval is still within the grace period, satisfies the
@@ -184,7 +188,8 @@ impl Services {
         &self,
         state_arc: &Arc<Mutex<AuthState>>,
     ) -> Result<bool, WarpgateError> {
-        let Some(grace) = self.web_approval_grace_period().await? else {
+        let user_id = state_arc.lock().await.user_info().id;
+        let Some(grace) = self.effective_web_approval_grace_period(user_id).await? else {
             return Ok(false);
         };
         self.auth_state_store
@@ -192,5 +197,231 @@ impl Services {
             .await
             .try_web_approval_bypass(state_arc, grace)
             .await
+    }
+}
+
+/// Resolves the effective web-approval caching window for `user_id` through
+/// the user > role > global override hierarchy: a user-level override wins
+/// outright; otherwise the shortest override among the user's currently
+/// active roles (see [`UserRoleAssignment::Entity::find_active`]) wins; else
+/// the global default applies. An explicit `0` at any level means "disabled
+/// at this level" and does not fall through further. Free-standing (rather
+/// than a `Services` method) so it's testable against a bare `DatabaseConnection`.
+async fn resolve_web_approval_grace_period(
+    db: &DatabaseConnection,
+    user_id: Uuid,
+) -> Result<Option<Duration>, WarpgateError> {
+    let seconds = resolve_web_approval_grace_period_seconds(db, user_id).await?;
+    Ok(seconds
+        .filter(|s| *s > 0)
+        .and_then(|s| u64::try_from(s).ok())
+        .map(Duration::from_secs))
+}
+
+async fn resolve_web_approval_grace_period_seconds(
+    db: &DatabaseConnection,
+    user_id: Uuid,
+) -> Result<Option<i64>, WarpgateError> {
+    if let Some(seconds) = User::Entity::find_by_id(user_id)
+        .one(db)
+        .await?
+        .and_then(|u| u.web_approval_grace_period_seconds)
+    {
+        return Ok(Some(seconds));
+    }
+
+    let role_ids: Vec<Uuid> = UserRoleAssignment::Entity::find_active()
+        .filter(UserRoleAssignment::Column::UserId.eq(user_id))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|a| a.role_id)
+        .collect();
+
+    if !role_ids.is_empty() {
+        let role_override = Role::Entity::find()
+            .filter(Role::Column::Id.is_in(role_ids))
+            .all(db)
+            .await?
+            .into_iter()
+            .filter_map(|r| r.web_approval_grace_period_seconds)
+            .min();
+        if role_override.is_some() {
+            return Ok(role_override);
+        }
+    }
+
+    Ok(Parameters::Entity::get(db)
+        .await?
+        .web_approval_grace_period_seconds)
+}
+
+#[cfg(all(test, feature = "sqlite"))]
+mod tests {
+    use sea_orm::{ActiveModelTrait, Database, Set};
+    use time::OffsetDateTime;
+    use warpgate_common::UserRequireCredentialsPolicy;
+    use warpgate_db_entities::Parameters::{ConfigMigrationValues, set_config_migration_values};
+    use warpgate_db_migrations::migrate_database;
+
+    use super::*;
+
+    async fn migrated_db() -> DatabaseConnection {
+        set_config_migration_values(ConfigMigrationValues::default());
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        migrate_database(&db).await.unwrap();
+        db
+    }
+
+    async fn make_user(db: &DatabaseConnection, grace_seconds: Option<i64>) -> Uuid {
+        let id = Uuid::new_v4();
+        User::ActiveModel {
+            id: Set(id),
+            username: Set(id.to_string()),
+            credential_policy: Set(
+                serde_json::to_value(UserRequireCredentialsPolicy::default()).unwrap(),
+            ),
+            description: Set(String::new()),
+            rate_limit_bytes_per_second: Set(None),
+            ldap_server_id: Set(None),
+            ldap_object_uuid: Set(None),
+            allowed_ip_ranges: Set(serde_json::Value::Null),
+            web_approval_grace_period_seconds: Set(grace_seconds),
+        }
+        .insert(db)
+        .await
+        .unwrap();
+        id
+    }
+
+    async fn make_role(db: &DatabaseConnection, grace_seconds: Option<i64>) -> Uuid {
+        let id = Uuid::new_v4();
+        Role::ActiveModel {
+            id: Set(id),
+            name: Set(id.to_string()),
+            description: Set(String::new()),
+            is_default: Set(false),
+            web_approval_grace_period_seconds: Set(grace_seconds),
+        }
+        .insert(db)
+        .await
+        .unwrap();
+        id
+    }
+
+    async fn assign_role(db: &DatabaseConnection, user_id: Uuid, role_id: Uuid) {
+        UserRoleAssignment::Entity::idempotent_grant(db, user_id, role_id, None)
+            .await
+            .unwrap();
+    }
+
+    async fn set_global_grace(db: &DatabaseConnection, grace_seconds: Option<i64>) {
+        let params = Parameters::Entity::get(db).await.unwrap();
+        let mut model: Parameters::ActiveModel = params.into();
+        model.web_approval_grace_period_seconds = Set(grace_seconds);
+        model.update(db).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_global_when_no_user_or_role_override() {
+        let db = migrated_db().await;
+        set_global_grace(&db, Some(60)).await;
+        let user_id = make_user(&db, None).await;
+
+        assert_eq!(
+            resolve_web_approval_grace_period(&db, user_id)
+                .await
+                .unwrap(),
+            Some(Duration::from_secs(60))
+        );
+    }
+
+    #[tokio::test]
+    async fn role_override_wins_over_global() {
+        let db = migrated_db().await;
+        set_global_grace(&db, Some(3600)).await;
+        let user_id = make_user(&db, None).await;
+        let role_id = make_role(&db, Some(120)).await;
+        assign_role(&db, user_id, role_id).await;
+
+        assert_eq!(
+            resolve_web_approval_grace_period(&db, user_id)
+                .await
+                .unwrap(),
+            Some(Duration::from_secs(120))
+        );
+    }
+
+    #[tokio::test]
+    async fn user_override_wins_over_role_and_global() {
+        let db = migrated_db().await;
+        set_global_grace(&db, Some(3600)).await;
+        let user_id = make_user(&db, Some(30)).await;
+        let role_id = make_role(&db, Some(120)).await;
+        assign_role(&db, user_id, role_id).await;
+
+        assert_eq!(
+            resolve_web_approval_grace_period(&db, user_id)
+                .await
+                .unwrap(),
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_active_roles_resolve_to_the_shortest() {
+        let db = migrated_db().await;
+        set_global_grace(&db, Some(3600)).await;
+        let user_id = make_user(&db, None).await;
+        let strict_role = make_role(&db, Some(60)).await;
+        let loose_role = make_role(&db, Some(600)).await;
+        assign_role(&db, user_id, strict_role).await;
+        assign_role(&db, user_id, loose_role).await;
+
+        assert_eq!(
+            resolve_web_approval_grace_period(&db, user_id)
+                .await
+                .unwrap(),
+            Some(Duration::from_secs(60))
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_role_assignment_is_ignored() {
+        let db = migrated_db().await;
+        set_global_grace(&db, Some(3600)).await;
+        let user_id = make_user(&db, None).await;
+        let role_id = make_role(&db, Some(60)).await;
+        UserRoleAssignment::Entity::idempotent_grant(
+            &db,
+            user_id,
+            role_id,
+            Some(OffsetDateTime::now_utc() - Duration::from_secs(60)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            resolve_web_approval_grace_period(&db, user_id)
+                .await
+                .unwrap(),
+            Some(Duration::from_secs(3600))
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_zero_at_user_level_disables_caching() {
+        let db = migrated_db().await;
+        set_global_grace(&db, Some(3600)).await;
+        let user_id = make_user(&db, Some(0)).await;
+        let role_id = make_role(&db, Some(120)).await;
+        assign_role(&db, user_id, role_id).await;
+
+        assert_eq!(
+            resolve_web_approval_grace_period(&db, user_id)
+                .await
+                .unwrap(),
+            None
+        );
     }
 }

--- a/warpgate-db-entities/src/Role.rs
+++ b/warpgate-db-entities/src/Role.rs
@@ -15,6 +15,7 @@ pub struct Model {
     #[sea_orm(column_type = "Text")]
     pub description: String,
     pub is_default: bool,
+    pub web_approval_grace_period_seconds: Option<i64>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -71,6 +72,7 @@ impl From<Model> for Role {
             name: model.name,
             description: model.description,
             is_default: model.is_default,
+            web_approval_grace_period_seconds: model.web_approval_grace_period_seconds,
         }
     }
 }

--- a/warpgate-db-entities/src/User.rs
+++ b/warpgate-db-entities/src/User.rs
@@ -31,6 +31,7 @@ pub struct Model {
     pub ldap_object_uuid: Option<Uuid>,
     #[sea_orm(column_type = "Text", nullable)]
     pub allowed_ip_ranges: serde_json::Value,
+    pub web_approval_grace_period_seconds: Option<i64>,
 }
 
 impl Related<super::Role::Entity> for Entity {
@@ -171,6 +172,7 @@ impl TryFrom<Model> for User {
             ldap_server_id: model.ldap_server_id,
             allowed_ip_ranges: allowed_ip_ranges
                 .map(|ranges| ranges.into_iter().map(Into::into).collect()),
+            web_approval_grace_period_seconds: model.web_approval_grace_period_seconds,
         })
     }
 }
@@ -252,6 +254,7 @@ impl TryFrom<User> for ActiveModel {
                 )?,
                 None => serde_json::Value::Null,
             }),
+            web_approval_grace_period_seconds: Set(user.web_approval_grace_period_seconds),
         })
     }
 }

--- a/warpgate-db-migrations/src/lib.rs
+++ b/warpgate-db-migrations/src/lib.rs
@@ -81,6 +81,7 @@ mod m00074_encryption_key_rotation;
 mod m00075_hash_ticket_and_api_token_secrets;
 mod m00076_open_targets_in_new_tab;
 mod m00077_session_user_target_id;
+mod m00078_web_approval_grace_period_hierarchy;
 
 pub(crate) mod helpers;
 
@@ -167,6 +168,7 @@ impl MigratorTrait for Migrator {
             Box::new(m00075_hash_ticket_and_api_token_secrets::Migration),
             Box::new(m00076_open_targets_in_new_tab::Migration),
             Box::new(m00077_session_user_target_id::Migration),
+            Box::new(m00078_web_approval_grace_period_hierarchy::Migration),
         ]
     }
 }

--- a/warpgate-db-migrations/src/m00078_web_approval_grace_period_hierarchy.rs
+++ b/warpgate-db-migrations/src/m00078_web_approval_grace_period_hierarchy.rs
@@ -1,0 +1,53 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("users"))
+                    .add_column(
+                        ColumnDef::new(Alias::new("web_approval_grace_period_seconds"))
+                            .big_integer(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("roles"))
+                    .add_column(
+                        ColumnDef::new(Alias::new("web_approval_grace_period_seconds"))
+                            .big_integer(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("roles"))
+                    .drop_column(Alias::new("web_approval_grace_period_seconds"))
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Alias::new("users"))
+                    .drop_column(Alias::new("web_approval_grace_period_seconds"))
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/warpgate-protocol-http/src/api/auth.rs
+++ b/warpgate-protocol-http/src/api/auth.rs
@@ -842,7 +842,7 @@ async fn serialize_auth_state_inner(
     };
 
     let web_approval_caching_grace_seconds = services
-        .web_approval_grace_period()
+        .effective_web_approval_grace_period(state.user_info().id)
         .await?
         .and_then(|d| i64::try_from(d.as_secs()).ok());
 

--- a/warpgate-web/src/admin/config/AccessRole.svelte
+++ b/warpgate-web/src/admin/config/AccessRole.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
     import { Alert, FormGroup, Input } from '@sveltestrap/sveltestrap'
     import { api, type Role, type Target, type User } from 'admin/lib/api'
+    import HelpText from 'admin/lib/HelpText.svelte'
     import AsyncButton from 'common/AsyncButton.svelte'
+    import { humantimeDuration } from 'common/duration'
     import { stringifyError } from 'common/errors'
     import ItemList, { type PaginatedResponse } from 'common/ItemList.svelte'
     import Loadable from 'common/Loadable.svelte'
@@ -105,6 +107,22 @@
                     <div>Automatically assign to all new users</div>
                 </label>
             </div>
+
+            <FormGroup floating label="Web approval cache period">
+                <input
+                    type="text"
+                    class="form-control"
+                    placeholder="e.g. 5m, 1h"
+                    use:humantimeDuration={{ seconds: role.webApprovalGracePeriodSeconds, onChange: v => { role.webApprovalGracePeriodSeconds = v } }}
+                >
+            </FormGroup>
+            <HelpText>
+                Overrides the global web approval cache period for users with
+                this role. Blank = inherit the global default. If a user holds
+                multiple roles with different values, the shortest one applies.
+                A user's own override, if set, always takes precedence over
+                this.
+            </HelpText>
         {/snippet}
     </Loadable>
 

--- a/warpgate-web/src/admin/config/users/User.svelte
+++ b/warpgate-web/src/admin/config/users/User.svelte
@@ -27,10 +27,12 @@
         type User,
         type UserRoleAssignmentResponse,
     } from 'admin/lib/api'
+    import HelpText from 'admin/lib/HelpText.svelte'
     import Section from 'admin/lib/Section.svelte'
     import SectionedForm from 'admin/lib/SectionedForm.svelte'
     import { adminPermissions } from 'admin/lib/store'
     import AsyncButton from 'common/AsyncButton.svelte'
+    import { humantimeDuration } from 'common/duration'
     import { stringifyError } from 'common/errors'
     import Loadable from 'common/Loadable.svelte'
     import PageSummaryBar from 'common/PageSummaryBar.svelte'
@@ -527,6 +529,23 @@
                     </FormGroup>
 
                     <AllowedIpRangesEditor bind:ranges={user.allowedIpRanges} />
+                </Section>
+
+                <Section id="security" title="Security">
+                    <FormGroup floating label="Web approval cache period">
+                        <input
+                            type="text"
+                            class="form-control"
+                            placeholder="e.g. 5m, 1h"
+                            use:humantimeDuration={{ seconds: user.webApprovalGracePeriodSeconds, onChange: v => { if (user) user.webApprovalGracePeriodSeconds = v } }}
+                        >
+                    </FormGroup>
+                    <HelpText>
+                        Overrides the role and global web approval cache period
+                        for this user. Blank = inherit from the user's roles, or
+                        the global default if none of their roles set one
+                        either.
+                    </HelpText>
                 </Section>
             </SectionedForm>
 

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Warpgate Web Admin",
-    "version": "v0.28.0-beta.3-modified"
+    "version": "v0.28.2-1-g250f869b-modified"
   },
   "servers": [
     {
@@ -6224,6 +6224,10 @@
           },
           "is_default": {
             "type": "boolean"
+          },
+          "web_approval_grace_period_seconds": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
@@ -6242,6 +6246,10 @@
           },
           "is_default": {
             "type": "boolean"
+          },
+          "web_approval_grace_period_seconds": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
@@ -7587,6 +7595,10 @@
             "items": {
               "type": "string"
             }
+          },
+          "web_approval_grace_period_seconds": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
@@ -7615,6 +7627,10 @@
             "items": {
               "type": "string"
             }
+          },
+          "web_approval_grace_period_seconds": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },

--- a/warpgate/src/commands/create_user.rs
+++ b/warpgate/src/commands/create_user.rs
@@ -42,6 +42,7 @@ pub async fn command(
             ldap_server_id: Set(None),
             ldap_object_uuid: Set(None),
             allowed_ip_ranges: Set(serde_json::Value::Null),
+            web_approval_grace_period_seconds: Set(None),
         };
         let user = values.insert(db).await.map_err(WarpgateError::from)?;
 

--- a/warpgate/src/commands/setup.rs
+++ b/warpgate/src/commands/setup.rs
@@ -436,6 +436,7 @@ pub async fn command(cli: &Cli, params: &GlobalParams) -> Result<()> {
                 name: Set(BUILTIN_ADMIN_USERNAME.to_string()),
                 description: Set("".to_string()),
                 is_default: Set(false),
+                web_approval_grace_period_seconds: Set(None),
             }
             .insert(&db)
             .await?


### PR DESCRIPTION
## Description

Folowing [this issue](https://github.com/warp-tech/warpgate/issues/2335)

Adds a hierarchical resolution mechanism for the web-approval caching window (the "remember this browser approval for N minutes" setting), so it can be tuned per security profile instead of only globally.

Previously `web_approval_grace_period_seconds` was a single global `Parameters` setting. This adds the same field to `User` and `Role`, and resolves it in priority order:

1. **User override** — wins outright if set.
2. **Role override** — otherwise, the shortest grace period among the user's currently active roles (expired/revoked assignments don't count). Taking the shortest is deliberately conservative: a stricter role's setting can't be loosened by also holding a looser one.
3. Global default — used when neither the user nor any of their roles set an override.

At every level, unset (null) means "inherit from the next level down"; an explicit 0 means "disable caching at this level" and does not fall through further.

This lets admins give e.g. contractors a short/no caching window via their role while internal engineers keep the longer global default, with individual users still overridable on top.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
