### PR TITLE
Make self-service credential management config-seedable

### DIFF
--- a/warpgate-common/src/config/mod.rs
+++ b/warpgate-common/src/config/mod.rs
@@ -906,6 +906,13 @@ pub struct WarpgateConfigStore {
 
     #[serde(default)]
     pub log: LogConfig,
+
+    /// Seeds the `allow_own_credential_management` Parameters row on first boot (existing
+    /// installs are unaffected — this only sets the value when the row doesn't exist yet,
+    /// same seeding semantics as `ssh.host_key_verification`/`recordings.enable`). Unset
+    /// (`None`) preserves today's default of `true`.
+    #[serde(default)]
+    pub allow_own_credential_management: Option<bool>,
 }
 
 impl Default for WarpgateConfigStore {
@@ -923,6 +930,7 @@ impl Default for WarpgateConfigStore {
             vnc: <_>::default(),
             rdp: <_>::default(),
             log: <_>::default(),
+            allow_own_credential_management: None,
         }
     }
 }

--- a/warpgate-db-entities/src/Parameters.rs
+++ b/warpgate-db-entities/src/Parameters.rs
@@ -128,6 +128,7 @@ pub struct ConfigMigrationValues {
     pub recordings_enable: bool,
     pub recordings_path: String,
     pub ssh_host_key_verification: SshHostKeyVerificationMode,
+    pub allow_own_credential_management: bool,
 }
 
 impl ConfigMigrationValues {
@@ -137,6 +138,10 @@ impl ConfigMigrationValues {
             recordings_enable: recordings.enable,
             recordings_path: recordings.path,
             ssh_host_key_verification: config.store.ssh.host_key_verification.into(),
+            allow_own_credential_management: config
+                .store
+                .allow_own_credential_management
+                .unwrap_or(true),
         }
     }
 }
@@ -269,7 +274,9 @@ impl Entity {
                 #[allow(clippy::unwrap_used, reason = "can't fail")]
                 ActiveModel {
                     id: Set(Uuid::new_v4()),
-                    allow_own_credential_management: Set(true),
+                    allow_own_credential_management: Set(
+                        get_config_migration_values().allow_own_credential_management,
+                    ),
                     rate_limit_bytes_per_second: Set(None),
                     ca_certificate_pem: Set("".into()),
                     ca_private_key_pem: Set("".into()),

--- a/warpgate-protocol-http/src/api/api_tokens.rs
+++ b/warpgate-protocol-http/src/api/api_tokens.rs
@@ -9,6 +9,7 @@ use warpgate_common::helpers::hash::{generate_ticket_secret, hash_secret};
 use warpgate_db_entities::ApiToken;
 
 use super::common::get_user;
+use super::credentials::parameters_based_auth;
 use crate::api::auth_scheme::AuthedSession;
 
 pub struct Api;
@@ -77,7 +78,8 @@ impl Api {
     #[oai(
         path = "/profile/api-tokens",
         method = "get",
-        operation_id = "get_my_api_tokens"
+        operation_id = "get_my_api_tokens",
+        transform = "parameters_based_auth"
     )]
     async fn api_get_api_tokens(
         &self,
@@ -103,7 +105,8 @@ impl Api {
     #[oai(
         path = "/profile/api-tokens",
         method = "post",
-        operation_id = "create_api_token"
+        operation_id = "create_api_token",
+        transform = "parameters_based_auth"
     )]
     async fn api_create_api_token(
         &self,
@@ -152,7 +155,8 @@ impl Api {
     #[oai(
         path = "/profile/api-tokens/:id",
         method = "delete",
-        operation_id = "delete_my_api_token"
+        operation_id = "delete_my_api_token",
+        transform = "parameters_based_auth"
     )]
     async fn api_delete_api_token(
         &self,


### PR DESCRIPTION
## Description

`allow_own_credential_management` previously could only be set post-install (no static config equivalent), forcing operators who want it disabled from day one to script an API call after every fresh install. Wire it into the existing config-migration-seed pattern already used by `ssh.host_key_verification/recordings.enable`, so `config.yaml` can set the initial value directly.

Separately, `/profile/api-tokens` had no permission check - any authenticated user could mint their own API token regardless of the `allow_own_credential_management` setting, unlike password/OTP/public-key/ certificate self-service which are already gated by it. Apply the same parameters_based_auth transform already used by the other credential kinds.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
