### PR TITLE
Add default_allowed_ip_ranges to sso_providers config

### DIFF
--- a/warpgate-core/src/config_providers/db.rs
+++ b/warpgate-core/src/config_providers/db.rs
@@ -176,6 +176,7 @@ impl DatabaseConfigProvider {
         credential: UserSsoCredential,
         preferred_username: String,
         default_credential_policy: Option<serde_json::Value>,
+        default_allowed_ip_ranges: Option<Vec<String>>,
     ) -> Result<Option<String>, WarpgateError> {
         // Check for LDAP servers with auto-linking enabled
         let ldap_servers: Vec<entities::LdapServer::Model> = entities::LdapServer::Entity::find()
@@ -243,7 +244,11 @@ impl DatabaseConfigProvider {
             rate_limit_bytes_per_second: Set(None),
             ldap_server_id: Set(ldap_server_id),
             ldap_object_uuid: Set(ldap_object_uuid),
-            allowed_ip_ranges: Set(serde_json::Value::Null),
+            allowed_ip_ranges: Set(
+                default_allowed_ip_ranges
+                    .map(|ranges| serde_json::to_value(ranges).unwrap_or(serde_json::Value::Null))
+                    .unwrap_or(serde_json::Value::Null),
+            ),
         }
         .insert(db)
         .await?;
@@ -518,6 +523,7 @@ impl ConfigProvider for DatabaseConfigProvider {
                     },
                     preferred_username,
                     sso_config.default_credential_policy.clone(),
+                    sso_config.default_allowed_ip_ranges.clone(),
                 )
                 .await;
         }

--- a/warpgate-sso/src/config.rs
+++ b/warpgate-sso/src/config.rs
@@ -99,6 +99,11 @@ pub struct SsoProviderConfig {
     /// Keys: "http", "ssh", "mysql", "postgres"
     /// Values: list of credential kinds e.g. ["sso"], ["web"], []
     pub default_credential_policy: Option<serde_json::Value>,
+    /// Default `allowed_ip_ranges` (CIDR strings) applied to users auto-created by this
+    /// provider. Only applied at creation time — does not retroactively affect existing
+    /// users, same seeding semantics as `default_credential_policy` above.
+    #[serde(default)]
+    pub default_allowed_ip_ranges: Option<Vec<String>>,
     /// kubectl OIDC parameters for generating a kubelogin kubeconfig.
     #[serde(default)]
     pub kubernetes: Option<SsoProviderKubernetesConfig>,


### PR DESCRIPTION
## Description

`allowed_ip_ranges` is hardcoded to unrestricted on every SSO auto-created user with no way to set a default, forcing operators who want to scope SSO-user access to a network range (e.g. requiring VPN) into either forking this project or running an external reconciliation loop against the admin API.

Mirrors the existing default_credential_policy field/pattern exactly: a new optional `default_allowed_ip_ranges` list on the SSO provider config, applied only at user-creation time (same seeding semantics as default_credential_policy — does not retroactively change existing users).

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
