### PR TITLE
Migrate Docker build and runtime images from EOL bullseye to bookworm

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,13 @@
 # syntax=docker/dockerfile:1.3-labs
 # hadolint global ignore=DL3008
-FROM rust:1.97.1-bullseye@sha256:02d78ca3f928195c2a907543de778adfd728ad7e2a24fdc6aef582b7c77842e0 AS build
+FROM rust:1.97.1-bookworm@sha256:0e2bcaef56d041a486784e54104a81aebe0da44bd03019bd70bc0401e42e4a97 AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates-java nodejs openjdk-17-jdk \
+    && apt-get install -y --no-install-recommends ca-certificates-java nodejs default-jre-headless \
     && rm -rf /var/lib/apt/lists/* \
     && cargo install --locked just@1.4.0
 
@@ -26,7 +26,7 @@ RUN just npm ci \
     && just npm run build \
     && cargo build --features mysql,postgres,rdp-openssl-tls --release
 
-FROM debian:bullseye-20260803@sha256:99cdf7792e25416bd801861ccd8e2fb27fb527b25e8d9a8704ebc3ead2015675
+FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
 LABEL maintainer=heywoodlh
 ARG USER_ID=1000
 


### PR DESCRIPTION
### Problem

Debian 11 (Bullseye) reached official End-of-LTS on August 31, 2026. Following EOL, Debian's package mirrors are decommissioning and archiving Bullseye security repositories. As observed across recent CI runs on `main` and pull requests (#2547, #2548, #2549), `apt-get install` inside `docker/Dockerfile` fails with HTTP `404 Not Found` for packages (such as `libglx-mesa0` and `libavahi-common3`) fetched via `deb.debian.org/debian-security`.

Furthermore, `docker/Dockerfile` currently installs `openjdk-17-jdk`, which pulls in ~250MB of unnecessary graphical (X11, Mesa, Avahi) libraries when only a headless JRE is needed for `openapi-generator-cli`.

### Solution

1. **Migrate to Debian 12 (Bookworm):**
   - Updates the build stage image to `rust:1.97.1-bookworm` (pinned with multi-arch digest `sha256:0e2bcaef56d041a486784e54104a81aebe0da44bd03019bd70bc0401e42e4a97`).
   - Updates the runtime stage image to `debian:bookworm-slim` (pinned with multi-arch digest `sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171`).
2. **Headless JRE:**
   - Replaces `openjdk-17-jdk` with `default-jre-headless` in the build stage. `openapi-generator-cli` runs cleanly on the headless JRE without pulling in X11/Mesa/Avahi dependencies.

### Verification

- Local multi-stage Docker build tested and passed with exit code 0.
- All dependencies (`default-jre-headless`, `nodejs`, `just`, `cargo`) and runtime packages (`ca-certificates`, `wget`, `sqlite3`) resolve and install cleanly without mirror errors.