### PR TITLE
Keep the auto-reconnect secret out of the RDP logon log line

### DIFF
--- a/warpgate-protocol-rdp/src/client/logon.rs
+++ b/warpgate-protocol-rdp/src/client/logon.rs
@@ -26,7 +26,18 @@ impl LogonWatcher {
             InfoData::LogonInfoV2(info) => Some(&info.logon_info),
             InfoData::PlainNotify => None,
             InfoData::LogonExtended(extended) => {
-                debug!(?extended, "Target sent extended logon info");
+                // Not `?extended`. `LogonInfoExtended` derives `Debug` over its
+                // whole shape, and the auto-reconnect packet inside it carries
+                // the sixteen random bytes a client turns into the verifier
+                // that re-attaches to this session without presenting
+                // credentials again ([MS-RDPBCGR] 2.2.10.1.1.1). Printing the
+                // struct wrote that value into the log.
+                debug!(
+                    flags = ?extended.present_fields_flags,
+                    errors = ?extended.errors_info,
+                    auto_reconnect = extended.auto_reconnect.is_some(),
+                    "Target sent extended logon info"
+                );
                 return;
             }
         };


### PR DESCRIPTION
`warpgate-protocol-rdp/src/client/logon.rs` logs the extended logon PDU through its derived `Debug`:

```rust
InfoData::LogonExtended(extended) => {
    debug!(?extended, "Target sent extended logon info");
    return;
}
```

In `ironrdp-pdu` 0.9.0, `LogonInfoExtended` (`src/rdp/session_info/logon_extended.rs:20`) has a plain `#[derive(Debug)]` and holds `auto_reconnect: Option<ServerAutoReconnect>`; `ServerAutoReconnect` holds `random_bits: [u8; 16]`.

Those sixteen bytes are the auto-reconnect random from [MS-RDPBCGR] 2.2.10.1.1.1 — the value a client turns into the HMAC verifier that re-attaches to the session without presenting credentials again. So the line writes a reconnection credential into the log.

It is `debug!`, below the default `warpgate=info`, which limits the blast radius but does not remove it: debug logging is what an operator turns on to diagnose RDP, which is exactly when this PDU arrives.

This keeps what the line was for — the present-fields flags and the error information — and replaces the packet itself with a boolean for whether one was present, which is the diagnostic value it actually carried.

Noticed while working on #2397.
