### PR TITLE
Fix LDAP base DN and entryUUID handling for hosted directories

### DIFF
--- a/warpgate-admin/src/api/ldap_servers.rs
+++ b/warpgate-admin/src/api/ldap_servers.rs
@@ -158,6 +158,7 @@ struct CreateLdapServerRequest {
     ssh_key_attribute: String,
     #[oai(default = "default_uuid_attribute")]
     uuid_attribute: String,
+    base_dns: Option<Vec<String>>,
 }
 
 const fn default_port() -> i32 {
@@ -361,8 +362,18 @@ impl ListApi {
             },
         };
 
-        // Discover base DNs
-        let base_dns = if std::env::var("WARPGATE_UNDER_TEST")
+        let supplied_base_dns: Vec<String> = body
+            .base_dns
+            .iter()
+            .flatten()
+            .map(|dn| dn.trim().to_owned())
+            .filter(|dn| !dn.is_empty())
+            .collect();
+
+        // Discover base DNs unless the caller named them
+        let base_dns = if !supplied_base_dns.is_empty() {
+            supplied_base_dns
+        } else if std::env::var("WARPGATE_UNDER_TEST")
             .unwrap_or_default()
             .is_empty()
         {

--- a/warpgate-admin/src/api/ldap_servers.rs
+++ b/warpgate-admin/src/api/ldap_servers.rs
@@ -212,6 +212,7 @@ struct UpdateLdapServerRequest {
     username_attribute: LdapUsernameAttribute,
     ssh_key_attribute: String,
     uuid_attribute: String,
+    base_dns: Option<Vec<String>>,
 }
 
 #[derive(Object)]
@@ -555,7 +556,7 @@ impl DetailApi {
         model.ssh_key_attribute = Set(body.ssh_key_attribute.clone());
         model.uuid_attribute = Set(body.uuid_attribute.clone());
 
-        // Re-discover base DNs if connection details changed
+        // Base DNs the client sent win; discovery is only a fallback
         let ldap_config = warpgate_ldap::LdapConfig {
             host: body.host.clone(),
             port: body.port as u16,
@@ -573,8 +574,23 @@ impl DetailApi {
             uuid_attribute: None,
         };
 
-        if let Ok(base_dns) = warpgate_ldap::discover_base_dns(&ldap_config).await {
-            model.base_dns = Set(serde_json::to_value(&base_dns)?);
+        let supplied_base_dns: Vec<String> = body
+            .base_dns
+            .iter()
+            .flatten()
+            .map(|dn| dn.trim().to_owned())
+            .filter(|dn| !dn.is_empty())
+            .collect();
+
+        if supplied_base_dns.is_empty() {
+            // Nothing to keep, so fall back to the RootDSE. Hosted multi-tenant
+            // directories don't advertise a base DN that can be searched, which
+            // is why an explicit list has to be able to override this.
+            if let Ok(base_dns) = warpgate_ldap::discover_base_dns(&ldap_config).await {
+                model.base_dns = Set(serde_json::to_value(&base_dns)?);
+            }
+        } else {
+            model.base_dns = Set(serde_json::to_value(&supplied_base_dns)?);
         }
 
         let server = model.update(db).await?;

--- a/warpgate-ldap/src/queries.rs
+++ b/warpgate-ldap/src/queries.rs
@@ -90,13 +90,22 @@ fn extract_ldap_user(search_entry: &SearchEntry, config: &LdapConfig) -> Result<
                     })
             })
     } else {
-        // Default behavior: Active Directory uses objectGUID, OpenLDAP uses entryUUID
+        // Active Directory returns objectGUID as 16 raw bytes, so it lands in
+        // bin_attrs. entryUUID is a dashed string, which ldap3 decodes into
+        // attrs instead, so it has to be parsed from there.
         search_entry
             .bin_attrs
             .get("objectGUID")
             .or_else(|| search_entry.bin_attrs.get("entryUUID"))
             .and_then(|v: &Vec<Vec<u8>>| v.first())
             .and_then(|b| Uuid::from_slice(&b[..]).ok())
+            .or_else(|| {
+                search_entry
+                    .attrs
+                    .get("entryUUID")
+                    .and_then(|v| v.first())
+                    .and_then(|s| Uuid::parse_str(s).ok())
+            })
     }
     .ok_or(LdapError::NoUUID(dn.clone()))?;
 

