### PR TITLE
Support wildcard entries in SSO return_domain_whitelist

### DIFF
--- a/warpgate-common-http/src/ext.rs
+++ b/warpgate-common-http/src/ext.rs
@@ -53,7 +53,7 @@ pub async fn construct_external_url(
     };
 
     if let Some(list) = domain_whitelist
-        && !list.contains(&host)
+        && !list.iter().any(|entry| domain_matches(&host, entry))
     {
         return Err(WarpgateError::ExternalHostNotWhitelisted(
             host,
@@ -69,6 +69,15 @@ pub async fn construct_external_url(
         }
     }
     Url::parse(&url).map_err(WarpgateError::UrlParse)
+}
+
+fn domain_matches(host: &str, entry: &str) -> bool {
+    match entry.strip_prefix("*.") {
+        Some(base) => host
+            .strip_suffix(base)
+            .is_some_and(|prefix| prefix.ends_with('.')),
+        None => host == entry,
+    }
 }
 
 #[cfg(test)]
@@ -95,5 +104,38 @@ mod tests {
             .expect("external url");
 
         assert_eq!(url.as_str(), "https://config.example:8888/");
+    }
+
+    #[test]
+    fn domain_matches_exact() {
+        assert!(domain_matches(
+            "srv1.config.example",
+            "srv1.config.example"
+        ));
+        assert!(!domain_matches(
+            "srv2.config.example",
+            "srv1.config.example"
+        ));
+    }
+
+    #[test]
+    fn domain_matches_wildcard() {
+        assert!(domain_matches(
+            "srv1.config.example",
+            "*.config.example"
+        ));
+        assert!(domain_matches(
+            "a.b.config.example",
+            "*.config.example"
+        ));
+        assert!(!domain_matches(
+            "config.example",
+            "*.config.example"
+        ));
+        assert!(!domain_matches("srv1.evil.com", "*.config.example"));
+        assert!(!domain_matches(
+            "srv1.notconfig.example",
+            "*.config.example"
+        ));
     }
 }


### PR DESCRIPTION
## Description

`return_domain_whitelist` only accepts exact hostnames, with no wildcard support, which is a problem for HTTP targets since their subdomains aren't a fixed known set.

This adds support for a `*.` prefix in whitelist entries, matching any subdomain of the given base (but not the bare domain itself), e.g. `*.bastion.example.com`. Plain entries keep matching exactly as before.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
