### PR TITLE
Add scope clarifications to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,4 +19,15 @@ In particular, this does not include the traffic from known Warpgate targets.
 
 ---
 
+Additional scope clarifications:
+
+* Privileged-by-design actors turning hostile are out of scope, regardless of how many tiers exist.
+* Hardening suggestions are welcome; their absence isn't itself a vulnerability unless independently reachable.
+* Malicious transitive dependencies are only in-scope with a confirmed exploit path, not just a bad advisory.
+* A trusted IdP's own authenticated users acting maliciously is between them and the IdP, not Warpgate.
+* Only code that shipped in a tagged release needs a formal advisory.
+* Judge severity against the most direct alternative attack the same actor already has.
+
+---
+
 CNA: [GitHub](https://www.cve.org/PartnerInformation/ListofPartners/partner/GitHub_M)


### PR DESCRIPTION
## What

Adds a set of scope clarifications to `SECURITY.md`, alongside the existing trusted-inputs list.

## Why

Follow-up from the discussion on #2427: findings coming out of automated/LLM-assisted security sweeps are more useful when the reporter has clear guardrails on what's in scope before they invest time investigating. This adds explicit language for cases that have come up but weren't previously spelled out:

- Privileged-by-design actors turning hostile are out of scope, regardless of how many tiers exist.
- Hardening suggestions are welcome; their absence isn't itself a vulnerability unless independently reachable.
- Malicious transitive dependencies are only in-scope with a confirmed exploit path, not just a bad advisory.
- A trusted IdP's own authenticated users acting maliciously is between them and the IdP, not Warpgate.
- Only code that shipped in a tagged release needs a formal advisory.
- Judge severity against the most direct alternative attack the same actor already has.

Approved by @Eugeny in #2427.