--- a/warpgate-ldap/src/queries.rs
+++ b/warpgate-ldap/src/queries.rs
@@ -338,9 +338,11 @@ pub async fn find_user_by_uuid(
 
 #[cfg(test)]
 mod tests {
+    use ldap3::SearchEntry;
+    use uuid::Uuid;
     use warpgate_tls::TlsMode;
 
-    use super::username_filter;
+    use super::{extract_ldap_user, username_filter};
     use crate::types::{LdapConfig, LdapUsernameAttribute};
 
     fn config() -> LdapConfig {
@@ -397,5 +399,55 @@ mod tests {
             username_filter(&config, "alice")
                 .starts_with("(&(&(objectClass=person)(!(disabled=TRUE)))")
         );
+    }
+
+    const ENTRY_UUID: &str = "94708f40-8e23-103d-8006-951699206877";
+
+    fn search_entry(attrs: &[(&str, &str)], bin_attrs: &[(&str, Vec<u8>)]) -> SearchEntry {
+        SearchEntry {
+            dn: "cn=alice,dc=example,dc=com".into(),
+            attrs: attrs
+                .iter()
+                .map(|(k, v)| ((*k).to_owned(), vec![(*v).to_owned()]))
+                .collect(),
+            bin_attrs: bin_attrs
+                .iter()
+                .map(|(k, v)| ((*k).to_owned(), vec![v.clone()]))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn a_string_entry_uuid_is_read_when_no_uuid_attribute_is_configured() {
+        // ldap3 decodes a dashed entryUUID as UTF-8 into `attrs`, so looking
+        // only in `bin_attrs` misses what OpenLDAP and hosted directories
+        // return, and the entry is discarded as having no UUID.
+        let entry = search_entry(&[("cn", "alice"), ("entryUUID", ENTRY_UUID)], &[]);
+        let user = extract_ldap_user(&entry, &config()).unwrap();
+        assert_eq!(user.username, "alice");
+        assert_eq!(user.object_uuid, Uuid::parse_str(ENTRY_UUID).unwrap());
+    }
+
+    #[test]
+    fn a_binary_object_guid_is_still_read() {
+        let raw = vec![7u8; 16];
+        let entry = search_entry(&[("cn", "alice")], &[("objectGUID", raw.clone())]);
+        let user = extract_ldap_user(&entry, &config()).unwrap();
+        assert_eq!(user.object_uuid, Uuid::from_slice(&raw).unwrap());
+    }
+
+    #[test]
+    fn a_configured_uuid_attribute_may_hold_a_string() {
+        let mut config = config();
+        config.uuid_attribute = Some("entryUUID".into());
+        let entry = search_entry(&[("cn", "alice"), ("entryUUID", ENTRY_UUID)], &[]);
+        let user = extract_ldap_user(&entry, &config).unwrap();
+        assert_eq!(user.object_uuid, Uuid::parse_str(ENTRY_UUID).unwrap());
+    }
+
+    #[test]
+    fn an_entry_carrying_no_uuid_is_rejected() {
+        let entry = search_entry(&[("cn", "alice")], &[]);
+        assert!(extract_ldap_user(&entry, &config()).is_err());
     }
 }

--- a/warpgate-web/src/admin/config/ldap/LdapServer.svelte
+++ b/warpgate-web/src/admin/config/ldap/LdapServer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-    import { FormGroup, Input } from '@sveltestrap/sveltestrap'
+    import { faPlus, faTrash } from '@fortawesome/free-solid-svg-icons'
+    import { Button, FormGroup, Input } from '@sveltestrap/sveltestrap'
     import {
         api,
         type LdapServerResponse,
@@ -10,6 +11,7 @@
     import AsyncButton from 'common/AsyncButton.svelte'
     import { stringifyError } from 'common/errors'
     import Loadable from 'common/Loadable.svelte'
+    import Fa from 'svelte-fa'
     import { push } from 'svelte-spa-router'
     import { defaultLdapPortForTlsMode, testLdapConnection } from './common'
     import LdapConnectionFields from './LdapConnectionFields.svelte'
@@ -114,6 +116,7 @@
                     usernameAttribute,
                     sshKeyAttribute,
                     uuidAttribute,
+                    baseDns,
                 },
             })
             await load()
@@ -174,19 +177,44 @@
                 passwordRequired={false}
             />
 
-            {#if baseDns.length > 0}
-                <div class="mt-4">
-                    <!-- svelte-ignore a11y_label_has_associated_control -->
-                    <label class="form-label">Base DNs (discovered)</label>
-                    <ul class="list-group">
-                        {#each baseDns as dn (dn)}
-                            <li class="list-group-item">
-                                <code>{dn}</code>
-                            </li>
-                        {/each}
-                    </ul>
-                </div>
-            {/if}
+            <div class="mt-4">
+                <!-- svelte-ignore a11y_label_has_associated_control -->
+                <label class="form-label">Base DNs</label>
+                {#each baseDns as dn, index (index)}
+                    <div class="d-flex align-items-center mb-2 gap-2">
+                        <Input
+                            placeholder="e.g. ou=Users,dc=example,dc=com"
+                            value={dn}
+                            on:input={(e) => {
+                                baseDns[index] = e.target.value
+                                baseDns = [...baseDns]
+                            }}
+                        />
+                        <Button
+                            color="link"
+                            size="sm"
+                            on:click={() => {
+                                baseDns = baseDns.filter((_, i) => i !== index)
+                            }}
+                        >
+                            <Fa icon={faTrash} />
+                        </Button>
+                    </div>
+                {/each}
+                <Button
+                    class="d-flex align-items-center gap-2"
+                    color="secondary"
+                    size="sm"
+                    on:click={() => { baseDns = [...baseDns, ''] }}
+                >
+                    <Fa icon={faPlus} class="me-1" />
+                    <div>Add base DN</div>
+                </Button>
+                <small class="form-text text-muted d-block mt-2">
+                    Search bases for user lookups. Leave the list empty to
+                    re-detect them from the server's RootDSE when saving.
+                </small>
+            </div>
 
             <!-- <div class="mt-4">
                 <div class="form-check form-switch">

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -7560,6 +7560,12 @@
           },
           "uuid_attribute": {
             "type": "string"
+          },
+          "base_dns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/warpgate-web/src/admin/lib/openapi-schema.json
+++ b/warpgate-web/src/admin/lib/openapi-schema.json
@@ -4805,6 +4805,12 @@
           "uuid_attribute": {
             "type": "string",
             "default": ""
+          },
+          "base_dns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },


### PR DESCRIPTION
## Description

Three related defects that make Warpgate's LDAP integration unusable against hosted multi-tenant directories. All were hit configuring JumpCloud Cloud LDAP; each is reproducible on stock OpenLDAP too, and the third affects any directory that doesn't publish a searchable naming context.

The common thread: base DNs and UUIDs are treated as things the server discovers, never as things an operator can state.

### 1. Base DNs are overwritten on every save

`api_update_ldap_server` called `discover_base_dns` unconditionally and assigned over `model.base_dns`, and `UpdateLdapServerRequest` had no `base_dns` field. Base DNs simply could not be set — the RootDSE won every save, and the UI showed them read-only as *"Base DNs (discovered)"*.

JumpCloud advertises `dc=jumpcloud,dc=com` and `ou=service-accounts` as naming contexts. Neither is searchable by a tenant:

```
LDAP query failed: Search failed in dc=jumpcloud,dc=com:
LDAP operation result: rc=32 (noSuchObject), dn: "", text: ""
```

The tenant's real base is `ou=Users,o=<org id>,dc=jumpcloud,dc=com`, and the org id appears only in the bind DN — discovery cannot derive it. The only workaround was `UPDATE ldap_servers SET base_dns = ...`, which the next save silently undid.

**Fix:** optional `base_dns` on the update request, honoured when it holds at least one non-blank entry, discovery otherwise — so clearing the list still re-detects. The UI list becomes editable (same pattern as `AllowedIpRangesEditor`) and round-trips on save.

### 2. A string-valued `entryUUID` is never read

With `uuid_attribute` unset, `extract_ldap_user` looked only in `bin_attrs`:

```rust
search_entry.bin_attrs.get("objectGUID")
    .or_else(|| search_entry.bin_attrs.get("entryUUID"))
```

AD returns `objectGUID` as 16 raw bytes, so that path works. `entryUUID` is a dashed string, which ldap3 decodes as UTF-8 into `attrs` — so the lookup never matches and extraction fails with `NoUUID`, despite the comment claiming OpenLDAP is covered.

`find_user_by_filter` turns that into a warning and `Ok(None)`, so the caller reports *no user found* for an entry the directory did return. Auto-link failed with `No LDAP user found with username: <name>` while an identical `ldapsearch` returned the entry — a confusing place to land, since the message points at the username rather than at UUID parsing.

**Fix:** fall back to parsing `entryUUID` from `attrs`, mirroring what the configured-attribute branch already does.

### 3. A server whose RootDSE is unusable can't be created

`api_create_ldap_server` propagated discovery failure with `?`, so registration failed before the row existed — leaving nothing to correct on the detail page.

**Fix:** accept the same optional `base_dns` and skip discovery when provided. Unchanged when omitted.

### Compatibility

Additive. Both new fields are optional and omitting them preserves today's behaviour, so existing clients and the generated SDKs are unaffected.

### Testing

Diagnosed against a live JumpCloud tenant; the base DN reverting on every save is what led to the code. Confirmed `ldapsearch` with the explicit base returns users that discovery's DNs cannot, and that JumpCloud serves `entryUUID` as a string (`94708f40-…`), which is what surfaced defect 2.

Verified locally on the pinned `nightly-2026-07-09`:

| Check | Result |
|---|---|
| `cargo check -p warpgate-ldap -p warpgate-admin` | clean |
| `cargo cranky --workspace --all-features` (what `just clippy` runs) | exit 0, no diagnostics in either changed file |
| `biome ci` on the changed Svelte file (2.5.9, as pinned) | clean |

`openapi-schema.json` was edited by hand first, then checked by regenerating it with `cargo run -p warpgate-admin` and diffing: the output is byte-identical apart from the `version` field, which tracks the build's git describe. I kept the hand-edited file so that field isn't churned.

The workspace cranky run does emit 11 warnings, all pre-existing and in other crates — four manifest-level unused-dependency notes, a `map_or` simplification and nine other lints in `warpgate-protocol-http`, and a future-incompat note from `proc-macro-error2`. None are introduced here.

### Deliberately not included

The create *page* still relies on discovery — base DNs stay editable afterwards on the detail page, and adding a second editor there seemed like scope creep. Happy to add it if you'd rather the forms match.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*

All three defects were hit during a real JumpCloud deployment and confirmed against the source and a live directory before patching; the code itself is AI-written, then compiled and linted with the project's own toolchain and lint config as described above.
