### PR TITLE
Align WebSocket header behaviour with HTTP behaviour

### DIFF
--- a/warpgate-protocol-http/src/proxy.rs
+++ b/warpgate-protocol-http/src/proxy.rs
@@ -64,6 +64,9 @@ trait SomeRequestBuilder {
     where
         HeaderValue: TryFrom<V>,
         <HeaderValue as TryFrom<V>>::Error: Into<http::Error>;
+
+    /// Set a target-configured header, replacing values copied or generated earlier.
+    fn set_header(self, k: HeaderName, v: HeaderValue) -> Self;
 }
 
 impl SomeRequestBuilder for reqwest::RequestBuilder {
@@ -74,6 +77,12 @@ impl SomeRequestBuilder for reqwest::RequestBuilder {
     {
         self.header(k, v)
     }
+
+    fn set_header(self, k: HeaderName, v: HeaderValue) -> Self {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(k, v);
+        self.headers(headers)
+    }
 }
 
 impl SomeRequestBuilder for http::request::Builder {
@@ -83,6 +92,13 @@ impl SomeRequestBuilder for http::request::Builder {
         <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
     {
         self.header(k, v)
+    }
+
+    fn set_header(mut self, k: HeaderName, v: HeaderValue) -> Self {
+        if let Some(headers) = self.headers_mut() {
+            headers.insert(k, v);
+        }
+        self
     }
 }
 
@@ -168,7 +184,7 @@ fn copy_client_response<R: SomeResponse>(
 fn rewrite_request<B: SomeRequestBuilder>(mut req: B, options: &TargetHTTPOptions) -> Result<B> {
     if let Some(ref headers) = options.headers {
         for (k, v) in headers {
-            req = req.header(HeaderName::try_from(k)?, v);
+            req = req.set_header(HeaderName::try_from(k)?, HeaderValue::try_from(v)?);
         }
     }
     Ok(req)
@@ -660,6 +676,31 @@ mod tests {
             headers: None,
             external_host: None,
         }
+    }
+
+    #[test]
+    fn rewrite_request_replaces_websocket_host() {
+        let mut options = make_options("http://ingress.internal");
+        options.headers = Some(std::collections::HashMap::from([(
+            "Host".to_string(),
+            "backend.example.com".to_string(),
+        )]));
+
+        let request = rewrite_request(
+            http::Request::builder().header(http::header::HOST, "ingress.internal"),
+            &options,
+        )
+        .unwrap()
+        .body(())
+        .unwrap();
+
+        let hosts = request
+            .headers()
+            .get_all(http::header::HOST)
+            .iter()
+            .map(|value| value.to_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(hosts, ["backend.example.com"]);
     }
 
     #[test]


### PR DESCRIPTION
## Description
We have a setup where we point multiple HTTP targets at a Kubernetes ingress. Kubernetes ingress does routing based on the Host header. To be able to point multiple Warpgate HTTP targets at the same ingress, but still route them to different internal services, we manually set the Host field to a different value through Warpgate's headers configuration for HTTP targets.

This works great for HTTP requests, however the WebSocket behaviour differs from HTTP behaviour. For HTTP, the manually set header overrides the automatic host header, however for WebSockets Warpgate simply adds the Host header twice, which then gets rejected by backend services.

This PR changes this behaviour for WebSockets, such that manually set headers overwrite the automatic headers, in the same way that it currently does so for HTTP.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
