### PR TITLE
SSH: deliver the channel close instead of attempting it

### DIFF
--- a/warpgate-protocol-ssh/src/client/channel_session.rs
+++ b/warpgate-protocol-ssh/src/client/channel_session.rs
@@ -155,10 +155,24 @@ impl SessionChannel {
                 }
             }
         }
-        self.close();
+        self.close_and_wait().await;
         Ok(())
     }
 
+    /// Delivers the close, rather than attempting it.
+    ///
+    /// `events_tx` holds 1024 events and every chunk of target output takes one
+    /// of them, so a session that has just streamed a large amount leaves the
+    /// queue full at exactly the moment the channel ends. `try_send` then fails,
+    /// the close is discarded, and the client is never told its channel is over.
+    async fn close_and_wait(&mut self) {
+        if !self.closed {
+            let _ = self.events_tx.send(RCEvent::Close(self.channel_id)).await;
+            self.closed = true;
+        }
+    }
+
+    /// The same, for `Drop`, where there is nothing to await with.
     fn close(&mut self) {
         if !self.closed {
             let _ = self.events_tx.try_send(RCEvent::Close(self.channel_id));


### PR DESCRIPTION
## Description

**This is what fails `Tests` on `main` about a quarter of the time.**
`test_recordings_index.py::Test::test_terminal_recording_index` is the visible
symptom; the cause is below, and it is not in the test. Every pull request pays
for it, including ones that have nothing to do with SSH.

A session that has streamed a large amount of output can end without the client ever being told its channel is closed. `ssh` then waits on a session that has already finished, until something kills it.

`events_tx` holds 1024 events and every chunk of target output takes one, so the queue is full at exactly the moment a high-output channel ends. `close()` used `try_send`, whose failure was discarded, and the close was lost. The call at the end of `run()` is in an async context and can wait for room; `Drop` keeps `try_send`, having nothing to await with.

**How it shows up.** That test streams ~1.5 MB through a recorded PTY and times out waiting for the client. In every failure the whole transfer had arrived — 1,489,491 bytes, last line `200000` — so the data is not the problem; the client is simply never released.

The gateway log names the difference. A successful run ends:

```
Event event=Eof(<channel>)
Event event=ExitStatus(<channel>, 0)
Event event=Close(<channel>)
Closed session
```

A failing one ends `ExitStatus` then `Eof`, and then nothing at all until the client is killed and teardown follows.

**Measured.** Each run below repeats the transfer twenty times and reports, for any that hangs, how many bytes had arrived.

| | commit | result |
|---|---|---|
| without this change | `c5f4106f` | [4 of 20 hung](https://github.com/janisdombr/warpgate/actions/runs/33278306744) |
| with it | `facada2a` | [0 of 20](https://github.com/janisdombr/warpgate/actions/runs/33279598017) |
| with it, again | `facada2a` | [0 of 20](https://github.com/janisdombr/warpgate/actions/runs/33280994427) |

At the observed rate, forty consecutive clean transfers is about one chance in eight thousand.

The reproduction and the loop that measures it are on [`tooling/recording-stall`](https://github.com/janisdombr/warpgate/tree/tooling/recording-stall) in my fork, based on `main` with nothing else merged, and are deliberately not part of this change. GitHub truncates the larger logs, so the loop's exit status is what carries the result — it fails on the first hang.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*

