### PR TITLE
Make a failed wait say why it failed

### DIFF
--- a/tests/test_util_wait_port.py
+++ b/tests/test_util_wait_port.py
@@ -1,0 +1,76 @@
+"""What `wait_port` tells the caller when the wait does not succeed.
+
+Every case here failed silently before: the caller was told the port was up.
+On 2026-09-13 that turned `minio/minio` disappearing from Docker Hub into
+`Port 1903 is not up` after a 60s timeout, with `docker: pull access denied`
+visible only in pytest's captured stderr.
+"""
+
+import socket
+import subprocess
+import threading
+import time
+
+import pytest
+
+from .util import alloc_port, wait_port
+
+
+def test_a_child_that_exits_is_named_rather_than_timed_out():
+    """The case the `for_process` argument exists for.
+
+    It raised inside a `try` whose `except` caught `TimeoutExpired`, so the
+    exception was swallowed, the wait thread died, and the caller was told the
+    port had come up."""
+    port = alloc_port()
+    child = subprocess.Popen(["sh", "-c", "exit 3"])
+    started = time.monotonic()
+    with pytest.raises(Exception) as caught:
+        wait_port(port, for_process=child, timeout=30)
+    # Asserted, or this passes just as well on a plain timeout.
+    assert time.monotonic() - started < 10, "waited for the timeout instead"
+    assert "exited with code 3" in str(caught.value), caught.value
+
+
+def test_a_port_that_never_opens_still_times_out():
+    port = alloc_port()
+    with pytest.raises(Exception, match=f"Port {port} is not up"):
+        wait_port(port, timeout=1)
+
+
+def test_an_open_port_that_closes_on_us_reaches_the_caller():
+    """`recv=True` raises a plain `Exception`, which is not a `socket.error`,
+    so it escaped the retry loop and killed the wait thread.
+
+    The peer has to accept and close: a peer that accepts and stays silent
+    makes `recv` time out, and `socket.timeout` IS a `socket.error`, so that
+    one is retried rather than reported -- which is the intended behaviour and
+    is why this test closes instead of holding."""
+    server = socket.socket()
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+
+    def accept_and_close():
+        conn, _ = server.accept()
+        conn.close()
+
+    threading.Thread(target=accept_and_close, daemon=True).start()
+    try:
+        with pytest.raises(Exception, match="not responding"):
+            wait_port(port, timeout=10)
+    finally:
+        server.close()
+
+
+def test_a_port_that_is_up_is_still_reported_as_up():
+    """The control. Without it the three above pass on a `wait_port` that
+    always raises."""
+    server = socket.socket()
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+    try:
+        wait_port(port, recv=False, timeout=10)
+    finally:
+        server.close()

--- a/tests/util.py
+++ b/tests/util.py
@@ -27,11 +27,23 @@ def alloc_port():
 
 
 def _wait_timeout(fn, msg, timeout=60):
-    t = threading.Thread(target=fn, daemon=True)
+    # A thread that died from an exception is not alive either, so testing
+    # `is_alive()` alone reported every failed wait as a successful one.
+    failure = []
+
+    def run():
+        try:
+            fn()
+        except BaseException as e:  # noqa: BLE001 - re-raised below
+            failure.append(e)
+
+    t = threading.Thread(target=run, daemon=True)
     t.start()
     t.join(timeout=timeout)
     if t.is_alive():
         raise Exception(msg)
+    if failure:
+        raise failure[0]
 
 
 def wait_port(port, recv=True, timeout=60, for_process: subprocess.Popen = None, connect_timeout=5, read_timeout=5):
@@ -52,9 +64,14 @@ def wait_port(port, recv=True, timeout=60, for_process: subprocess.Popen = None,
                 if for_process:
                     try:
                         for_process.wait(timeout=0.1)
-                        raise Exception("Process exited while waiting for port")
                     except subprocess.TimeoutExpired:
                         continue
+                    # Outside the `try`: raised inside it, this was swallowed
+                    # by the `except` above and never reached the caller.
+                    raise Exception(
+                        f"Process exited with code {for_process.returncode} "
+                        f"while waiting for port {port}"
+                    )
                 else:
                     time.sleep(0.1)
 
@@ -77,11 +94,7 @@ def wait_mysql_port(port):
                 time.sleep(1)
                 continue
 
-    t = threading.Thread(target=wait, daemon=True)
-    t.start()
-    t.join(timeout=60)
-    if t.is_alive():
-        raise Exception(f"Port {port} is not up")
+    _wait_timeout(wait, f"Port {port} is not up")
 
 
 def open_wg_sqlite_db(config_path):


### PR DESCRIPTION
`_wait_timeout` raised only `if t.is_alive()`. A waiter thread that died from an exception is not alive either, so a failure that raised rather than running out the clock was reported to the caller as a port that came up.

Two waits rode on that:

- `wait_port`'s `for_process` branch raised inside a `try` whose `except` catches `TimeoutExpired`, so the one mechanism written to say "the process died" was swallowed by the line below it. A child that exits immediately returned success in 0.01s.
- `recv=True` raises a plain `Exception`, which is not a `socket.error`, so an open port that closes on us never reached the caller either.

`wait_mysql_port` had its own copy of the same thread block and now shares the fixed one.

Today `minio/minio` stopped being publicly pullable from Docker Hub, so `docker run` in `start_minio` exits at once. `main` reports `Port 1903 is not up` after 60s; `docker: pull access denied` is in pytest's captured stderr, which is printed only on failure and names no port. With this, the same run says which process exited and with what code.

`tests/test_util_wait_port.py` covers the two repaired paths, the plain timeout, and a port that is genuinely up. Against the current `tests/util.py` the two repaired ones fail and the other two pass.

The registry side is handled by #2581, now merged, which switches `start_minio` to `quay.io/minio/minio`. This PR is only about the wait reporting what happened. (An earlier version of this paragraph said #2578; that was a wrong number on my part — #2578 is an unrelated authentication PR and never touched the registry.)

## Description

...

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*


