### PR TITLE
Record that an LDAP connection test ran, and how it ended

### DIFF
--- a/warpgate-admin/src/api/ldap_servers.rs
+++ b/warpgate-admin/src/api/ldap_servers.rs
@@ -428,6 +428,8 @@ impl ListApi {
         {
             match warpgate_ldap::test_connection(&ldap_config).await {
                 Ok(_) => {
+                    tracing::info!(host=%body.host, port=body.port, "LDAP connection test succeeded");
+
                     // Try to discover base DNs
                     let base_dns = warpgate_ldap::discover_base_dns(&ldap_config).await.ok();
 
@@ -439,13 +441,22 @@ impl ListApi {
                         },
                     )))
                 }
-                Err(e) => Ok(TestLdapServerConnectionResponse::Ok(Json(
-                    TestLdapServerResponse {
-                        success: false,
-                        message: format!("Connection failed: {e}"),
-                        base_dns: None,
-                    },
-                ))),
+                Err(e) => {
+                    // The message stays verbatim: an admin asked what was
+                    // wrong with a server they are configuring, and that
+                    // answer is the endpoint. What was missing is the record.
+                    // This dials a host and port taken from the request body
+                    // and left nothing behind saying it had run.
+                    tracing::warn!(host=%body.host, port=body.port, error=%e, "LDAP connection test failed");
+
+                    Ok(TestLdapServerConnectionResponse::Ok(Json(
+                        TestLdapServerResponse {
+                            success: false,
+                            message: format!("Connection failed: {e}"),
+                            base_dns: None,
+                        },
+                    )))
+                }
             }
         } else {
             Ok(TestLdapServerConnectionResponse::Ok(Json(


### PR DESCRIPTION
The `POST /ldap-servers/test` endpoint dials a host and port taken from the request body and writes nothing to the log. `warpgate-admin/src/api/ldap_servers.rs` has no logging statements at all.

It is gated by `AdminPermission::ConfigEdit`, so the caller is trusted — but trust in a role and an audit trail are different things, and this is a bastion. As it stands an admin can use the gateway to probe arbitrary `host:port` combinations and nothing afterwards shows it happened, or that it succeeded.

This adds `tracing::info!` on success and `tracing::warn!` on failure, both carrying the host and port, and the error on the failing path.

The message returned to the caller is deliberately unchanged. It is the answer to the question the "test connection" button was pressed to ask, and sanitising it would remove the feature rather than protect anything.

Noticed while working on #2397.