### PR TITLE
Make the ciphertext-tampering test always tamper

### DIFF
--- a/warpgate-common/src/encryption.rs
+++ b/warpgate-common/src/encryption.rs
@@ -406,8 +406,12 @@ mod tests {
         let (head, payload) = encrypted.rsplit_once(':').unwrap();
 
         let mut bytes = BASE64.decode(payload.as_bytes()).unwrap();
-        let last = bytes.len() - 1;
-        bytes.swap(0, last);
+        // Flipping a bit always changes the ciphertext. Swapping the first
+        // and last bytes does nothing when they are equal, which a random
+        // nonce makes them about once in 256 runs.
+        if let Some(byte) = bytes.last_mut() {
+            *byte ^= 1;
+        }
 
         let tampered = format!("{head}:{}", BASE64.encode(&bytes));
         assert!(matches!(


### PR DESCRIPTION
`bytes.swap(0, last)` leaves the payload untouched when those two bytes happen to be equal, which a random nonce makes them about once in 256 runs. The decrypt then succeeds and the assertion fails, so `Tests` goes red for a reason that has nothing to do with the change under test. It failed that way on an unrelated pull request today.

Flipping a bit always changes the ciphertext. It also drops a `len() - 1` that would panic on an empty payload.

Measured by running the test alone in a loop: 2 failures in 400 before, 0 in 2000 after.

Fork CI: https://github.com/janisdombr/warpgate/pull/11

## Description

...

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
